### PR TITLE
chromium-ozone-wayland: Hardcode a few command-line arguments.

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -9,7 +9,8 @@ OUTPUT_DIR = "out/Release"
 B = "${S}/${OUTPUT_DIR}"
 
 SRC_URI += " \
-           file://v8-qemu-wrapper.patch \
+        file://v8-qemu-wrapper.patch \
+        file://wrapper-extra-flags.patch \
 "
 
 # Append instead of assigning; the gtk-icon-cache class inherited above also

--- a/recipes-browser/chromium/chromium-ozone-wayland_64.0.3274.0.r517731.igalia.1.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_64.0.3274.0.r517731.igalia.1.bb
@@ -24,3 +24,6 @@ GN_ARGS += "\
         use_xkbcommon=true \
         use_jumbo_build=true \
 "
+
+# The chromium binary must always be started with those arguments.
+CHROMIUM_EXTRA_ARGS_append = " --mus --ozone-platform=wayland"

--- a/recipes-browser/chromium/chromium-x11_62.0.3202.94.bb
+++ b/recipes-browser/chromium/chromium-x11_62.0.3202.94.bb
@@ -9,7 +9,6 @@ SRC_URI += "\
         file://0001-More-conservative-check-for-string_view-availability.patch \
         file://chromium-gcc5-cxx14-workaround.patch \
         file://chromium-gcc5-workarounds.patch \
-        file://wrapper-extra-flags.patch \
 "
 SRC_URI_append_libc-musl = "\
         file://musl-support/0001-sandbox-Define-TEMP_FAILURE_RETRY-if-not-defined.patch \


### PR DESCRIPTION
The chromium binary must always be passed `--mus --ozone-platform=wayland`, so
ensure that is always done via `CHROMIUM_EXTRA_ARGS`.