### PR TITLE
chromium: show progress for do_compile

### DIFF
--- a/recipes-browser/chromium/chromium-browser.inc
+++ b/recipes-browser/chromium/chromium-browser.inc
@@ -203,6 +203,8 @@ do_configure_append() {
 
 }
 
+do_compile[progress] = "outof:^\[(\d+)/(\d+)\]\s+"
+
 do_compile() {
         # build with ninja
         ninja -C ${S}/out/${CHROMIUM_BUILD_TYPE} ${PARALLEL_MAKE} chrome chrome_sandbox \


### PR DESCRIPTION
This was stolen from meta-oe / meson.bbclass - chromium uses ninja for
build too.

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>