### PR TITLE
Firefox 52.9esr

### DIFF
--- a/recipes-browser/firefox-l10n/firefox-l10n-ach_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ach_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "f2ee22a27e7a57db3f2c86e2553cbb99"
-SRC_URI[sha256sum] = "0c069738a285dfbc4d5754086cdd108ae36ca89e5ac08cecbcc42e972a5d275d"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ach_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ach_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "63e954da9967baa335281e5bbed5a28f"
+SRC_URI[sha256sum] = "f0430c3a56a450f4bf5c21caf847a279cb19e8a5373939a13f537f8b7bab7367"

--- a/recipes-browser/firefox-l10n/firefox-l10n-af_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-af_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "9be70386209a4da65a607028b37f1530"
-SRC_URI[sha256sum] = "d7645158223413e16473bb56a44c7c04ab8ef7b3ff7da6cf02f4ece06ac9d454"

--- a/recipes-browser/firefox-l10n/firefox-l10n-af_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-af_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "24537d244c8582821145cae3fe94d071"
+SRC_URI[sha256sum] = "e271fa624527ff760878cd420942c704077fecbf723de22d3dd9287a60e076af"

--- a/recipes-browser/firefox-l10n/firefox-l10n-an_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-an_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "e01abf5d87fa0d985de9ecbe4e777a7f"
-SRC_URI[sha256sum] = "06907c301e1cbcba62d31661b64f1744f7df8827722b21252277749642de4857"

--- a/recipes-browser/firefox-l10n/firefox-l10n-an_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-an_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "7b21773d429adaee688a71d11e247637"
+SRC_URI[sha256sum] = "0d58ab44168656d85fc4d2a726ab39f7a79a5e3d161cd21c32b190bbae05e560"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ar_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ar_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "0a5e25b6c6578257b6d0510cea1cda61"
-SRC_URI[sha256sum] = "c96116a11b70fe005284aacc6b9c5758902667c5e412a658665390ac505b7857"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ar_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ar_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "d58977fcdaea11fad31264750624b76f"
+SRC_URI[sha256sum] = "1658b2782ff9ba538f9215d1214be2d201293739fba29cade86205506465aab4"

--- a/recipes-browser/firefox-l10n/firefox-l10n-as_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-as_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "8f7472cb385247e4ebdfe4e52575fb38"
-SRC_URI[sha256sum] = "c998b908c3999c096560ec00ec9abc4e179c2399e4b4c12e67f4db80388a0a71"

--- a/recipes-browser/firefox-l10n/firefox-l10n-as_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-as_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "062fc02ffc17b86a735436ab77b583f7"
+SRC_URI[sha256sum] = "bb14fbbd04c85f4ad09c98afe27a8eccfc86b965e269c6599cbb76507e1018d7"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ast_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ast_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "48be3eb7dd0059ef32eba3603ddec351"
-SRC_URI[sha256sum] = "b30101831b319b655e75fa54a6805c9ccfa62918906b1fb1c5057fb3317c1a61"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ast_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ast_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "c70fcef07a16aee12bfe18ecd4d5ec58"
+SRC_URI[sha256sum] = "0a9fb3717235352a72ba21707dc5bf15337e16a7cf16ebe72a9695a238d26648"

--- a/recipes-browser/firefox-l10n/firefox-l10n-az_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-az_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "e9155cc593f0350ccf466f150d522959"
-SRC_URI[sha256sum] = "e33318ccee8f9d51af79939a8ff0bb8aede9c82113ff28bf67bf53b9db6acce3"

--- a/recipes-browser/firefox-l10n/firefox-l10n-az_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-az_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "d68f8e404f4a0aab56d49740940cc2c8"
+SRC_URI[sha256sum] = "9eb05526f4e3fe539d3c756d617cd50780116bbd87a3eda5817f156c30bfa286"

--- a/recipes-browser/firefox-l10n/firefox-l10n-bg_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-bg_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "18dbcda2693e94187e5cfeb775a3fc80"
-SRC_URI[sha256sum] = "bc8f076c26966fb7267d4d83dd8aa42cec8afee83e4fb9f9179bae6900c3724b"

--- a/recipes-browser/firefox-l10n/firefox-l10n-bg_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-bg_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "1bf20bd13afe59a4ee43f47e0fc8d2ce"
+SRC_URI[sha256sum] = "dabfefa33d774e99047e30fd1ca2bd6049ed98d8ed7f1e70d92573b9c5ec8dd5"

--- a/recipes-browser/firefox-l10n/firefox-l10n-bn-bd_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-bn-bd_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "f54c4aef09722dd4e1af91d2a99f8729"
-SRC_URI[sha256sum] = "8b0beccda82b82ae4ae3c6ec8aaa8f5650848a069d7dbd6a9ae9332e9131bc26"

--- a/recipes-browser/firefox-l10n/firefox-l10n-bn-bd_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-bn-bd_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "1f27a910f5a91097316f749501ca00cb"
+SRC_URI[sha256sum] = "4ba54f6692543397f7694169dba0568331ef60cb09b9a5b08e8170a7bf6a75fe"

--- a/recipes-browser/firefox-l10n/firefox-l10n-bn-in_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-bn-in_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "9e202d2189cb237403689ede091a8d73"
-SRC_URI[sha256sum] = "119e447221572186d0bd390767e25214f157a8dfdeba461c2ddbf76e5fa3b8e4"

--- a/recipes-browser/firefox-l10n/firefox-l10n-bn-in_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-bn-in_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "a2337eebb3dd7cda6045b786bed1f431"
+SRC_URI[sha256sum] = "11e44f831003ed4cfb929cbbe7c7a9a80830b9d3e0da29cb2f40e8f042fd6ffb"

--- a/recipes-browser/firefox-l10n/firefox-l10n-br_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-br_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "ce49033a33bf613357689600d1ab49d7"
-SRC_URI[sha256sum] = "cc3ce8d3c3c54d5418e5c911ba7e94dea503c62b969f7effd26790ab100aadc2"

--- a/recipes-browser/firefox-l10n/firefox-l10n-br_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-br_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "763328b90106516f97e4796e6650ed8e"
+SRC_URI[sha256sum] = "fe9d9df8b4437d3bb9b160dfef6e908bb88ae99546a6a05691ea68417dd96816"

--- a/recipes-browser/firefox-l10n/firefox-l10n-bs_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-bs_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "8ef08ce22d6b3ec01e73c5081be2f880"
-SRC_URI[sha256sum] = "5ae3a134fc1c14bc8547532d1848ba483f1e0d4faa7119d6615c35f0656caa7d"

--- a/recipes-browser/firefox-l10n/firefox-l10n-bs_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-bs_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "2da036f44ff16f4b217483c6bddc80f4"
+SRC_URI[sha256sum] = "8d2074da2ddece656e1b65a957cb1ffc027ce21df62e83acaf57deb37c0481ab"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ca_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ca_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "020d61e92943d5befa12726256bda775"
-SRC_URI[sha256sum] = "8c8f8c8ffc64e435b29f9ed8751c6006fe9a665e754e1a656d78a06b9f989b0b"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ca_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ca_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "f9147aa515aceea86251bb35fb1c8b82"
+SRC_URI[sha256sum] = "66a1d3ba08d4324706763eaebbe4b4d60b02fb6710187681100c342d7d4b5ad8"

--- a/recipes-browser/firefox-l10n/firefox-l10n-cak_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-cak_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "7b32680222059b4510d62a6bd81fc246"
-SRC_URI[sha256sum] = "2fd0fdfc2785365f78277c9fe4fc9a3c3a8494448f94c302379cc71af0afd9f3"

--- a/recipes-browser/firefox-l10n/firefox-l10n-cak_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-cak_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "8d03c27cb0bc014971781ea063df34aa"
+SRC_URI[sha256sum] = "324e161c85f2287502e04abab1de88e8b4c0924a30996aa848f859d2d1d556e3"

--- a/recipes-browser/firefox-l10n/firefox-l10n-cs_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-cs_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "fe6a6e6e97f0b5ece6c71c27d259aef7"
-SRC_URI[sha256sum] = "d902653a500d41d157148c7812a16118b65d321a5d5c9edacfd4a3e6276f3142"

--- a/recipes-browser/firefox-l10n/firefox-l10n-cs_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-cs_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "0817d9112fbea8a47165dedf2d761069"
+SRC_URI[sha256sum] = "8ea19529b0536099bee5ad65799bb422a6e9460fe9670c951e8609eef54133d6"

--- a/recipes-browser/firefox-l10n/firefox-l10n-cy_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-cy_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "d42a48357e55a8954d6ad0c6f574f0c8"
-SRC_URI[sha256sum] = "a66f32cef38343a78f7f38990861cce9de29a8bb2b3237c52841d3c9336fb4dd"

--- a/recipes-browser/firefox-l10n/firefox-l10n-cy_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-cy_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "43b833b90fe72db84f3eb2c70ff1419d"
+SRC_URI[sha256sum] = "0e5f8613768bfa6456b781effb1982bd78f8405c30ee3e763d95ed5cae0de97f"

--- a/recipes-browser/firefox-l10n/firefox-l10n-da_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-da_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "d07b18688e921272a2a2e14d77514e00"
-SRC_URI[sha256sum] = "2818096eea89b3fbd8a77a23e587d8770ec0f5175f1bf7838c2db8bb7456ae1c"

--- a/recipes-browser/firefox-l10n/firefox-l10n-da_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-da_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "675fbaa3a39ed7c2a878a30c932cc502"
+SRC_URI[sha256sum] = "b50c30e90580b0c8bc6871dae8639a01019618caf713c1b8bae32485f0e8b167"

--- a/recipes-browser/firefox-l10n/firefox-l10n-de_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-de_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "eccc6ef0341151c59bed0003de1ee5fe"
-SRC_URI[sha256sum] = "f70b4b250a9ca85640fba8467293a0b52f2882d53694edd80abc96b13df13d69"

--- a/recipes-browser/firefox-l10n/firefox-l10n-de_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-de_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "a6cfa6219f860558810dfce24bca3893"
+SRC_URI[sha256sum] = "f59ed6f6466815a47ba0e62bee6f589c851f1d6248df0ad0b439e31929e61338"

--- a/recipes-browser/firefox-l10n/firefox-l10n-dsb_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-dsb_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "ec63e7b30325bfd05b01bd7b6060578d"
-SRC_URI[sha256sum] = "71b9e71ca4545ea55f13245b90600d0114d3ae72d16ad2db25db3f034592ec7f"

--- a/recipes-browser/firefox-l10n/firefox-l10n-dsb_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-dsb_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "3297eec50b9bea8d0051d404a61a2a6f"
+SRC_URI[sha256sum] = "c8f57aec50a10b6475ef4d06d7c2de794918c1ee17596a80445cf90c1e450082"

--- a/recipes-browser/firefox-l10n/firefox-l10n-el_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-el_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "542b6aa240b4f7710cd823cb47aa4384"
-SRC_URI[sha256sum] = "94ee8b852a012f3a0a9997fd263ff9f88405d6bbe427ffa33fc37bff567df0bf"

--- a/recipes-browser/firefox-l10n/firefox-l10n-el_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-el_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "2526621d755134b66dbadbee7037846a"
+SRC_URI[sha256sum] = "c3bcece23d752bc3bb6bf36f135354f6abaa244bdd82a37ebdef2024b97efd65"

--- a/recipes-browser/firefox-l10n/firefox-l10n-en-gb_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-en-gb_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "367a69eaed4f2ee638f87951c8f85f5a"
-SRC_URI[sha256sum] = "e5b5a6ff2e3d9f483b9afb425f5a89a25a3333db06260a2623faf2d7847a014b"

--- a/recipes-browser/firefox-l10n/firefox-l10n-en-gb_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-en-gb_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "441684c41d070f13477e35d118e8fee2"
+SRC_URI[sha256sum] = "2d0c00c47132e19c470c23758df33d0fa5583efab1a3b5648b18148dded4e7f7"

--- a/recipes-browser/firefox-l10n/firefox-l10n-en-us_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-en-us_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "f7e15c8ff932c648473d1d6adef966fa"
-SRC_URI[sha256sum] = "e5487e67c1789fa15d3a37f5316f9204a9c871868720205c81d9b5c6bb2a4f9e"

--- a/recipes-browser/firefox-l10n/firefox-l10n-en-us_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-en-us_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "c166be6c81150157950f14d5a073d4c2"
+SRC_URI[sha256sum] = "55586600fa4bcb6223998639116e47a0ecadde8278fc8db54bfe7f1deecd839b"

--- a/recipes-browser/firefox-l10n/firefox-l10n-en-za_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-en-za_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "f341a5188020a645e3999358afc9164a"
-SRC_URI[sha256sum] = "0d6e4fcca8b7160a4c262229d06e61b116e3bfa8f164097d32e37ae53bb0a06f"

--- a/recipes-browser/firefox-l10n/firefox-l10n-en-za_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-en-za_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "123a1495aa79bbd692a99700380ace0f"
+SRC_URI[sha256sum] = "f76a6b8ccaaffbbeade411976d71176dd598c30a0fc576caef7b8e2140e7e8ea"

--- a/recipes-browser/firefox-l10n/firefox-l10n-eo_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-eo_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "bffa57fa5b55ad77449ecec02a7fe061"
-SRC_URI[sha256sum] = "24ea6ff03bed39895d0c3f6cc4432fba6d58bd42814efd2dacfc12021090a2d7"

--- a/recipes-browser/firefox-l10n/firefox-l10n-eo_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-eo_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "37c7240cdd733b2f4635d903d8a44010"
+SRC_URI[sha256sum] = "e81a9b48b0c87944de07a2cb7bb3b1329137f283c5dd0d81b05ed8b5e62e66f0"

--- a/recipes-browser/firefox-l10n/firefox-l10n-es-ar_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-es-ar_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "73d932dda350e9615d72d3725dd4719f"
-SRC_URI[sha256sum] = "e9830ef15fe651c794e8c912fdbe6deb9b611cca49f02c31b847a56e5def71e0"

--- a/recipes-browser/firefox-l10n/firefox-l10n-es-ar_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-es-ar_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "5c7261fc2044faaf59db63aaa73e504f"
+SRC_URI[sha256sum] = "3567cddae4a303042938d2a2d744dade06ab77831816c0f32295cbebe79c75ca"

--- a/recipes-browser/firefox-l10n/firefox-l10n-es-cl_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-es-cl_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "b4536cc02c8928bd3c68f0447475b69f"
-SRC_URI[sha256sum] = "fe09b523998ec03878a6198b0ecd93145340ee9fad37b0a891e252754af12fab"

--- a/recipes-browser/firefox-l10n/firefox-l10n-es-cl_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-es-cl_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "3e875a8a08ce6abd986e03c2fb65c7dc"
+SRC_URI[sha256sum] = "657225821c9c37fdfe12d09ac561d2702f20b2d17c9141f7e7bbcf7a1d7494e4"

--- a/recipes-browser/firefox-l10n/firefox-l10n-es-es_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-es-es_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "188c706ec4dfc15010ce4335c390b432"
-SRC_URI[sha256sum] = "c45f4ca91ccee666079790ce377f474c7992d410c88c16ce4551867711467a30"

--- a/recipes-browser/firefox-l10n/firefox-l10n-es-es_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-es-es_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "c59ac694ce3c69f159946560d6695da4"
+SRC_URI[sha256sum] = "9b67115c23cebe3e3ce57c3a19dd7a5afaaf98e18e06357c4eace53b4808f302"

--- a/recipes-browser/firefox-l10n/firefox-l10n-es-mx_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-es-mx_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "48772c072c67b1fac8a8874620ca5c86"
-SRC_URI[sha256sum] = "2f4b8e0e9377a85fb85a891cbbf1cd2007456dfa22c7ed78462d39fc6ad0c558"

--- a/recipes-browser/firefox-l10n/firefox-l10n-es-mx_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-es-mx_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "1280d46d552929eab297274e801afac6"
+SRC_URI[sha256sum] = "348b9a59d5c621e807c002be4f57f616ed51da2d6e750611bb18da9081a61b42"

--- a/recipes-browser/firefox-l10n/firefox-l10n-et_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-et_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "ea0ac8470708784a3aa1a9147f88e832"
-SRC_URI[sha256sum] = "a59a78a08c5116b103304952f4abcaa347bb9992d49ac0e6251d32258b24fcf3"

--- a/recipes-browser/firefox-l10n/firefox-l10n-et_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-et_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "b60e6bc74683c5121508ca834122e02f"
+SRC_URI[sha256sum] = "487f6643e335e8a9cec42f14d50140de2f0a3b6d55af87aa123c432fd5f5eda1"

--- a/recipes-browser/firefox-l10n/firefox-l10n-eu_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-eu_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "6b25d89a55ec93dacc33491cd1e5a08a"
-SRC_URI[sha256sum] = "34147575109ddb584dcb64d79d0e52f3fb923816269e9322c967a78b93c7825c"

--- a/recipes-browser/firefox-l10n/firefox-l10n-eu_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-eu_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "d541b6836d96e4ea3e05c57eb26d8670"
+SRC_URI[sha256sum] = "63aac2681aae850d61b69c0411013ce2ae2c56bc428f174934668a3affd5f3fa"

--- a/recipes-browser/firefox-l10n/firefox-l10n-fa_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-fa_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "5eaceac5d5c84388b5a18d90361d23f4"
-SRC_URI[sha256sum] = "734508a2d7997969c0cfa2f46751830e0e29b5522548994b385f7010449a05c9"

--- a/recipes-browser/firefox-l10n/firefox-l10n-fa_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-fa_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "db8cbc6eb7cbd25f16e649f813e56514"
+SRC_URI[sha256sum] = "b8799469657e5c39cea9ecb034db50bd0cd28a8ce146d5335a14ba22245291b7"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ff_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ff_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "32aa15f25e46b53bf8ae040454abe3be"
-SRC_URI[sha256sum] = "4bc09e0c823a44eff73d3a6e8500254f3e4296099428545c8fe8018a89013ecc"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ff_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ff_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "1f4978924f0c70c2fb76c58d6f5fc75d"
+SRC_URI[sha256sum] = "2e794d017814967a4a142d53c8d6004d8f15f85d42b1d9d31bef989f1ee147f3"

--- a/recipes-browser/firefox-l10n/firefox-l10n-fi_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-fi_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "252be8e499a70f51c6a9a255478845ad"
-SRC_URI[sha256sum] = "00bdbade3619e757805e043cf210bc20bc9ef67e7c5a7d2d5d87a921b782ad4e"

--- a/recipes-browser/firefox-l10n/firefox-l10n-fi_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-fi_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "182ed13383782e6002be4ac733a6abe3"
+SRC_URI[sha256sum] = "d8570f7716ad0b1e9fd59dc731f972b0518dd2dcaa1e41014ee6ce1de24795c1"

--- a/recipes-browser/firefox-l10n/firefox-l10n-fr_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-fr_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "a483eee3f877f8738900903b39661dcb"
-SRC_URI[sha256sum] = "0797c241bfc4b15becab480c8eb7ed68797f9f745a116511a55a92aea68c0577"

--- a/recipes-browser/firefox-l10n/firefox-l10n-fr_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-fr_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "0463d99200b5f8679da7f6f2da59276c"
+SRC_URI[sha256sum] = "d57f183a96c7d57502a884458839518b20b183afcf88662c5a3fac4198afa320"

--- a/recipes-browser/firefox-l10n/firefox-l10n-fy-nl_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-fy-nl_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "1961d24dd3cbffc368bb2804f79f0d94"
-SRC_URI[sha256sum] = "006dd61c7bb4582355fc5d50363152348a51b47ced2b81e0cc34a27c2a28f746"

--- a/recipes-browser/firefox-l10n/firefox-l10n-fy-nl_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-fy-nl_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "8731fcec9a4b53ecbe3123886dc1694f"
+SRC_URI[sha256sum] = "c00ec788d868a77fe1b6fa1532ededef75b1339c803b7b6ba75e5029c0d8a4e9"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ga-ie_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ga-ie_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "d1fd8eec18a4e81fdc38faaa373b59a7"
-SRC_URI[sha256sum] = "311c222f54accb81014384cfda644c9d718a09baf4935056016307324cadf83a"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ga-ie_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ga-ie_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "d7f556dbc13b7f5ec25b6354f04a3483"
+SRC_URI[sha256sum] = "19fd25e53641298c2d726cda6ed60a1bf978813331405b04adecb101213c545b"

--- a/recipes-browser/firefox-l10n/firefox-l10n-gd_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-gd_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "a88f7615f495f457a274c9c872dda563"
-SRC_URI[sha256sum] = "1672e7edba46bfb551628e65066b7246270b19159fbae0fabb988ddb21b74ad3"

--- a/recipes-browser/firefox-l10n/firefox-l10n-gd_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-gd_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "f2c5b81bd0f000155a626707d7256279"
+SRC_URI[sha256sum] = "14291f4955b8d24f01586c4e2b46ef00cf2b684f83fdb2f62ee4a5eea8fac8a3"

--- a/recipes-browser/firefox-l10n/firefox-l10n-gl_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-gl_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "9037e0f06d7b702f8664bcd935131eed"
-SRC_URI[sha256sum] = "6ba049f809536745ba87e2ef459781f1c8ff99edbe08330edea157f4cf7056aa"

--- a/recipes-browser/firefox-l10n/firefox-l10n-gl_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-gl_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "1f3ad7979ecf68063a6aaa8f061795bd"
+SRC_URI[sha256sum] = "aa5b1ab335018aa7e45ef7274fa37807a4a7999224aa6632a19f18e50a6558d4"

--- a/recipes-browser/firefox-l10n/firefox-l10n-gn_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-gn_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "7ddb6a1595c4991de7f1930d468f27fb"
-SRC_URI[sha256sum] = "2bb3a7347135675dd29bb72658c523428eb6af15380d52457a7f1aac1d381b7c"

--- a/recipes-browser/firefox-l10n/firefox-l10n-gn_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-gn_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "f1608420a733c504f0679816fd8deb7f"
+SRC_URI[sha256sum] = "bb5829ca7512341d4d5c395ecfda75e1d8a1f66725032f09533c60bfa7c32efe"

--- a/recipes-browser/firefox-l10n/firefox-l10n-gu-in_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-gu-in_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "bd85477679f07f10627716343727b9cf"
-SRC_URI[sha256sum] = "fbb71bf898b556476ddef5396c93daab30fb613229323c4ccedec789361e5db3"

--- a/recipes-browser/firefox-l10n/firefox-l10n-gu-in_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-gu-in_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "c041df6265d86b995e3d2d4ef6c190a5"
+SRC_URI[sha256sum] = "b0b7ffdc54d1067f4405f33a568941d738dcc0ad9a045b66fc50ca4e05a25f2d"

--- a/recipes-browser/firefox-l10n/firefox-l10n-he_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-he_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "abd1eba6695524887ef4e2975f01a0a0"
-SRC_URI[sha256sum] = "86917c56b4e7563db92a36d9facb9e41777d5751ea3357688946bd157f1c629e"

--- a/recipes-browser/firefox-l10n/firefox-l10n-he_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-he_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "db5351add68151b4d8de72edeb2bcffe"
+SRC_URI[sha256sum] = "5054a5f1071c926290dbffd5820ff19214e22ad6a63662bc93a5c1af885d14e7"

--- a/recipes-browser/firefox-l10n/firefox-l10n-hi-in_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-hi-in_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "475a66b5bce7be4978c85570f4a9b534"
-SRC_URI[sha256sum] = "452c73e8962c3ed2858a95e69caf8afaa432e6c3a0f6b3c04b1d758e8b0aadf3"

--- a/recipes-browser/firefox-l10n/firefox-l10n-hi-in_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-hi-in_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "3dac3de55a6b72cc051e13cfa971e67e"
+SRC_URI[sha256sum] = "444a522fdcac5ce9d4901de58fa6e6fa9c5b8a772755c6d1eec120e22aa5c964"

--- a/recipes-browser/firefox-l10n/firefox-l10n-hr_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-hr_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "e5e32f76b512875a26aeb160abe92e0f"
-SRC_URI[sha256sum] = "2298fd3b2ff6260fe27a41f46efe98b5c4e17b33f8f21f5a6d74caea31ca8fce"

--- a/recipes-browser/firefox-l10n/firefox-l10n-hr_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-hr_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "bbe97c2d38a9660d73a36c2fc7f38817"
+SRC_URI[sha256sum] = "553bdf6a60bded015ceeef002db99028c9334a4fc2825f9f147ac922f923b1e2"

--- a/recipes-browser/firefox-l10n/firefox-l10n-hsb_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-hsb_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "f408a10f199ee3ec9d573829a42a6235"
-SRC_URI[sha256sum] = "4bf3aa58d2c8d0659da6027d85fc5c516921cc87d70fedf092621c2ff27f8d4a"

--- a/recipes-browser/firefox-l10n/firefox-l10n-hsb_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-hsb_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "6b004409e2c0e838a030960531ecb519"
+SRC_URI[sha256sum] = "4838a040484a5e06e641c05f04f83c3f69b8e6c214e38589e154d53d61e96004"

--- a/recipes-browser/firefox-l10n/firefox-l10n-hu_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-hu_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "7acea974a3789ef025037fdb12d56882"
-SRC_URI[sha256sum] = "35b2ac640ec58bda58073d45d3a0cff6d278e251fa11a98596151943961ec0ce"

--- a/recipes-browser/firefox-l10n/firefox-l10n-hu_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-hu_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "6f1ca22369ddf4d00fc4be399f3d6b85"
+SRC_URI[sha256sum] = "2d1a34a83c15f87c05c5be22dd48fd447e1d0772843e4ae3fbd64f17a6660acc"

--- a/recipes-browser/firefox-l10n/firefox-l10n-hy-am_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-hy-am_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "24367093efbd0fab73cb4cb4b2cf85a7"
-SRC_URI[sha256sum] = "5347069b88b0020bf2bebcbf7fbc6e397088ac74e046458e4aaba9c837c211aa"

--- a/recipes-browser/firefox-l10n/firefox-l10n-hy-am_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-hy-am_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "7ea92f428067593cf0c6927ced6482cf"
+SRC_URI[sha256sum] = "818c2dbfdc5900391e8aab5d27418bdc88959b66164e0a57890cff5ae56d5b9d"

--- a/recipes-browser/firefox-l10n/firefox-l10n-id_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-id_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "71886cc24e35936d7f4fa7fab35e6340"
-SRC_URI[sha256sum] = "dad28e6b93f574d2995455eac8dccaa537eb3d8a3366807932161a12eafd97fb"

--- a/recipes-browser/firefox-l10n/firefox-l10n-id_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-id_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "08d1c4be24bc5b6a5e407e726d221a49"
+SRC_URI[sha256sum] = "1c6a6c1c5024a81df3f858ab8038c4228630d9a4eca073cabbe35fb884503ec7"

--- a/recipes-browser/firefox-l10n/firefox-l10n-is_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-is_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "f78fb172989a4c38fe2602e099188be0"
-SRC_URI[sha256sum] = "c4c3296f24996c35c9e18db7bbbcd4025c0a3a774d7af570b8edb6096fd5e1d1"

--- a/recipes-browser/firefox-l10n/firefox-l10n-is_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-is_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "5bb0188c6b2f9ee516916ecd4eb12023"
+SRC_URI[sha256sum] = "c85bb05e1e43bb34a469423efd70d4b3d0bd0266d8f851c959687d2ba346f197"

--- a/recipes-browser/firefox-l10n/firefox-l10n-it_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-it_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "4d5d9696caf75c0947144856e9f7c972"
-SRC_URI[sha256sum] = "608ecc2e914ac17979ec28bd4c18532d4ea7e274b001326e082e2f642737f597"

--- a/recipes-browser/firefox-l10n/firefox-l10n-it_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-it_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "fe9d53390d92420544f9ed4c084470fc"
+SRC_URI[sha256sum] = "5b4a5350d9f44cc9535987c50da886b52922402d1d607008239aa289f23f9a34"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ja_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ja_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "94edb09570754c735f15f95be296a2fc"
-SRC_URI[sha256sum] = "ac443368d345d2401f1e994f1f1698d5eea19af07b3fb7cf7d50b1d9662c13e1"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ja_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ja_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "9fa27550af0746e926867d1889608099"
+SRC_URI[sha256sum] = "aaed4fa95b9f1766f4a2e2537b15554b7a8821d105f27254c4bbb23cef22cb47"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ka_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ka_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "a0e8714547278dc82ef0541003dc9859"
-SRC_URI[sha256sum] = "8b0d1d355dde3d69d5f926a7a40b9f2a35c9de6c62b09c05f034f553908cdfbe"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ka_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ka_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "a1d4bab666e4349d5820342e7518c890"
+SRC_URI[sha256sum] = "c1aa4b8781925a68975a0e4a7ea419a8c2c8312fc5d81f2b35f5aabfa0a379a5"

--- a/recipes-browser/firefox-l10n/firefox-l10n-kab_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-kab_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "3eaa0f260884b0215af790a37ba15264"
-SRC_URI[sha256sum] = "b1c074e5f191bf464911fbfcf7b77bb6b7207a70f058afe9660ff2b877b95c71"

--- a/recipes-browser/firefox-l10n/firefox-l10n-kab_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-kab_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "f3519cf57762baa141f6e85853b54613"
+SRC_URI[sha256sum] = "13a4f598164775e3a5fcffcca073460c5760294c54bf8d3b86c4d3e6354bac42"

--- a/recipes-browser/firefox-l10n/firefox-l10n-kk_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-kk_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "eb436891fe9c1755213d9d8308493801"
-SRC_URI[sha256sum] = "e78680221cc5d0e726a1ac8362df672a70aa4d0f3e0c08c47c9f3fac7eab0211"

--- a/recipes-browser/firefox-l10n/firefox-l10n-kk_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-kk_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "1600f46ecd12479beac8f794df57587f"
+SRC_URI[sha256sum] = "c07c624b39f030e2b670c7b95df82ce3118af2a46c9a4ce2bd4d24c3405a1104"

--- a/recipes-browser/firefox-l10n/firefox-l10n-km_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-km_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "a7aeec32329703d954a3d81d17d64f3c"
-SRC_URI[sha256sum] = "d6311f10d091e66902947db4a71fa4951876beed37b4c03e02cbffb63049eff8"

--- a/recipes-browser/firefox-l10n/firefox-l10n-km_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-km_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "7f265dce3fcb583992439f41229af7da"
+SRC_URI[sha256sum] = "207736a063247eddb70838c1b8101c2b6fa8e4b8fff55447378780af6c2a5646"

--- a/recipes-browser/firefox-l10n/firefox-l10n-kn_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-kn_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "70ec166e133a8540926e755cc47adffc"
-SRC_URI[sha256sum] = "fd95160dad8787ed8803bc8e98f2ef7c3e57df5e03a05013acb038753f82baa6"

--- a/recipes-browser/firefox-l10n/firefox-l10n-kn_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-kn_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "189ca30cb18f3531435da0fa66c74aa9"
+SRC_URI[sha256sum] = "ebffd88e898ad8aedefeb15d85628ecc02014ba17578fa01347e536c16eba46a"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ko_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ko_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "7df487c0fe286aca3a69dd04db1c9f0f"
-SRC_URI[sha256sum] = "ca78841e987df549a641e078e355c3ca025cdcf7c65124b610f0844ac07a6015"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ko_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ko_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "0c8978c56d6e055bc54a9abcef054844"
+SRC_URI[sha256sum] = "465c5cf939297ea1a4b2725ac6b647f084a34000990f0c6bc2e755313c57691a"

--- a/recipes-browser/firefox-l10n/firefox-l10n-lij_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-lij_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "66abba38eebea02bb4c40b567f94b727"
-SRC_URI[sha256sum] = "4864ae85dd728391e3144b48771b26bdf60a6c226924ef3dac3583b57635f2d8"

--- a/recipes-browser/firefox-l10n/firefox-l10n-lij_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-lij_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "eff2f52e0cb0d61056bb6c5ee435e58d"
+SRC_URI[sha256sum] = "8c38efcfb7b55a05c8435a175b08f3f040b9ba670e658b3c010c71aa758242f4"

--- a/recipes-browser/firefox-l10n/firefox-l10n-lt_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-lt_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "c3d9958e41c254f0376ae317e4e83ac1"
-SRC_URI[sha256sum] = "116b6981342e442f448c98289fd6439068128d2a0362076d9522095dea6f7320"

--- a/recipes-browser/firefox-l10n/firefox-l10n-lt_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-lt_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "8f5eedf3f98ca5e0c139a3e374c5ae94"
+SRC_URI[sha256sum] = "74ea5a3e367d775ebd31eeba01650d8d380ac2dc863aa26eafe17e431b0b40be"

--- a/recipes-browser/firefox-l10n/firefox-l10n-lv_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-lv_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "5057d330181d6840b28f0f7c977588d1"
-SRC_URI[sha256sum] = "dca41d4e38dbb5bae255108f7ee853579346ecfe50b0572a2c7c7a04b969913b"

--- a/recipes-browser/firefox-l10n/firefox-l10n-lv_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-lv_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "87ae315d7e2471bcf80cc34850c39607"
+SRC_URI[sha256sum] = "107e399c050de243083d4d05a184de9ceb645fba067bd6c97ac6ba692f3cbc9a"

--- a/recipes-browser/firefox-l10n/firefox-l10n-mai_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-mai_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "1371ef651bc81d558d358b681306c755"
-SRC_URI[sha256sum] = "8141c6320d0e52a82f5a6574be227f193fa3491a3db4eddb0a6a39ac83f56793"

--- a/recipes-browser/firefox-l10n/firefox-l10n-mai_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-mai_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "a85393cd070be51e476e36f7718d3f58"
+SRC_URI[sha256sum] = "5904ecb6bee710f6a25eb9eb4a70ce3b32cc921545f4d3aae089573a8ced89c7"

--- a/recipes-browser/firefox-l10n/firefox-l10n-mk_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-mk_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "2fe1d047b74a6954dc7e5d1705d4c2e5"
-SRC_URI[sha256sum] = "1ce5170def238a5eb32f0f55c99f010f255902212c416b055520748f7a873de6"

--- a/recipes-browser/firefox-l10n/firefox-l10n-mk_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-mk_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "f3f4648eff819d6b505092b97564ee3b"
+SRC_URI[sha256sum] = "071310d0e7c2b0fdfbdc8f2646660383ec590f933d2f72a6464414976d873b21"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ml_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ml_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "025be7b547b39603f86113bca6e2682e"
-SRC_URI[sha256sum] = "2023a29c5725ea458ebade2874e49c48e4fd83931f110a4d172ef238f0a4635f"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ml_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ml_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "5a55e20139991165cb23cb2e0c13c896"
+SRC_URI[sha256sum] = "5da1ac0f791df172435fe6e9dc0f8fed5a54bec5bcc219380718b6dec0739a56"

--- a/recipes-browser/firefox-l10n/firefox-l10n-mr_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-mr_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "7ee0b38ee2d721c05914cb94764343ab"
-SRC_URI[sha256sum] = "7b8b4f669e445aac69fc7b5d6159c2459a97b65af06d8db9cd8acc60f82abb0a"

--- a/recipes-browser/firefox-l10n/firefox-l10n-mr_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-mr_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "cab1b5b68c0ae90de8976ccf1d9ef1f5"
+SRC_URI[sha256sum] = "dd9da1a0f0a33c2fcc6a9a149c97314478d62471c33aec00f0324836b894748a"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ms_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ms_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "cf20ee295c7dec07efd16c823cc59909"
-SRC_URI[sha256sum] = "5c8df679a379c443a5ac3416e0d3b21fd2ed5ef955addc7d0b09acd26085b285"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ms_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ms_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "710974cdbca3acc2ba671bb262aea514"
+SRC_URI[sha256sum] = "76905cf4d180915ab1dd8ce07acc618ee0a8f32e25245aa193a0285c39181ae6"

--- a/recipes-browser/firefox-l10n/firefox-l10n-nb-no_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-nb-no_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "8af3e13838d6401c0c44e8b30bdc0eaa"
-SRC_URI[sha256sum] = "0a222ca1fda65aa5c291d08bdc50807d674d05bb52ce77683c063bd768391b05"

--- a/recipes-browser/firefox-l10n/firefox-l10n-nb-no_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-nb-no_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "f18d2dd49b9df1f17c3dc23a5a1fb2f5"
+SRC_URI[sha256sum] = "badc78dfdc174feb0b3c360ff6f087aeac2c00ab177768f5fc3d9db37eb03265"

--- a/recipes-browser/firefox-l10n/firefox-l10n-nl_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-nl_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "db4f818d31e08b8a88374460e4f0377b"
-SRC_URI[sha256sum] = "9da67e7a18168ccf4b3b805945c2dffd75f7d1574b05bb384049bfc3e29c37f3"

--- a/recipes-browser/firefox-l10n/firefox-l10n-nl_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-nl_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "7eba7eb6899bb554c8f5a675d7bd59bf"
+SRC_URI[sha256sum] = "e87999ef3c49563295fe7229127c5c32b2a1deaed77d142923a1c02f1eacdceb"

--- a/recipes-browser/firefox-l10n/firefox-l10n-nn-no_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-nn-no_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "2e4856430f930719bc6e4774e781bd64"
-SRC_URI[sha256sum] = "a98bf22c3ecc3225ebfbb310c84324e545ce85627461c1bff22008aa29f504d6"

--- a/recipes-browser/firefox-l10n/firefox-l10n-nn-no_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-nn-no_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "cacb0c7333aee0fa134f97c8bb7c97ed"
+SRC_URI[sha256sum] = "65be2e545586bda4c63a4ea17f904cd93e8a5ab69e8f692dfdb03e4348ca22ae"

--- a/recipes-browser/firefox-l10n/firefox-l10n-or_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-or_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "6316b773942fa3e8745fed4ee06f11b0"
-SRC_URI[sha256sum] = "6ab0259bf3666112a6171b0ac11b9ae74341930aa5158f154a2eeebd5a33eeb4"

--- a/recipes-browser/firefox-l10n/firefox-l10n-or_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-or_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "4738a0df7351c773646a71ec212b815b"
+SRC_URI[sha256sum] = "e6d616793b35f5a3ec08eaf21a58fde941f4e704478ad728e754d3b9db6a9df6"

--- a/recipes-browser/firefox-l10n/firefox-l10n-pa-in_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-pa-in_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "16bcab569c4b7624bbcef1300b05dba5"
-SRC_URI[sha256sum] = "10dffc15f93c9347a6ce6c2ca53877057fc758a8c3a3e7777ab5858839072f9c"

--- a/recipes-browser/firefox-l10n/firefox-l10n-pa-in_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-pa-in_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "c9fee9a6deabff72393d266b00f5cf21"
+SRC_URI[sha256sum] = "15705ba576cc09df020e02b5fa1e98039e6438daffaf44ef169dbc3da352eba7"

--- a/recipes-browser/firefox-l10n/firefox-l10n-pl_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-pl_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "e7cd9560509ad1267e9dc6b3a591efbb"
-SRC_URI[sha256sum] = "ebc90628adaf91bff4a2dbfa3bedb0bdb363cab180dea7b341d048f6a494c739"

--- a/recipes-browser/firefox-l10n/firefox-l10n-pl_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-pl_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "1906658eff72947a2ca5f75d10b54f3c"
+SRC_URI[sha256sum] = "a3431256dc89be10524babf7243ef48b366348166f8c6f3b33e7ab3dad8f6fa9"

--- a/recipes-browser/firefox-l10n/firefox-l10n-pt-br_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-pt-br_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "f70751cfb361b27d4596736ed3cb68a1"
-SRC_URI[sha256sum] = "d73047b8c868acdd502498fa0731d672f4e8e50e55fab6661ad1e8b68e03d522"

--- a/recipes-browser/firefox-l10n/firefox-l10n-pt-br_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-pt-br_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "757f11e0dd0fe7d5c30dff58bf87196a"
+SRC_URI[sha256sum] = "15b2d810761ea44828d5166588143b631a8341414a35742c2985142260464faa"

--- a/recipes-browser/firefox-l10n/firefox-l10n-pt-pt_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-pt-pt_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "a6531a28893d546fa04c64d30c6fcd09"
-SRC_URI[sha256sum] = "d3692c2cdc86a60b5ab872d3ae70805c7623636831adba34759c99fe4760451a"

--- a/recipes-browser/firefox-l10n/firefox-l10n-pt-pt_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-pt-pt_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "7522d3fd1aecf2c56fe3f170bc73fa1f"
+SRC_URI[sha256sum] = "7fe472ee9817615a200326c14556281b75a1190b5918725251f6b5b48793979e"

--- a/recipes-browser/firefox-l10n/firefox-l10n-rm_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-rm_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "8f667d46758640dc67c822741f32f24b"
-SRC_URI[sha256sum] = "dbad8461140a9bcc5677b64af330adc48da4a5c2a140e10b1fced2f8229b526f"

--- a/recipes-browser/firefox-l10n/firefox-l10n-rm_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-rm_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "a8fae1b6958c7599263d19da94ebde0d"
+SRC_URI[sha256sum] = "12206fb5285cd7d2b1125a6c372b05591e7beec37bbd05c3e0fafd900af70cfe"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ro_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ro_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "09aa4bcc19dd887f7effed4e00777953"
-SRC_URI[sha256sum] = "fa81c4bd21272c894d35b273658218a51c2f17e0f6149fcfc6e07c94217a1377"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ro_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ro_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "8ab784c95c9b7b1083a5be62b2a834d4"
+SRC_URI[sha256sum] = "7d7311b5c059d86f5db629d7bb2fdd88232c138f911076f9533d144c139fd2cf"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ru_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ru_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "5932d82abf864a376ed5d892179465a2"
-SRC_URI[sha256sum] = "b2eff18982c8464b34455dd375b888d76f3b13b488c9ad1cd0c6e5075616bb6b"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ru_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ru_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "c9cb732f9e78ef770b85406ea5d48177"
+SRC_URI[sha256sum] = "3baf8d0aa2769c76e548ff41dbd11dea6796ef0a25558c9aa3c9447ad7ba3fd6"

--- a/recipes-browser/firefox-l10n/firefox-l10n-si_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-si_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "50822bb77510839b0ff883f22b74a47e"
-SRC_URI[sha256sum] = "03c7d40c2df94c8d1a1e838b22aa974d86ee50c5f61d735da8802b1a5ae04d85"

--- a/recipes-browser/firefox-l10n/firefox-l10n-si_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-si_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "495207a67bc3f0ad24194567b562921e"
+SRC_URI[sha256sum] = "a05cf9bef043afebabf9b7db194706288a3d73eaf1007f4ce6d96a0084b2d441"

--- a/recipes-browser/firefox-l10n/firefox-l10n-sk_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-sk_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "adebd46c1490c0cb6831771f0d7af0f0"
-SRC_URI[sha256sum] = "8ee0ca43a6f4600891ee2258879d575aa4fa475421bdd53aac5b66462d9ba34a"

--- a/recipes-browser/firefox-l10n/firefox-l10n-sk_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-sk_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "e378ceea8efbc7f62db242f959452ca3"
+SRC_URI[sha256sum] = "ba88eec4cd462d636662529ed5757c359d9a684b3659dfcfc899b5863c07a552"

--- a/recipes-browser/firefox-l10n/firefox-l10n-sl_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-sl_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "d68614d516011927723a3c7972fb59e6"
-SRC_URI[sha256sum] = "e03149721297f487b6b8d395add7594f72d6c506ec1be0eb229cf36dcf256824"

--- a/recipes-browser/firefox-l10n/firefox-l10n-sl_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-sl_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "e962c8fca48f720c0b877ecc9a5adb57"
+SRC_URI[sha256sum] = "99746474185eb6090a3cfc5917166da3a598007f0dd9a4d864483938c2f1786d"

--- a/recipes-browser/firefox-l10n/firefox-l10n-son_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-son_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "8091f438c0de5ac9549f6d1b41170e9f"
-SRC_URI[sha256sum] = "16906b5639d0331c96a89e443dc173ff50136c3a9663c769d81cc450a0f8f70d"

--- a/recipes-browser/firefox-l10n/firefox-l10n-son_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-son_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "7cd05dbeb3f910ad868cc80244586006"
+SRC_URI[sha256sum] = "5a9a0ff096f06f5885f0f3b95825fece99c9bffa340d51c2eecf76c6a710e4f9"

--- a/recipes-browser/firefox-l10n/firefox-l10n-sq_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-sq_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "cceca6438ef354c3667f8afbc113b853"
-SRC_URI[sha256sum] = "f9d6bb89af80e355ac77b59bd0d7d9088fb0e400fc59402ddf83bf6337fc7f1e"

--- a/recipes-browser/firefox-l10n/firefox-l10n-sq_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-sq_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "9f92c926b0f4a1d44bdd2742f9561104"
+SRC_URI[sha256sum] = "7300854b0367c3569bccba4552f94ab948dbba28e4b407a1919cc509dc6e9224"

--- a/recipes-browser/firefox-l10n/firefox-l10n-sr_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-sr_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "65c4ae5acb4afa8002139bbb9ec6f8aa"
-SRC_URI[sha256sum] = "5ea9289e509f62ac2315db1d332741a31d935cc02b9ce3af36898b082f293d9f"

--- a/recipes-browser/firefox-l10n/firefox-l10n-sr_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-sr_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "2291d9d91cfafecdbafbd29428bd303d"
+SRC_URI[sha256sum] = "ba95f83cd63abf7518e98ec71eed90a47f4fe43e1ce1215ef047663935543d43"

--- a/recipes-browser/firefox-l10n/firefox-l10n-sv-se_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-sv-se_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "dc44994b4c92c908a47606dceb13f7df"
-SRC_URI[sha256sum] = "7967be14966c44205fb1319350210667bdea3772cc59309c67cff972bbd19fe8"

--- a/recipes-browser/firefox-l10n/firefox-l10n-sv-se_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-sv-se_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "7739be7a455981ba5778d6e0d2487378"
+SRC_URI[sha256sum] = "e427833cf0985c680732d5ff6c98e34d0c86caa4ed8363f822bfadc291d24f3f"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ta_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ta_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "df0ded60fca0958742b227dd374acac1"
-SRC_URI[sha256sum] = "2b009ceb488018ac7473e3a3f6fea9e9218644be4fef53e6b88dc27ec4290bca"

--- a/recipes-browser/firefox-l10n/firefox-l10n-ta_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-ta_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "2de4b3f5911097118cf5611cbb68596c"
+SRC_URI[sha256sum] = "66bfb2dcbe11b41207e81e1d259f0a0783dd7425c26f1c97f02df4e275c9d50f"

--- a/recipes-browser/firefox-l10n/firefox-l10n-te_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-te_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "b75c99ef2099b821730782b7d09d99c1"
-SRC_URI[sha256sum] = "9907eef05e38743e66758248a7bf52edf2d4e9d22c82b437ba7deb920e5da9c0"

--- a/recipes-browser/firefox-l10n/firefox-l10n-te_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-te_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "7745f0c85fc6c61a264651cc02c08df3"
+SRC_URI[sha256sum] = "a9be8bbaffbf17dc64ef42de29de38b61b3acf493141de9f462161afc7fbe8ba"

--- a/recipes-browser/firefox-l10n/firefox-l10n-th_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-th_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "7a6c13815509b6de5b5181c90f727ca2"
-SRC_URI[sha256sum] = "94942825b0d1a0cfe49fa64e1789635c527064ce5c599740d96590ffd4a86231"

--- a/recipes-browser/firefox-l10n/firefox-l10n-th_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-th_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "0cbbb9bbf4b4d5dece17775063a8e4aa"
+SRC_URI[sha256sum] = "24daaab49e4b71be426ef7276d556edb22fb8c53bb20f684fae1985fedbe2ba4"

--- a/recipes-browser/firefox-l10n/firefox-l10n-tr_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-tr_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "60a7f1d8602a4d72e8b2083787e04d4f"
-SRC_URI[sha256sum] = "b023c5398ff903a2f276802a11e5acda7d591b0a25f54ad1f857d71ccd3dcf05"

--- a/recipes-browser/firefox-l10n/firefox-l10n-tr_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-tr_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "a173616100472acbe35c8af7e71a05b9"
+SRC_URI[sha256sum] = "52cc765c308a4f1bc9d99396784da84fd4405c6e571b4911f36f34bc5aa94735"

--- a/recipes-browser/firefox-l10n/firefox-l10n-uk_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-uk_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "6a3079f9a38f9c10ec84e28890233ac0"
-SRC_URI[sha256sum] = "ae9002bac9accfc3037322208e19ab98258ad796e1696cb74ffd17359ac41843"

--- a/recipes-browser/firefox-l10n/firefox-l10n-uk_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-uk_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "dcd0867090dba0ddeb6ff9deaab8770d"
+SRC_URI[sha256sum] = "43a2b0033269aa6bce8699ef9cff2407fda2cc0ad56b924d0fb110cccbe5125a"

--- a/recipes-browser/firefox-l10n/firefox-l10n-uz_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-uz_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "86fa0bab642976ed51c93ba4e31fe44d"
-SRC_URI[sha256sum] = "f729000a17f6770423895af7d123fb0cde0f5fbe854d692a474a26a4991f6f2e"

--- a/recipes-browser/firefox-l10n/firefox-l10n-uz_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-uz_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "40323fee0e5fe562523479b8ced336d9"
+SRC_URI[sha256sum] = "4bc7a88ffa5a025f1eeb2533ede56e1b76259df57cba6bfb30acc82b48ed5a7b"

--- a/recipes-browser/firefox-l10n/firefox-l10n-vi_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-vi_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "eb0913c9f7fd4cac521e74706e47652f"
-SRC_URI[sha256sum] = "324ff5d2900d58d7c44b05381ac4d280d94586392d786aa7ae3b68f11a5bc4b0"

--- a/recipes-browser/firefox-l10n/firefox-l10n-vi_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-vi_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "27ff79da74e2d9404deb15cc245ac302"
+SRC_URI[sha256sum] = "844dfecaf0156967b6c8ca031e1782f2afbfc7c057d15f3ed47ae3962f0dfca7"

--- a/recipes-browser/firefox-l10n/firefox-l10n-xh_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-xh_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "0655aca94a3fb35b03c2c3f69ff1c2af"
-SRC_URI[sha256sum] = "f2abe016111ec875c19d76e7265d40c3bcbb264fbb3c5aee71835326a8231a03"

--- a/recipes-browser/firefox-l10n/firefox-l10n-xh_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-xh_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "c97dce8beb08d6e5a9117452cefd1f3a"
+SRC_URI[sha256sum] = "693a74d9a97667fbd741f5db3ff3ee2648eefddb41fe53b0fb7a91300022d4c1"

--- a/recipes-browser/firefox-l10n/firefox-l10n-zh-cn_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-zh-cn_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "d9c49066bac757bb6f6484f7020e35a9"
-SRC_URI[sha256sum] = "a1bdc0ad4365fedf3cd9cb87a58dafcc08333a79e0383cdf97a20e91e5a4f1b4"

--- a/recipes-browser/firefox-l10n/firefox-l10n-zh-cn_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-zh-cn_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "6323793af1ec9c8c9a138d71dba0bb72"
+SRC_URI[sha256sum] = "3f77022c3669c5d2c8a728c2027bd515263361cc7722c546662a56e9c63ed788"

--- a/recipes-browser/firefox-l10n/firefox-l10n-zh-tw_52.8.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-zh-tw_52.8.0esr.bb
@@ -1,7 +1,0 @@
-# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
-# Released under the MIT license (see packages/COPYING)
-
-require firefox-l10n.inc
-
-SRC_URI[md5sum] = "698e639ff494cb044358ae0a1444f71d"
-SRC_URI[sha256sum] = "a837d5724e77fc8a7983caa7cd913dcb52588c807f21d27f502d426430059acf"

--- a/recipes-browser/firefox-l10n/firefox-l10n-zh-tw_52.9.0esr.bb
+++ b/recipes-browser/firefox-l10n/firefox-l10n-zh-tw_52.9.0esr.bb
@@ -1,0 +1,7 @@
+# Copyright (C) 2009-2018, O.S. Systems Software Ltda. All Rights Reserved
+# Released under the MIT license (see packages/COPYING)
+
+require firefox-l10n.inc
+
+SRC_URI[md5sum] = "80d7f631308f45f48b8fdd9e05c975d3"
+SRC_URI[sha256sum] = "b029a2c9828c8f7fa4161bc7d0280ceed8ae23a1fd1f85e8052dfaa288b60bfd"

--- a/recipes-browser/firefox/firefox_52.9.0esr.bb
+++ b/recipes-browser/firefox/firefox_52.9.0esr.bb
@@ -46,8 +46,8 @@ SRC_URI = "https://archive.mozilla.org/pub/firefox/releases/${PV}/source/firefox
            file://0003-do-not-link-against-crmf-library-it-is-not-there.patch \
            "
 
-SRC_URI[archive.md5sum] = "32a7c074788569ca548de2c0394fd0aa"
-SRC_URI[archive.sha256sum] = "babed4fe0ae95783e39358aedf7111b20fd9442f73b3b41b025fa4951fe76287"
+SRC_URI[archive.md5sum] = "b8c2f3619c684818be9a513f8aa1dbfd"
+SRC_URI[archive.sha256sum] = "c01d09658c53c1b3a496e353a24dad03b26b81d3b1d099abc26a06f81c199dd6"
 
 S = "${WORKDIR}/firefox-${PV}"
 # MOZ_APP_BASE_VERSION should be incremented after a release


### PR DESCRIPTION
Upgrade firefox & firefox-l10n to 52.9.0.

I've confirmed that firefox 52.9.0esr can work normally on poky master@028a292001f64ad86c6b960a05ba1f6fd72199de
