### PR TITLE
firefox: Use --disable-elf-hack option if supported

### DIFF
--- a/classes/mozilla.bbclass
+++ b/classes/mozilla.bbclass
@@ -7,7 +7,10 @@ inherit gettext pkgconfig
 
 EXTRA_OEMAKE += "SHELL=/bin/sh"
 EXTRA_OECONF = "--target=${TARGET_SYS} --host=${BUILD_SYS} \
-                --build=${BUILD_SYS} --prefix=${prefix} --disable-elf-hack"
+                --build=${BUILD_SYS} --prefix=${prefix}"
+EXTRA_OECONF_arm_append = " --disable-elf-hack"
+EXTRA_OECONF_x86_append = " --disable-elf-hack"
+EXTRA_OECONF_x86-64_append = " --disable-elf-hack"
 SELECTED_OPTIMIZATION = "-Os -fsigned-char -fno-strict-aliasing"
 
 export CROSS_COMPILE = "1"


### PR DESCRIPTION
--disable-elf-hack option should specify with EXTRA_OECONF overrides.
Always specifying it causes confusion why disable-elf-hack is not effective
such as aarch64 and mips and so on.

Because Elf-hack supports arm, i586, and x86_64.
Other platforms is not supported and ignored such as aarch64(Arm 64bit).

ref: https://dxr.mozilla.org/mozilla-esr45/source/configure.in#7398

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>