### PR TITLE
firefox: Update LICENSE

### DIFF
--- a/recipes-browser/firefox-l10n/firefox-l10n.inc
+++ b/recipes-browser/firefox-l10n/firefox-l10n.inc
@@ -5,7 +5,7 @@ DEPENDS = "mozilla-devscripts-native unzip-native zip-native"
 # drop to keep allarch
 # RDEPENDS_${PN} = "firefox"
 
-LICENSE = "MPLv1 | GPLv2+ | LGPLv2.1+"
+LICENSE = "MPLv2"
 
 # Ugly hack for now; we need to check license per recipe later
 LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690"

--- a/recipes-browser/firefox/firefox_52.8.0esr.bb
+++ b/recipes-browser/firefox/firefox_52.8.0esr.bb
@@ -5,7 +5,7 @@ DESCRIPTION ?= "Browser made by mozilla"
 DEPENDS += "alsa-lib curl startup-notification libevent libnotify libvpx \
             virtual/libgl nss nspr pulseaudio yasm-native icu unzip-native"
 
-LICENSE = "MPLv1 | GPLv2+ | LGPLv2.1+"
+LICENSE = "MPLv2"
 LIC_FILES_CHKSUM = "file://toolkit/content/license.html;endline=39;md5=f7e14664a6dca6a06efe93d70f711c0e"
 
 SRC_URI = "https://archive.mozilla.org/pub/firefox/releases/${PV}/source/firefox-${PV}.source.tar.xz;name=archive \


### PR DESCRIPTION
Current firefox is distributed under MPLv2, not MPLv1 and not triple
license.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>