### PR TITLE
chromium-ozone-wayland: Require "wayland" in DISTRO_FEATURES.

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland_64.0.3274.0.r517731.igalia.1.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_64.0.3274.0.r517731.igalia.1.bb
@@ -8,6 +8,8 @@ SRC_URI += " \
  file://0001-Fix-memcpy-was-not-declared-in-this-scope.patch \
 "
 
+REQUIRED_DISTRO_FEATURES = "wayland"
+
 DEPENDS += "\
         libxkbcommon \
         virtual/egl \


### PR DESCRIPTION
Follow what's done in the chromium-x11 recipe and ensure "wayland" is set in
`DISTRO_FEATURES`.