### PR TITLE
chromium: Install libEGL / libGLESv2 if created

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -384,6 +384,14 @@ do_install() {
 
 	# ChromeDriver.
 	install -m 0755 chromedriver ${D}${bindir}/chromedriver
+
+	# EGL / GLESv2
+	if [ -f libEGL.so ]; then
+		install libEGL.so ${D}${libdir}/chromium
+	fi
+	if [ -f libGLESv2.so ]; then
+		install libGLESv2.so ${D}${libdir}/chromium
+    fi
 }
 
 PACKAGES =+ "${PN}-chromedriver"


### PR DESCRIPTION
Fixes:
| [2263:2263:1221/015335.950665:ERROR:gl_implementation.cc(241)] Failed to load /usr/lib/chromium/libGLESv2.so: /usr/lib/chromium/libGLESv2.so: cannot open shared object file: No such file or directory
| [2263:2263:1221/015335.957888:ERROR:gpu_child_thread.cc(254)] Exiting GPU process due to errors during initialization
| [2213:2247:1221/015335.971247:ERROR:browser_gpu_channel_host_factory.cc(108)] Failed to launch GPU process.
| Bus error (core dumped)

Thanks to Trevor Woerner for suggesting this [1]

[1] https://github.com/OSSystems/meta-browser/issues/81

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>