### PR TITLE
chromium: build ChromeDriver

### DIFF
--- a/recipes-browser/chromium/chromium-browser.inc
+++ b/recipes-browser/chromium/chromium-browser.inc
@@ -84,7 +84,7 @@ BPN = "chromium"
 #       Enable this option if you want to add support for additional proprietary
 #       codecs, most notably MPEG standards (h.264, h.265, MP4, MP3, AAC, MPEG-2 ..)
 
-PACKAGECONFIG ??= "use-egl"
+PACKAGECONFIG ??= "use-egl build-chromedriver"
 
 # this makes sure the dependencies for the EGL mode are present; otherwise, the configure scripts
 # automatically and silently fall back to GLX
@@ -100,6 +100,7 @@ PACKAGECONFIG[ignore-lost-context] = ""
 PACKAGECONFIG[impl-side-painting] = ""
 PACKAGECONFIG[kiosk-mode] = ""
 PACKAGECONFIG[proprietary-codecs] = ""
+PACKAGECONFIG[build-chromedriver] = ""
 
 
 # ozone-wayland will be cloned into a directory with this name
@@ -204,7 +205,8 @@ do_configure_append() {
 
 do_compile() {
         # build with ninja
-        ninja -C ${S}/out/${CHROMIUM_BUILD_TYPE} ${PARALLEL_MAKE} chrome chrome_sandbox
+        ninja -C ${S}/out/${CHROMIUM_BUILD_TYPE} ${PARALLEL_MAKE} chrome chrome_sandbox \
+		${@bb.utils.contains('PACKAGECONFIG', 'build-chromedriver', 'chromedriver', '', d)}
 }
 
 do_install_append() {

--- a/recipes-browser/chromium/chromium.inc
+++ b/recipes-browser/chromium/chromium.inc
@@ -51,6 +51,9 @@ do_install() {
 	if [ -f "${B}/out/${CHROMIUM_BUILD_TYPE}/chrome" ]; then
 		install -Dm 0755 ${B}/out/${CHROMIUM_BUILD_TYPE}/chrome ${D}${bindir}/${BPN}/chrome
 	fi
+	if [ -f "${B}/out/${CHROMIUM_BUILD_TYPE}/chromedriver" ]; then
+		install -Dm 0755 ${B}/out/${CHROMIUM_BUILD_TYPE}/chromedriver ${D}${bindir}/${BPN}/chromedriver
+	fi
 	if [ -f "${B}/out/${CHROMIUM_BUILD_TYPE}/icudtl.dat" ]; then
 		install -Dm 0644 ${B}/out/${CHROMIUM_BUILD_TYPE}/icudtl.dat ${D}${bindir}/${BPN}/icudtl.dat
 	fi
@@ -87,10 +90,11 @@ do_install() {
 
 }
 
-PACKAGES =+ "${PN}-codecs-ffmpeg ${PN}-plugin-pdf"
+PACKAGES =+ "${PN}-codecs-ffmpeg ${PN}-plugin-pdf ${PN}-chromedriver"
 
 FILES_${PN}-codecs-ffmpeg = "${libdir}/${BPN}/libffmpegsumo.so"
 FILES_${PN}-plugin-pdf = "${libdir}/${BPN}/libpdf.so"
+FILES_${PN}-chromedriver = "${bindir}/${BPN}/chromedriver"
 
 FILES_${PN} = "${bindir}/${BPN} ${datadir}/applications ${sbindir}/ ${libdir}/${BPN}/"
 FILES_${PN} += "${bindir} ${libdir}"


### PR DESCRIPTION
This patch enables the build of ChromeDriver. This comes
in very handy for test automation. More information can
be found here:
  https://sites.google.com/a/chromium.org/chromedriver/

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>