### PR TITLE
chromium: Fix ILL_ILLOPN signal in sandbox

### DIFF
--- a/recipes-browser/chromium/chromium/chromium/unset-madv-free.patch
+++ b/recipes-browser/chromium/chromium/chromium/unset-madv-free.patch
@@ -1,0 +1,15 @@
+diff -Naur chromium-52.0.2743.76/third_party/WebKit/Source/wtf/allocator/PageAllocator.cpp chromium-52.0.2743.76b/third_party/WebKit/Source/wtf/allocator/PageAllocator.cpp
+--- chromium-52.0.2743.76/third_party/WebKit/Source/wtf/allocator/PageAllocator.cpp	2016-07-15 17:02:49.000000000 -0500
++++ chromium-52.0.2743.76b/third_party/WebKit/Source/wtf/allocator/PageAllocator.cpp	2016-11-18 09:13:01.109731385 -0600
+@@ -41,6 +41,11 @@
+ #include <errno.h>
+ #include <sys/mman.h>
+ 
++#if OS(LINUX) && defined(MADV_FREE)
++// Added in Linux 4.5, but it breaks the sandbox.
++#undef MADV_FREE
++#endif
++
+ #ifndef MADV_FREE
+ #define MADV_FREE MADV_DONTNEED
+ #endif

--- a/recipes-browser/chromium/chromium_52.0.2743.76.bb
+++ b/recipes-browser/chromium/chromium_52.0.2743.76.bb
@@ -9,6 +9,7 @@ SRC_URI += "\
         file://0005-Override-root-filesystem-access-restriction.patch \
         file://chromium/0011-Replace-readdir_r-with-readdir.patch \
         file://chromium/remove-Werror.patch \
+        file://chromium/unset-madv-free.patch \
         ${@bb.utils.contains('PACKAGECONFIG', 'component-build', 'file://component-build.gypi', '', d)} \
         ${@bb.utils.contains('PACKAGECONFIG', 'ignore-lost-context', 'file://0001-Remove-accelerated-Canvas-support-from-blacklist.patch', '', d)} \
 "


### PR DESCRIPTION
Fix Aw Snap! error when running chromium 52 in Morty with sandbox enabled.

Based on upstream qtwebengine-chromium commit b12ffcd411d4776f7120ccecb3be34344d930d2b
http://code.qt.io/cgit/qt/qtwebengine-chromium.git/commit/?h=49-based&id=b12ffcd411d4776f7120ccecb3be34344d930d2b

Signed-off-by: Michael Davis <michael.davis@essvote.com>