### PR TITLE
firefox: Use system-wide nss & nspr

### DIFF
--- a/recipes-mozilla/firefox/firefox/mozconfig
+++ b/recipes-mozilla/firefox/firefox/mozconfig
@@ -13,7 +13,8 @@ ac_add_options --disable-strip
 ac_add_options --disable-install-strip
 
 # System libraries
-#ac_add_options --with-system-nss # your version is too old
+ac_add_options --with-system-nss
+ac_add_options --with-system-nspr
 #ac_add_options --with-system-jpeg # Insufficient JPEG library version
 ac_add_options --with-system-zlib
 ac_add_options --with-system-bz2


### PR DESCRIPTION
The recipe requires system-wide nss & nspr but they were not used
because built-in libraries were implicitly enabled. This patch fix
this issue.

Firefox 45ESR requires following versions:

* nss: 3.21.1
* nspr: 4.12

You need krogoth or later to satisfy these version.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>