### PR TITLE
chromium: add support for 32-bit raspberrypi

### DIFF
--- a/recipes-browser/chromium/chromium.inc
+++ b/recipes-browser/chromium/chromium.inc
@@ -6,6 +6,7 @@ COMPATIBLE_MACHINE_x86 = "(.*)"
 COMPATIBLE_MACHINE_x86-64 = "(.*)"
 COMPATIBLE_MACHINE_armv6 = "(.*)"
 COMPATIBLE_MACHINE_armv7a = "(.*)"
+COMPATIBLE_MACHINE_armv7ve = "(.*)"
 
 # The build type defaults to Release. If you want a Debug build, you can set
 # the variable CHROMIUM_BUILD_TYPE to "Debug" in your conf/local.conf file.

--- a/recipes-browser/chromium/files/armv7ve/include.gypi
+++ b/recipes-browser/chromium/files/armv7ve/include.gypi
@@ -1,0 +1,9 @@
+{
+  'variables': {
+    # Configure for armv7 compilation
+    'target_arch': 'arm',
+    'armv7': 1,
+    'arm_thumb': 1,
+    'arm_neon': 1,
+  }, 
+}

--- a/recipes-browser/chromium/files/armv7ve/oe-defaults.gypi
+++ b/recipes-browser/chromium/files/armv7ve/oe-defaults.gypi
@@ -1,0 +1,15 @@
+{
+  'variables': {
+    'use_system_bzip2': 1,
+    'disable_nacl': 1,
+    'proprietary_codecs': 1,
+    'v8_use_snapshot': 1,
+    'use_system_ffmpeg': 0,
+    'linux_use_tcmalloc': 0,
+    'linux_link_kerberos': 0,
+    'use_kerberos': 0,
+    'use_cups': 0,
+    'use_gnome_keyring': 0,
+    'linux_link_gnome_keyring': 0
+  }, 
+}


### PR DESCRIPTION
Applying the commit from master into morty to support the raspberry pi devices.