### PR TITLE
firefox: Use system-wide cairo instead of built-in one

### DIFF
--- a/recipes-mozilla/firefox/firefox/mozconfig
+++ b/recipes-mozilla/firefox/firefox/mozconfig
@@ -24,6 +24,7 @@ ac_add_options --with-system-libvpx
 ac_add_options --with-system-icu
 ac_add_options --enable-system-ffi
 ac_add_options --enable-system-pixman
+ac_add_options --enable-system-cairo
 
 # Features
 ac_add_options --enable-startup-notification


### PR DESCRIPTION
Add "--enable-system-cairo" to mozconfig.
Because gtk+ depends on cairo, no need to add it to DEPENDS.
