### PR TITLE
chromium-x11: Remove musl-only dependency.

### DIFF
--- a/recipes-browser/chromium/chromium-x11_66.0.3359.139.bb
+++ b/recipes-browser/chromium/chromium-x11_66.0.3359.139.bb
@@ -33,7 +33,6 @@ DEPENDS += "\
         libxscrnsaver \
         libxtst \
 "
-DEPENDS_append_libc-musl = " libexecinfo"
 
 # Compatibility glue while we have both chromium-x11 and
 # chromium-ozone-wayland recipes, and the former used to be called just


### PR DESCRIPTION
Support for musl was dropped altogether in commit 6e5dd35 ("chromium-x11:
Remove musl-related code"), but the dependency on libexecinfo when musl is
used ended up remaining in the recipe.