### PR TITLE
firefox: Remove needless dependency on orbit2 and libidl-native

### DIFF
--- a/classes/mozilla.bbclass
+++ b/classes/mozilla.bbclass
@@ -1,6 +1,5 @@
 SECTION = "x11/utils"
-DEPENDS += "gnu-config-native virtual/libintl libxt libxi \
-	    zip-native gtk+ orbit2 libidl-native"
+DEPENDS += "gnu-config-native virtual/libintl libxt libxi zip-native gtk+"
 
 SRC_URI += "file://mozconfig"
 


### PR DESCRIPTION
Current firefox doesn't depend on orbit2.
These dependencies originate from too old code:

http://git.openembedded.org/openembedded/commit/?id=c8e5702127e507e82e6f68a4b8c546803accea9d

Signed-off-by: Takuro Ashie <ashie@clear-code.com>