### PR TITLE
firefox: Pave ways to remove gcc specific compiler flags

### DIFF
--- a/recipes-mozilla/firefox/firefox_45.9.0esr.bb
+++ b/recipes-mozilla/firefox/firefox_45.9.0esr.bb
@@ -75,8 +75,11 @@ EXTRA_OEMAKE += "installdir=${libdir}/${PN}"
 
 ARM_INSTRUCTION_SET = "arm"
 
-CFLAGS +=" -fno-delete-null-pointer-checks -fno-lifetime-dse"
-CXXFLAGS +=" -fno-delete-null-pointer-checks -fno-lifetime-dse"
+CXXFLAGS += "-fno-delete-null-pointer-checks -fno-lifetime-dse"
+CXXFLAGS_remove_toolchain-clang = "-fno-lifetime-dse"
+CFLAGS += "-fno-delete-null-pointer-checks -fno-lifetime-dse"
+CFLAGS_remove_toolchain-clang = "-fno-lifetime-dse"
+
 TARGET_CC_ARCH += "${LDFLAGS}"
 
 do_install_append() {


### PR DESCRIPTION
-fno-lifetime-dse is not supported by clang

Signed-off-by: Khem Raj <raj.khem@gmail.com>