### PR TITLE
chromium: add i586 (qemux86) support

### DIFF
--- a/recipes-browser/chromium/chromium_52.0.2743.76.bb
+++ b/recipes-browser/chromium/chromium_52.0.2743.76.bb
@@ -13,6 +13,8 @@ SRC_URI += "\
         ${@bb.utils.contains('PACKAGECONFIG', 'ignore-lost-context', 'file://0001-Remove-accelerated-Canvas-support-from-blacklist.patch', '', d)} \
 "
 
+SRC_URI_append_i586 = "file://x86-m32.patch"
+
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0fca02217a5d49a14dfe2d11837bb34d"
 SRC_URI[md5sum] = "0fee71466e1f2dc39ed4549d04b58ee2"
 SRC_URI[sha256sum] = "c54cdc11c3324152f3d5be98dcb4eae2bda0fc9dac7dd5f9010150458d68c18c"

--- a/recipes-browser/chromium/files/i586/x86-m32.patch
+++ b/recipes-browser/chromium/files/i586/x86-m32.patch
@@ -1,0 +1,42 @@
+Index: chromium-52.0.2743.76/build/common.gypi
+===================================================================
+--- chromium-52.0.2743.76.orig/build/common.gypi
++++ chromium-52.0.2743.76/build/common.gypi
+@@ -3849,10 +3849,6 @@
+                   '-msse2',
+                   '-mfpmath=sse',
+                   '-mmmx',  # Allows mmintrin.h for MMX intrinsics.
+-                  '-m32',
+-                ],
+-                'ldflags': [
+-                  '-m32',
+                 ],
+                 'conditions': [
+                   # Use gold linker for Android ia32 target.
+Index: chromium-52.0.2743.76/build/config/compiler/BUILD.gn
+===================================================================
+--- chromium-52.0.2743.76.orig/build/config/compiler/BUILD.gn
++++ chromium-52.0.2743.76/build/config/compiler/BUILD.gn
+@@ -502,8 +502,6 @@ config("compiler_cpu_abi") {
+       ]
+       ldflags += [ "-m64" ]
+     } else if (current_cpu == "x86") {
+-      cflags += [ "-m32" ]
+-      ldflags += [ "-m32" ]
+       if (!is_nacl) {
+         cflags += [
+           "-msse2",
+Index: chromium-52.0.2743.76/third_party/icu/icu.gyp
+===================================================================
+--- chromium-52.0.2743.76.orig/third_party/icu/icu.gyp
++++ chromium-52.0.2743.76/third_party/icu/icu.gyp
+@@ -48,9 +48,6 @@
+          target_arch=="mipsel")', {
+         'target_conditions': [
+           ['_toolset=="host"', {
+-            'cflags': [ '-m32' ],
+-            'ldflags': [ '-m32' ],
+-            'asflags': [ '-32' ],
+             'xcode_settings': {
+               'ARCHS': [ 'i386' ],
+             },


### PR DESCRIPTION
Build and run tested on qemux86 (i586) and turbot (x86-64).

Signed-off-by: Trevor Woerner <twoerner@gmail.com>