### PR TITLE
chromium-x11: patch refresh

### DIFF
--- a/recipes-browser/chromium/files/0001-GCC-PlaybackImageProvider-Settings-explicitely-set-c.patch
+++ b/recipes-browser/chromium/files/0001-GCC-PlaybackImageProvider-Settings-explicitely-set-c.patch
@@ -24,10 +24,9 @@ Reviewed-by: David Reveman <reveman@chromium.org>
 Commit-Queue: José Dapena Paz <jose.dapena@lge.com>
 Cr-Commit-Position: refs/heads/master@{#541827}
 ---
- cc/raster/playback_image_provider.cc          |  7 +++++--
- cc/raster/playback_image_provider.h           |  6 ++++--
- cc/raster/playback_image_provider_unittest.cc | 15 ++++++++++-----
- 3 files changed, 19 insertions(+), 9 deletions(-)
+ cc/raster/playback_image_provider.cc | 7 +++++--
+ cc/raster/playback_image_provider.h  | 6 ++++--
+ 2 files changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/cc/raster/playback_image_provider.cc b/cc/raster/playback_image_provider.cc
 index 557b421bbaef..b2ace4dc4fa8 100644
@@ -58,7 +57,7 @@ diff --git a/cc/raster/playback_image_provider.h b/cc/raster/playback_image_prov
 index 67974f3f341d..a33092d2b5b4 100644
 --- a/cc/raster/playback_image_provider.h
 +++ b/cc/raster/playback_image_provider.h
-@@ -20,8 +20,10 @@
+@@ -20,8 +20,10 @@ class CC_EXPORT PlaybackImageProvider : public ImageProvider {
   public:
    struct CC_EXPORT Settings {
      Settings();
@@ -70,7 +69,7 @@ index 67974f3f341d..a33092d2b5b4 100644
  
      // The set of image ids to skip during raster.
      PaintImageIdFlatSet images_to_skip;
-@@ -39,7 +41,7 @@
+@@ -34,7 +36,7 @@ class CC_EXPORT PlaybackImageProvider : public ImageProvider {
    // If no settings are provided, all images are skipped during rasterization.
    PlaybackImageProvider(ImageDecodeCache* cache,
                          const gfx::ColorSpace& target_color_space,
@@ -78,6 +77,4 @@ index 67974f3f341d..a33092d2b5b4 100644
 +                        base::Optional<Settings>&& settings);
    ~PlaybackImageProvider() override;
  
-   void BeginRaster() override;
--- 
-2.14.3
+   PlaybackImageProvider(PlaybackImageProvider&& other);

--- a/recipes-browser/chromium/files/0001-GCC-build-fix-base-Optional-T-requires-the-full-decl.patch
+++ b/recipes-browser/chromium/files/0001-GCC-build-fix-base-Optional-T-requires-the-full-decl.patch
@@ -30,7 +30,7 @@ index c425aee850dd..2bad7bb5ce8b 100644
 --- a/services/preferences/tracked/pref_hash_filter.h
 +++ b/services/preferences/tracked/pref_hash_filter.h
 @@ -21,9 +21,9 @@
- #include "services/preferences/public/interfaces/preferences.mojom.h"
+ #include "services/preferences/public/mojom/preferences.mojom.h"
  #include "services/preferences/tracked/hash_store_contents.h"
  #include "services/preferences/tracked/interceptable_pref_filter.h"
 +#include "services/preferences/tracked/pref_hash_store.h"
@@ -40,6 +40,3 @@ index c425aee850dd..2bad7bb5ce8b 100644
  class PrefService;
  
  namespace base {
--- 
-2.14.3
-

--- a/recipes-browser/chromium/files/0001-GCC-fully-declare-ConfigurationPolicyProvider.patch
+++ b/recipes-browser/chromium/files/0001-GCC-fully-declare-ConfigurationPolicyProvider.patch
@@ -18,14 +18,17 @@ As it is used from a base::Optional, it needs the full declaration
 to calculate is_trivially_*.
 
 Change-Id: I9a1dde8b2278f8094407a39bc58f3931c7d0a5e3
+---
+ components/policy/core/browser/browser_policy_connector_base.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/components/policy/core/browser/browser_policy_connector_base.h b/components/policy/core/browser/browser_policy_connector_base.h
 index a7674b55cdf4..c12c62c0ba73 100644
 --- a/components/policy/core/browser/browser_policy_connector_base.h
 +++ b/components/policy/core/browser/browser_policy_connector_base.h
-@@ -12,13 +12,13 @@
+@@ -11,13 +11,13 @@
+ #include "base/callback_forward.h"
  #include "base/macros.h"
- #include "base/optional.h"
  #include "components/policy/core/browser/configuration_policy_handler_list.h"
 +#include "components/policy/core/common/configuration_policy_provider.h"
  #include "components/policy/core/common/schema.h"
@@ -38,6 +41,3 @@ index a7674b55cdf4..c12c62c0ba73 100644
  class PolicyService;
  class PolicyServiceImpl;
  
--- 
-2.14.1
-


### PR DESCRIPTION
Bitbake will now flag patches that require fuzz when applied:

	http://lists.openembedded.org/pipermail/openembedded-core/2018-March/148675.html
	https://bugzilla.yoctoproject.org/show_bug.cgi?id=10450

Fixup the affected patches.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>