### PR TITLE
firefox: Don't build system-wide nss & nspr

### DIFF
--- a/recipes-mozilla/firefox/firefox_45.5.1esr.bb
+++ b/recipes-mozilla/firefox/firefox_45.5.1esr.bb
@@ -3,7 +3,7 @@
 
 DESCRIPTION ?= "Browser made by mozilla"
 DEPENDS += "alsa-lib curl startup-notification libevent cairo libnotify libvpx \
-            virtual/libgl nss nspr pulseaudio yasm-native icu"
+            virtual/libgl pulseaudio yasm-native icu"
 
 LICENSE = "MPLv1 | GPLv2+ | LGPLv2.1+"
 LIC_FILES_CHKSUM = "file://toolkit/content/license.html;endline=39;md5=f7e14664a6dca6a06efe93d70f711c0e"


### PR DESCRIPTION
The current mozconfig implies to use buit-in nss & nspr so that
system-wide nss & nspr aren't needed.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>