### PR TITLE
chromium: Stop passing --start-fullscreen with the kiosk-mode PACKAGECONFIG

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -248,7 +248,7 @@ GN_ARGS_append_libc-musl += 'use_allocator="none" use_allocator_shim=false'
 CHROMIUM_EXTRA_ARGS ?= " \
         ${@bb.utils.contains('PACKAGECONFIG', 'use-egl', '--use-gl=egl', '', d)} \
         ${@bb.utils.contains('PACKAGECONFIG', 'impl-side-painting', '--enable-gpu-rasterization --enable-impl-side-painting', '', d)} \
-        ${@bb.utils.contains('PACKAGECONFIG', 'kiosk-mode', '--start-fullscreen --kiosk --no-first-run --incognito', '', d)} \
+        ${@bb.utils.contains('PACKAGECONFIG', 'kiosk-mode', '--kiosk --no-first-run --incognito', '', d)} \
 "
 
 # V8's JIT infrastructure requires binaries such as mksnapshot and


### PR DESCRIPTION
The only purpose of the "--start-fullscreen" option is to start Chromium in,
well, full screen mode. It turns out the "--kiosk-mode" does the same
thing and applies some other restrictions ("--start-fullscreen" allows one
to exit full screen mode, "--kiosk-mode" does not, for example).

Since "--start-fullscreen" is essentially a subset of "--kiosk-mode",
passing both on the command line is redundant.

See also:
* https://bugs.chromium.org/p/chromium/issues/detail?id=167430
* https://chromium.googlesource.com/chromium/src/+/64.0.3282.186/chrome/browser/ui/startup/startup_browser_creator_impl.cc#364