### PR TITLE
Firefox: update installation paths for ESR,l10n,addons

### DIFF
--- a/recipes-mozilla/firefox-addon/firefox-addon.inc
+++ b/recipes-mozilla/firefox-addon/firefox-addon.inc
@@ -29,8 +29,8 @@ do_install() {
         EXTENSION=`sed --posix '/em:id=/!d;s/[ ]*em:id="//;s/".*//' $e/install.rdf`
         [ -z "$EXTENSION" ] && exit 1
 
-        mkdir -p ${D}${libdir}/firefox/extensions/
-        cp -R --no-dereference --preserve=mode,links -v $e ${D}${libdir}/firefox/extensions/${EXTENSION}
+        mkdir -p ${D}${libdir}/firefox/browser/extensions/
+        cp -R --no-dereference --preserve=mode,links -v $e ${D}${libdir}/firefox/browser/extensions/${EXTENSION}
     done
 }
 

--- a/recipes-mozilla/firefox-l10n/firefox-l10n.inc
+++ b/recipes-mozilla/firefox-l10n/firefox-l10n.inc
@@ -39,8 +39,8 @@ do_install() {
 
     xpi-pack ${LANGUAGE} ${EXTENSION}.xpi
 
-    mkdir -p ${D}${libdir}/firefox/extensions/
-    install -m 0644 ${EXTENSION}.xpi ${D}${libdir}/firefox/extensions/${EXTENSION}.xpi
+    mkdir -p ${D}${libdir}/firefox/browser/extensions/
+    install -m 0644 ${EXTENSION}.xpi ${D}${libdir}/firefox/browser/extensions/${EXTENSION}.xpi
 }
 
 FILES_${PN} += "${libdir}/firefox"

--- a/recipes-mozilla/firefox/firefox/fixes/Fix-firefox-install-dir.patch
+++ b/recipes-mozilla/firefox/firefox/fixes/Fix-firefox-install-dir.patch
@@ -1,0 +1,12 @@
+diff -up a/config/baseconfig.mk.orig b/config/baseconfig.mk
+--- a/config/baseconfig.mk.orig	2014-04-22 15:38:52.948165295 +0200
++++ b/config/baseconfig.mk	2016-03-30 13:32:10.035403121 +0200
+@@ -4,7 +4,7 @@
+ # whether a normal build is happening or whether the check is running.
+ MOZ_APP_BASE_VERSION = $(firstword $(subst ., ,$(MOZ_APP_VERSION))).$(word 2,$(subst ., ,$(MOZ_APP_VERSION)))
+ includedir := $(includedir)/$(MOZ_APP_NAME)-$(MOZ_APP_BASE_VERSION)
+ idldir = $(datadir)/idl/$(MOZ_APP_NAME)-$(MOZ_APP_BASE_VERSION)
+-installdir = $(libdir)/$(MOZ_APP_NAME)-$(MOZ_APP_BASE_VERSION)
++installdir = $(libdir)/$(MOZ_APP_NAME)
+ sdkdir = $(libdir)/$(MOZ_APP_NAME)-devel-$(MOZ_APP_BASE_VERSION)
+ ifndef TOP_DIST

--- a/recipes-mozilla/firefox/firefox_38.6.1esr.bb
+++ b/recipes-mozilla/firefox/firefox_38.6.1esr.bb
@@ -47,6 +47,7 @@ SRC_URI = "https://archive.mozilla.org/pub/firefox/releases/${PV}/source/firefox
            file://debian-hacks/NSS-Adds-the-SPI-Inc.-and-CAcert.org-CA-certificates.patch \
            file://debian-hacks/Work-around-binutils-assertion-on-mips.patch \
            file://debian-hacks/Revert-Bump-search-engine-max-icon-size-to-35kB.patch \
+           file://fixes/Fix-firefox-install-dir.patch \
            "
 
 SRC_URI[archive.md5sum] = "cc74abc48ac7a888aeb24ba31a7ff209"


### PR DESCRIPTION
Bring all firefox packages in-line to unified installation path at /usr/lib/firefox/* and move the extensions to the proper location so that they are loaded.

* Firefox ESR was installing to /usr/lib/firefox-38.6/ patch baseconfig so that it is /usr/lib/firefox
* firefox-l10n was installing language packs to /usr/lib/firefox/extensions. This is was incompatible with ESR as it was, and incorrect as they need to be in /usr/lib/firefox/browser/extentions
* firefox-addons was doing the same as firefox-l10n

Signed-off-by: Jason Plum <jplum@devonit.com>