### PR TITLE
fixed gcc (arm-poky-linux-gnueabi-gcc (Linaro GCC 4.8-2014.04) 4.8.3 …

### DIFF
--- a/recipes-browser/chromium/cef3_280796.bb
+++ b/recipes-browser/chromium/cef3_280796.bb
@@ -6,7 +6,7 @@ RDEPENDS_${PN} += "pango cairo fontconfig pciutils pulseaudio freetype fontconfi
 
 SRCREV_tools = "99bcb0e676eb396bcf8e1af3903aa4b578aeeee0"
 SRCREV_cef = "bbad53dfca9f98dddcb31a590410fece0a4f0234"
-SRCREV_egl = "a5b81b7617ba6757802b9b5f8c950034d5f961ec"
+SRCREV_egl = "18198a3b877ababfbb90aa19c360b7162639bf8b"
 SRCREV_FORMAT = "cef_egl_tools"
 
 SRC_URI = "http://people.linaro.org/~zoltan.kuscsik/chromium-browser/chromium_rev_${PV}.tar.xz \


### PR DESCRIPTION
…20140401 (prerelease)) errors:

../../ui/ozone/platform/egl/egl_wrapper.cc: In function 'int ozone_egl_destroy()':
../../ui/ozone/platform/egl/egl_wrapper.cc:196:49: error: invalid conversion from 'NativeWindowType {aka void*}' to 'NativeWindow {aka int}' [-fpermissive]
     ozone_egl_nativeDestroyWindow(g_NativeWindow);

../../ui/ozone/platform/egl/egl_wrapper.cc:82:6: error:   initializing argument 1 of 'void ozone_egl_nativeDestroyWindow(NativeWindow)' [-fpermissive]
 void ozone_egl_nativeDestroyWindow(NativeWindow window)

by changing the .bb file to use the latest commit of git://github.com/kuscsik/ozone-egl.git
