### PR TITLE
firefox: Fix host library contamination on x86_64

### DIFF
--- a/recipes-mozilla/firefox/firefox/add-libresolv.patch
+++ b/recipes-mozilla/firefox/firefox/add-libresolv.patch
@@ -1,0 +1,40 @@
+Index: firefox-45.9.0esr/webapprt/gtk/moz.build
+===================================================================
+--- firefox-45.9.0esr.orig/webapprt/gtk/moz.build
++++ firefox-45.9.0esr/webapprt/gtk/moz.build
+@@ -24,3 +24,7 @@ DISABLE_STL_WRAPPING = True
+ CXXFLAGS += CONFIG['TK_CFLAGS']
+ 
+ OS_LIBS += CONFIG['TK_LIBS']
++OS_LIBS += [
++    'resolv',
++]
++
+Index: firefox-45.9.0esr/ipc/app/moz.build
+===================================================================
+--- firefox-45.9.0esr.orig/ipc/app/moz.build
++++ firefox-45.9.0esr/ipc/app/moz.build
+@@ -129,6 +129,9 @@ if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'gonk
+         'binder',
+         'utils',
+     ]
++OS_LIBS += [
++    'resolv',
++]
+ 
+ if CONFIG['GNU_CXX']:
+     CXXFLAGS += ['-Wshadow']
+Index: firefox-45.9.0esr/js/xpconnect/shell/moz.build
+===================================================================
+--- firefox-45.9.0esr.orig/js/xpconnect/shell/moz.build
++++ firefox-45.9.0esr/js/xpconnect/shell/moz.build
+@@ -35,6 +35,9 @@ if CONFIG['OS_ARCH'] == 'WINNT':
+ CFLAGS += CONFIG['TK_CFLAGS']
+ CXXFLAGS += CONFIG['TK_CFLAGS']
+ OS_LIBS += CONFIG['TK_LIBS']
++OS_LIBS += [
++    'resolv',
++]
+ 
+ if CONFIG['GNU_CXX']:
+     CXXFLAGS += ['-Wshadow']

--- a/recipes-mozilla/firefox/firefox_45.9.0esr.bb
+++ b/recipes-mozilla/firefox/firefox_45.9.0esr.bb
@@ -44,6 +44,7 @@ SRC_URI = "https://archive.mozilla.org/pub/firefox/releases/${PV}/source/firefox
            file://0003-do-not-link-against-crmf-library-it-is-not-there.patch \
            file://gcc7.patch \
            file://remove_AC_PATH_XTRA.patch \
+           file://add-libresolv.patch \
 "
 SRC_URI_append_libc-musl = "\
            file://0001-mallinfo-is-glibc-specific-API.patch \


### PR DESCRIPTION
On x86_64 build system starts to poke into build system libraries
and its especially seen with glibc 2.26 since it has deprecated
certain symbols which are not available in libc

e.g.

/usr/lib/libresolv.so.2: undefined reference to `__res_maybe_init@GLIBC_PRIVATE'
collect2: error: ld returned 1 exit status

So its linking to libresolv.so from host system is clear due to this error
because its then using libc.so from cross build which is glibc 2.26
and doesnt have that symbol.

Explicilty specify -lresolv on linker cmdline for components where its
needed.

Signed-off-by: Khem Raj <raj.khem@gmail.com>