### PR TITLE
chromium: Fix build breakage due to egl override

### DIFF
--- a/recipes-browser/chromium/chromium-browser.inc
+++ b/recipes-browser/chromium/chromium-browser.inc
@@ -98,7 +98,6 @@ PACKAGECONFIG[disable-api-keys-info-bar] = ""
 PACKAGECONFIG[component-build] = ""
 PACKAGECONFIG[ignore-lost-context] = ""
 PACKAGECONFIG[impl-side-painting] = ""
-PACKAGECONFIG[use-egl] = ""
 PACKAGECONFIG[kiosk-mode] = ""
 PACKAGECONFIG[proprietary-codecs] = ""
 


### PR DESCRIPTION
The correct dependencies on egl/wayland-egl are set in line 91:
PACKAGECONFIG[use-egl] = ",,virtual/egl virtual/libgles2"
We must not assign "" to the config in order not to break the build.

Currently the 'bitbake chromium' task fails with the following message:
Log data follows:
| DEBUG: Executing python function sysroot_cleansstate
| DEBUG: Python function sysroot_cleansstate finished
| DEBUG: Executing shell function do_configure
| Updating projects from gyp files...
| Package egl was not found in the pkg-config search path.
| Perhaps you should add the directory containing `egl.pc'
| to the PKG_CONFIG_PATH environment variable
| No package 'egl' found
| Package wayland-egl was not found in the pkg-config search path.
| Perhaps you should add the directory containing `wayland-egl.pc'
| to the PKG_CONFIG_PATH environment variable
| No package 'wayland-egl' found