### PR TITLE
chromium: remove more Werror flags

### DIFF
--- a/recipes-browser/chromium/chromium/chromium/remove-Werror.patch
+++ b/recipes-browser/chromium/chromium/chromium/remove-Werror.patch
@@ -1,5 +1,3 @@
-Index: chromium-53.0.2774.4/build/common.gypi
-===================================================================
 --- chromium-53.0.2774.4.orig/build/common.gypi
 +++ chromium-53.0.2774.4/build/common.gypi
 @@ -1446,7 +1446,7 @@
@@ -46,8 +44,6 @@ Index: chromium-53.0.2774.4/build/common.gypi
            'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
            'USE_HEADERMAP': 'NO',
            'WARNING_CFLAGS': [
-Index: chromium-53.0.2774.4/build/config/compiler/BUILD.gn
-===================================================================
 --- chromium-53.0.2774.4.orig/build/config/compiler/BUILD.gn
 +++ chromium-53.0.2774.4/build/config/compiler/BUILD.gn
 @@ -1040,9 +1040,6 @@ config("chromium_code") {
@@ -72,3 +68,50 @@ Index: chromium-53.0.2774.4/build/config/compiler/BUILD.gn
      if (is_clang && !is_nacl) {
        # TODO(thakis): Remove !is_nacl once
        # https://codereview.webrtc.org/1552863002/ made its way into chromium.
+diff -ur chromium-52.0.2743.76__ORIG/v8/gypfiles/standalone.gypi chromium-52.0.2743.76/v8/gypfiles/standalone.gypi
+--- chromium-52.0.2743.76__ORIG/v8/gypfiles/standalone.gypi	2016-07-15 18:04:19.000000000 -0400
++++ chromium-52.0.2743.76/v8/gypfiles/standalone.gypi	2017-03-13 16:04:16.587323380 -0400
+@@ -147,7 +147,6 @@
+     'host_clang%': '<(host_clang)',
+     'target_arch%': '<(target_arch)',
+     'v8_target_arch%': '<(v8_target_arch)',
+-    'werror%': '-Werror',
+     'use_goma%': '<(use_goma)',
+     'gomadir%': '<(gomadir)',
+     'asan%': '<(asan)',
+@@ -499,7 +498,6 @@
+             'cflags!': [
+               '-pedantic',
+               '-Wall',
+-              '-Werror',
+               '-Wextra',
+               '-Wshorten-64-to-32',
+             ],
+@@ -705,7 +703,6 @@
+       'target_defaults': {
+         'cflags': [
+           '-Wall',
+-          '<(werror)',
+           '-Wno-unused-parameter',
+           '-Wno-long-long',
+           '-pthread',
+@@ -757,7 +754,6 @@
+       'target_defaults': {
+         'cflags': [
+           '-Wall',
+-          '<(werror)',
+           '-Wno-unused-parameter',
+           # Don't warn about the "struct foo f = {0};" initialization pattern.
+           '-Wno-missing-field-initializers',
+diff -ur chromium-52.0.2743.76__ORIG/v8/gypfiles/toolchain.gypi chromium-52.0.2743.76/v8/gypfiles/toolchain.gypi
+--- chromium-52.0.2743.76__ORIG/v8/gypfiles/toolchain.gypi	2016-07-15 18:04:19.000000000 -0400
++++ chromium-52.0.2743.76/v8/gypfiles/toolchain.gypi	2017-03-13 16:03:29.851181458 -0400
+@@ -82,7 +82,7 @@
+     'v8_toolset_for_shell%': 'target',
+ 
+     'host_os%': '<(OS)',
+-    'werror%': '-Werror',
++    'werror%': '',
+     # For a shared library build, results in "libv8-<(soname_version).so".
+     'soname_version%': '',
+ 


### PR DESCRIPTION
Apply a commit to **not** treat warnings as errors.
(cc1plus: all warnings being treated as errors.)

Original commit from: https://github.com/OSSystems/meta-browser/commit/76f46c4dc91523783a0f209d3f77a7a1404956a8 This commit is the parent commit in last pull request that I submitted.

I have compiled through and without any other error.