### PR TITLE
chromium: Dependency adjustments

### DIFF
--- a/recipes-browser/chromium/README
+++ b/recipes-browser/chromium/README
@@ -19,6 +19,9 @@ PACKAGECONFIG knobs
   to a separate shared object. Use component mode for development, testing, and
   in case the build machine is not a 64-bit one, or has less than 8 GB RAM.
 
+* cups: (off by default)
+  Enables CUPS support in Chromium, and adds a dependency on the "cups" recipe.
+
 * ignore-lost-context: (off by default)
   There is a flaw in the HTML Canvas specification. When the canvas' backing
   store is some kind of hardware resource like an OpenGL texture, this resource

--- a/recipes-browser/chromium/chromium-browser.inc
+++ b/recipes-browser/chromium/chromium-browser.inc
@@ -85,6 +85,7 @@ EXTRA_OEGYP = " \
 	-Dv8_use_external_startup_data=0 \
 	-Dlinux_use_bundled_gold=0 \
 	-Dlinux_use_bundled_binutils=0 \
+	-Duse_gconf=0 \
 	-Duse_pulseaudio=${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', '1', '0', d)} \
 	-I ${WORKDIR}/oe-defaults.gypi \
 	-I ${WORKDIR}/include.gypi \

--- a/recipes-browser/chromium/chromium-browser.inc
+++ b/recipes-browser/chromium/chromium-browser.inc
@@ -11,9 +11,6 @@ require chromium.inc
 DESCRIPTION = "Chromium is an open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web."
 HOMEPAGE = "https://www.chromium.org/Home"
 
-DEPENDS += "gperf-native"
-DEPENDS_append_libc-musl = " libexecinfo"
-
 SRC_URI = "\
         https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${PV}.tar.xz \
         file://include.gypi \

--- a/recipes-browser/chromium/chromium-browser.inc
+++ b/recipes-browser/chromium/chromium-browser.inc
@@ -57,6 +57,7 @@ PACKAGECONFIG[use-egl] = ",,virtual/egl virtual/libgles2"
 # and command-line switches (extra dependencies should not
 # be necessary but are OK to add).
 PACKAGECONFIG[component-build] = ""
+PACKAGECONFIG[cups] = "-Duse_cups=1,-Duse_cups=0,cups"
 PACKAGECONFIG[ignore-lost-context] = ""
 PACKAGECONFIG[impl-side-painting] = ""
 PACKAGECONFIG[kiosk-mode] = ""
@@ -77,6 +78,7 @@ CHROMIUM_EXTRA_ARGS ?= " \
 
 
 EXTRA_OEGYP = " \
+	${PACKAGECONFIG_CONFARGS} \
 	-Dangle_use_commit_id=0 \
 	-Dclang=0 \
 	-Dhost_clang=0 \

--- a/recipes-browser/chromium/chromium-browser.inc
+++ b/recipes-browser/chromium/chromium-browser.inc
@@ -85,6 +85,7 @@ EXTRA_OEGYP = " \
 	-Dv8_use_external_startup_data=0 \
 	-Dlinux_use_bundled_gold=0 \
 	-Dlinux_use_bundled_binutils=0 \
+	-Duse_pulseaudio=${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', '1', '0', d)} \
 	-I ${WORKDIR}/oe-defaults.gypi \
 	-I ${WORKDIR}/include.gypi \
 	${@bb.utils.contains('PACKAGECONFIG', 'component-build', '-Dcomponent=shared_library', '', d)} \

--- a/recipes-browser/chromium/chromium-browser.inc
+++ b/recipes-browser/chromium/chromium-browser.inc
@@ -11,7 +11,7 @@ require chromium.inc
 DESCRIPTION = "Chromium is an open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web."
 HOMEPAGE = "https://www.chromium.org/Home"
 
-DEPENDS += "libgnome-keyring gperf-native"
+DEPENDS += "gperf-native"
 DEPENDS_append_libc-musl = " libexecinfo"
 
 SRC_URI = "\

--- a/recipes-browser/chromium/chromium.inc
+++ b/recipes-browser/chromium/chromium.inc
@@ -5,18 +5,6 @@ inherit gtk-icon-cache
 OUTPUT_DIR = "out/${CHROMIUM_BUILD_TYPE}"
 B = "${S}/${OUTPUT_DIR}"
 
-# Append instead of assigning; the gtk-icon-cache class inherited above also
-# adds packages to DEPENDS.
-DEPENDS += " \
-    cairo \
-    libdrm \
-    ninja-native \
-    nss \
-    pango \
-    pciutils \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'pulseaudio', '', d)} \
-"
-
 COMPATIBLE_MACHINE = "(-)"
 COMPATIBLE_MACHINE_x86 = "(.*)"
 COMPATIBLE_MACHINE_x86-64 = "(.*)"

--- a/recipes-browser/chromium/chromium.inc
+++ b/recipes-browser/chromium/chromium.inc
@@ -18,8 +18,6 @@ DEPENDS += " \
     pango \
     pciutils \
     ${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'pulseaudio', '', d)} \
-    xz-native \
-    zlib-native \
 "
 
 COMPATIBLE_MACHINE = "(-)"

--- a/recipes-browser/chromium/chromium.inc
+++ b/recipes-browser/chromium/chromium.inc
@@ -11,7 +11,6 @@ DEPENDS += " \
     cairo \
     cups \
     libdrm \
-    libexif \
     ninja-native \
     nss \
     pango \

--- a/recipes-browser/chromium/chromium.inc
+++ b/recipes-browser/chromium/chromium.inc
@@ -9,7 +9,6 @@ B = "${S}/${OUTPUT_DIR}"
 # adds packages to DEPENDS.
 DEPENDS += " \
     cairo \
-    cups \
     libdrm \
     ninja-native \
     nss \

--- a/recipes-browser/chromium/chromium.inc
+++ b/recipes-browser/chromium/chromium.inc
@@ -17,7 +17,7 @@ DEPENDS += " \
     nss \
     pango \
     pciutils \
-    pulseaudio \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'pulseaudio', '', d)} \
     xz-native \
     zlib-native \
 "

--- a/recipes-browser/chromium/chromium.inc
+++ b/recipes-browser/chromium/chromium.inc
@@ -10,7 +10,6 @@ B = "${S}/${OUTPUT_DIR}"
 DEPENDS += " \
     cairo \
     cups \
-    gconf \
     libdrm \
     libexif \
     ninja-native \

--- a/recipes-browser/chromium/chromium.inc
+++ b/recipes-browser/chromium/chromium.inc
@@ -7,7 +7,20 @@ B = "${S}/${OUTPUT_DIR}"
 
 # Append instead of assigning; the gtk-icon-cache class inherited above also
 # adds packages to DEPENDS.
-DEPENDS += "xz-native pciutils pulseaudio cairo nss zlib-native cups ninja-native gconf libexif pango libdrm"
+DEPENDS += " \
+    cairo \
+    cups \
+    gconf \
+    libdrm \
+    libexif \
+    ninja-native \
+    nss \
+    pango \
+    pciutils \
+    pulseaudio \
+    xz-native \
+    zlib-native \
+"
 
 COMPATIBLE_MACHINE = "(-)"
 COMPATIBLE_MACHINE_x86 = "(.*)"

--- a/recipes-browser/chromium/chromium_54.0.2810.2.bb
+++ b/recipes-browser/chromium/chromium_54.0.2810.2.bb
@@ -6,6 +6,7 @@ DEPENDS += " \
     gtk+ \
     libxi \
     libxss \
+    libxtst \
     xextproto \
 "
 

--- a/recipes-browser/chromium/chromium_54.0.2810.2.bb
+++ b/recipes-browser/chromium/chromium_54.0.2810.2.bb
@@ -7,6 +7,7 @@ DEPENDS += " \
     libxi \
     libxss \
     libxtst \
+    virtual/libgl \
     xextproto \
 "
 

--- a/recipes-browser/chromium/chromium_54.0.2810.2.bb
+++ b/recipes-browser/chromium/chromium_54.0.2810.2.bb
@@ -4,12 +4,21 @@ inherit distro_features_check
 
 DEPENDS += " \
     alsa-lib \
+    cairo \
+    gperf-native \
     gtk+ \
+    libdrm \
     libxi \
     libxss \
     libxtst \
+    ninja-native \
+    nss \
+    pango \
+    pciutils \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'pulseaudio', '', d)} \
     virtual/libgl \
 "
+DEPENDS_append_libc-musl = " libexecinfo"
 
 # The wrapper script we use from upstream requires bash.
 RDEPENDS_${PN} = "bash"

--- a/recipes-browser/chromium/chromium_54.0.2810.2.bb
+++ b/recipes-browser/chromium/chromium_54.0.2810.2.bb
@@ -1,5 +1,7 @@
 require chromium-browser.inc
 
+inherit distro_features_check
+
 DEPENDS += "xextproto gtk+ libxi libxss"
 
 # The wrapper script we use from upstream requires bash.
@@ -18,8 +20,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=0fca02217a5d49a14dfe2d11837bb34d"
 SRC_URI[md5sum] = "3f596ecbd6a39d5ada29f11780ec6dcf"
 SRC_URI[sha256sum] = "f038e72cbd8b7383d13c286329623fda8d6d48f45fa2d964e554b5565283ad71"
 
-# X11 must be available for this flavor of Chromium
-python() {
-    if not bb.utils.contains('DISTRO_FEATURES', 'x11', True, False, d):
-        raise bb.parse.SkipPackage("X11 is not available")
-}
+# For now, we need X11 for Chromium to build and run.
+REQUIRED_DISTRO_FEATURES = "x11"

--- a/recipes-browser/chromium/chromium_54.0.2810.2.bb
+++ b/recipes-browser/chromium/chromium_54.0.2810.2.bb
@@ -2,7 +2,12 @@ require chromium-browser.inc
 
 inherit distro_features_check
 
-DEPENDS += "xextproto gtk+ libxi libxss"
+DEPENDS += " \
+    gtk+ \
+    libxi \
+    libxss \
+    xextproto \
+"
 
 # The wrapper script we use from upstream requires bash.
 RDEPENDS_${PN} = "bash"

--- a/recipes-browser/chromium/chromium_54.0.2810.2.bb
+++ b/recipes-browser/chromium/chromium_54.0.2810.2.bb
@@ -9,7 +9,6 @@ DEPENDS += " \
     libxss \
     libxtst \
     virtual/libgl \
-    xextproto \
 "
 
 # The wrapper script we use from upstream requires bash.

--- a/recipes-browser/chromium/chromium_54.0.2810.2.bb
+++ b/recipes-browser/chromium/chromium_54.0.2810.2.bb
@@ -3,6 +3,7 @@ require chromium-browser.inc
 inherit distro_features_check
 
 DEPENDS += " \
+    alsa-lib \
     gtk+ \
     libxi \
     libxss \

--- a/recipes-browser/chromium/chromium_54.0.2810.2.bb
+++ b/recipes-browser/chromium/chromium_54.0.2810.2.bb
@@ -4,12 +4,26 @@ inherit distro_features_check
 
 DEPENDS += " \
     alsa-lib \
+    atk \
+    bison-native \
     cairo \
+    dbus \
+    expat \
+    freetype \
+    glib-2.0 \
     gperf-native \
     gtk+ \
     libdrm \
+    libx11 \
+    libxcomposite \
+    libxcursor \
+    libxdamage \
+    libxext \
+    libxfixes \
     libxi \
-    libxss \
+    libxrandr \
+    libxrender \
+    libxscrnsaver \
     libxtst \
     ninja-native \
     nss \


### PR DESCRIPTION
Clean up the recipe's dependencies: add missing ones, remove others that are redundant and make the whole thing easier to read by merging all DEPENDS lines and having them one per line.

The missing dependencies are actually required for me to manage to build the M54 recipe with Yocto rocko.

See also: #62.