### PR TITLE
firefox: refresh patches

### DIFF
--- a/recipes-browser/firefox/firefox/0001-use-pkg-config-to-find-nss.patch
+++ b/recipes-browser/firefox/firefox/0001-use-pkg-config-to-find-nss.patch
@@ -1,16 +1,25 @@
-diff -Nur firefox-52.1.0esr-bak/old-configure firefox-52.1.0esr/old-configure
---- firefox-52.1.0esr-bak/old-configure	2017-04-18 03:33:03.000000000 +0900
-+++ firefox-52.1.0esr/old-configure	2017-05-17 17:14:09.684432744 +0900
-@@ -10638,6 +10638,8 @@
+From ba6d42aff5c66a42fa9e1b685b58bd342adf62a0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andreas=20M=C3=BCller?= <schnitzeltony@googlemail.com>
+Date: Thu, 12 Jan 2017 08:44:26 +0100
+
+---
+ old-configure | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/old-configure b/old-configure
+index bd7299504..30ec9e111 100644
+--- a/old-configure
++++ b/old-configure
+@@ -10639,6 +10639,8 @@ fi
  	echo $ac_n "checking for NSS - version >= $min_nss_version""... $ac_c" 1>&6
- echo "configure:10640: checking for NSS - version >= $min_nss_version" >&5
+ echo "configure:10641: checking for NSS - version >= $min_nss_version" >&5
  
 +        NSS_CONFIG="pkg-config nss"
 +        nss_config_args=
  	no_nss=""
  	if test "$NSS_CONFIG" = "no"; then
  		no_nss="yes"
-@@ -10645,11 +10647,11 @@
+@@ -10646,11 +10648,11 @@ echo "configure:10641: checking for NSS - version >= $min_nss_version" >&5
  		NSS_CFLAGS=`$NSS_CONFIG $nss_config_args --cflags`
  		NSS_LIBS=`$NSS_CONFIG $nss_config_args --libs`
  

--- a/recipes-browser/firefox/firefox/prefs/Don-t-auto-disable-extensions-in-system-directories.patch
+++ b/recipes-browser/firefox/firefox/prefs/Don-t-auto-disable-extensions-in-system-directories.patch
@@ -10,12 +10,12 @@ diff --git a/browser/app/profile/firefox.js b/browser/app/profile/firefox.js
 index f8a2fd3..b8082ff 100644
 --- a/browser/app/profile/firefox.js
 +++ b/browser/app/profile/firefox.js
-@@ -74,7 +74,7 @@ pref("extensions.systemAddon.update.url", "https://aus5.mozilla.org/update/3/Sys
+@@ -62,7 +62,7 @@ pref("extensions.systemAddon.update.url", "https://aus5.mozilla.org/update/3/Sys
  
  // Disable add-ons that are not installed by the user in all scopes by default.
  // See the SCOPE constants in AddonManager.jsm for values to use here.
 -pref("extensions.autoDisableScopes", 15);
 +pref("extensions.autoDisableScopes", 3);
  
- // Require signed add-ons by default
- pref("xpinstall.signatures.required", true);
+ // Add-on content security policies.
+ pref("extensions.webextensions.base-content-security-policy", "script-src 'self' https://* moz-extension: blob: filesystem: 'unsafe-eval' 'unsafe-inline'; object-src 'self' https://* moz-extension: blob: filesystem:;");

--- a/recipes-browser/firefox/firefox/prefs/Set-javascript.options.showInConsole.patch
+++ b/recipes-browser/firefox/firefox/prefs/Set-javascript.options.showInConsole.patch
@@ -10,11 +10,11 @@ diff --git a/modules/libpref/init/all.js b/modules/libpref/init/all.js
 index e855cdb..4f35cbe 100644
 --- a/modules/libpref/init/all.js
 +++ b/modules/libpref/init/all.js
-@@ -1139,6 +1139,7 @@ pref("javascript.options.strict.debug",     false);
+@@ -1232,6 +1232,7 @@ pref("javascript.options.strict.debug",     false);
  #endif
  pref("javascript.options.baselinejit",      true);
  pref("javascript.options.ion",              true);
 +pref("javascript.options.showInConsole",    true);
  pref("javascript.options.asmjs",            true);
- pref("javascript.options.native_regexp",    true);
- pref("javascript.options.parallel_parsing", true);
+ pref("javascript.options.wasm",             false);
+ pref("javascript.options.wasm_baselinejit", false);

--- a/recipes-browser/firefox/firefox/remove-needless-windows-dependency.patch
+++ b/recipes-browser/firefox/firefox/remove-needless-windows-dependency.patch
@@ -1,9 +1,18 @@
-diff -Nur firefox-51.0b9-bak/build/moz.configure/toolchain.configure firefox-51.0b9/build/moz.configure/toolchain.configure
---- firefox-51.0b9-bak/build/moz.configure/toolchain.configure	2016-12-20 01:20:15.000000000 +0900
-+++ firefox-51.0b9/build/moz.configure/toolchain.configure	2016-12-26 14:44:36.325894355 +0900
-@@ -874,5 +874,5 @@
- set_define('_LIBCPP_INLINE_VISIBILITY', libcxx_inline_visibility)
- set_define('_LIBCPP_INLINE_VISIBILITY_EXCEPT_GCC49', libcxx_inline_visibility)
+From 297fba4a91604f3727aa6d5c3f2a8952dac648ab Mon Sep 17 00:00:00 2001
+From: Takuro Ashie <ashie@clear-code.com>
+Date: Tue, 29 May 2018 14:06:24 +0900
+
+---
+ build/moz.configure/toolchain.configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/moz.configure/toolchain.configure b/build/moz.configure/toolchain.configure
+index 8b2416152..da75cdfe6 100644
+--- a/build/moz.configure/toolchain.configure
++++ b/build/moz.configure/toolchain.configure
+@@ -906,5 +906,5 @@ set_define('HAVE_VISIBILITY_ATTRIBUTE',
+ set_config('WRAP_SYSTEM_INCLUDES', wrap_system_includes)
+ set_config('VISIBILITY_FLAGS', visibility_flags)
  
 -include('windows.configure')
 +#include('windows.configure')


### PR DESCRIPTION
Just touch what is necessary to avoid surprises.

Warning seen:
| ...
| Applying patch remove-needless-windows-dependency.patch
| patching file build/moz.configure/toolchain.configure
| Hunk #1 succeeded at 906 with fuzz 2 (offset 32 lines).
| ...
| Applying patch Set-javascript.options.showInConsole.patch
| patching file modules/libpref/init/all.js
| Hunk #1 succeeded at 1232 with fuzz 2 (offset 93 lines).
| ...
| Applying patch Don-t-auto-disable-extensions-in-system-directories.patch
| patching file browser/app/profile/firefox.js
| Hunk #1 succeeded at 62 with fuzz 2 (offset -12 lines).
| ...
| Applying patch 0001-use-pkg-config-to-find-nss.patch
| patching file old-configure
| Hunk #1 succeeded at 10639 with fuzz 2 (offset 1 line).
| Hunk #2 succeeded at 10648 (offset 1 line).
| ...

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>