### PR TITLE
chromium: Use explicit destination name in FILES

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -391,10 +391,10 @@ PACKAGES =+ "${PN}-chromedriver"
 FILES_${PN}-chromedriver = "${bindir}/chromedriver"
 
 FILES_${PN} = " \
-        ${bindir}/${PN} \
-        ${datadir}/applications/${PN}.desktop \
+        ${bindir}/chromium \
+        ${datadir}/applications/chromium.desktop \
         ${datadir}/icons/hicolor/*x*/apps/chromium.png \
-        ${libdir}/${PN}/* \
+        ${libdir}/chromium/* \
 "
 
 PACKAGE_DEBUG_SPLIT_STYLE = "debug-without-src"


### PR DESCRIPTION
The reason of this change is a failing packing stage due to different naming in PN and explicit
target directory names in install. Some of the files cannot be packed if an explicit destination is not
set. Given that the recipe is named chromium-x11 and the future wayland recipe will be called
chromium-ozone-wayland, default the target packaging naming to just chromium.

Error:

Files/directories were installed but not shipped in any package:
  /usr/share/applications
  /usr/share/applications/chromium.desktop
  /usr/bin/chromium
  /usr/lib/chromium/

Signed-off-by: Maksim Sisov <msisov@igalia.com>