### PR TITLE
chromium-ozone-wayland: Disable Jumbo builds by default.

### DIFF
--- a/recipes-browser/chromium/README
+++ b/recipes-browser/chromium/README
@@ -45,6 +45,14 @@ PACKAGECONFIG knobs
   http://www.chromium.org/developers/design-documents/impl-side-painting for
   more.
 
+* jumbo-build: (off by default)
+  Enables what's also known as "unity builds": several source files are merged
+  together and compiled only once in order to reduce build times, but may end
+  up requiring more memory at certain points.
+
+  Jumbo builds are documented here:
+  https://chromium.googlesource.com/chromium/src/+/master/docs/jumbo.md
+
 * kiosk-mode: (off by default)
   Enable this option if you want your browser to start up full-screen, without
   any menu bars, without any clutter, and without any initial start-up

--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -71,6 +71,7 @@ PACKAGECONFIG[use-egl] = ",,virtual/egl virtual/libgles2"
 PACKAGECONFIG[component-build] = ""
 PACKAGECONFIG[cups] = "use_cups=true,use_cups=false,cups"
 PACKAGECONFIG[impl-side-painting] = ""
+PACKAGECONFIG[jumbo-build] = ""
 PACKAGECONFIG[kiosk-mode] = ""
 PACKAGECONFIG[proprietary-codecs] = ' \
         ffmpeg_branding="Chrome" proprietary_codecs=true, \
@@ -83,6 +84,7 @@ GN_ARGS = " \
         is_component_build=${@bb.utils.contains('PACKAGECONFIG', 'component-build', 'true', 'false', d)} \
         use_gconf=false \
         use_gnome_keyring=false \
+        use_jumbo_build=${@bb.utils.contains('PACKAGECONFIG', 'jumbo-build', 'true', 'false', d)} \
         use_kerberos=false \
         use_pulseaudio=${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'true', 'false', d)} \
         use_system_freetype=true \

--- a/recipes-browser/chromium/chromium-ozone-wayland_64.0.3274.0.r517731.igalia.1.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_64.0.3274.0.r517731.igalia.1.bb
@@ -22,5 +22,4 @@ GN_ARGS += "\
         ozone_platform_wayland=true \
         ozone_platform_x11=false \
         use_xkbcommon=true \
-        use_jumbo_build=true \
 "


### PR DESCRIPTION
Whether to use Jumbo builds or not should be up to each user; while it may
decrease build times, it can require more RAM (it tends to cause problems
for me specifically when using GCC because of the amount of memory it
requires).

Additionally, it's not an Ozone-Wayland-specific setting, so it should've
been in chromium-gn.inc had it been the case.

We now provide a PACKAGECONFIG knob (off by default) to control that.

Signed-off-by: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>