### PR TITLE
chromium-x11: Set PROVIDES="chromium".

### DIFF
--- a/recipes-browser/chromium/chromium-x11_62.0.3202.94.bb
+++ b/recipes-browser/chromium/chromium-x11_62.0.3202.94.bb
@@ -40,3 +40,8 @@ SRC_URI_append_libc-musl = "\
 REQUIRED_DISTRO_FEATURES = "x11"
 
 DEPENDS_append_libc-musl = " libexecinfo"
+
+# Compatibility glue while we have both chromium-x11 and
+# chromium-ozone-wayland recipes, and the former used to be called just
+# "chromium".
+PROVIDES = "chromium"


### PR DESCRIPTION
As discussed in pull request #77, it makes sense to provide some
compatibility glue for users who were used to just doing "bitbake chromium"
before the recipe got renamed to "chromium-x11".