### PR TITLE
firefox: Add some missing items of PRIVATE_LIBS

### DIFF
--- a/recipes-mozilla/firefox/firefox_45.5.1esr.bb
+++ b/recipes-mozilla/firefox/firefox_45.5.1esr.bb
@@ -87,7 +87,11 @@ PRIVATE_LIBS = "libmozjs.so \
                 libxul.so \
                 libmozalloc.so \
                 libplc4.so \
-                libplds4.so"
+                libplds4.so \
+                liblgpllibs.so \
+                libmozsqlite3.so \
+                libbrowsercomps.so \
+                libclearkey.so"
 
 # mark libraries also provided by nss as private too
 PRIVATE_LIBS += " \


### PR DESCRIPTION
Following libraries aren't specified as PRIVATE_LIBS although they are also built under the private directory:

* liblgpllibs.so
* libmozsqlite3.so
* libbrowsercomps.so
* libclearkey.so"
