### PR TITLE
README: Point to Chromium's README.

### DIFF
--- a/README
+++ b/README
@@ -28,7 +28,7 @@ Maintainers: Eric Bénard <eric@eukrea.com>
 When sending single patches, please use something like :
 git send-email -1 -s --to openembedded-devel@lists.openembedded.org --subject-prefix='meta-browser][PATCH'
 
-TODO
-----
-- enable Chromium WebGL with OpenGL ES support
-- fix Chromium support other platforms than armv7
+Recipes
+-------
+recipes-browser/chromium: Chromium browser. See its own README for more
+                          information.


### PR DESCRIPTION
Now that the Chromium recipe has its own README describing its intricacies,
point to it from the top-level one.

While here, remove a few TODO items that are at least 5-years-old.

See also: #62.