### PR TITLE
firefox/chromium: Exclude from musl world builds

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland_64.0.3274.0.r517731.igalia.1.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_64.0.3274.0.r517731.igalia.1.bb
@@ -27,3 +27,6 @@ GN_ARGS += "\
 
 # The chromium binary must always be started with those arguments.
 CHROMIUM_EXTRA_ARGS_append = " --mus --ozone-platform=wayland"
+
+# http://errors.yoctoproject.org/Errors/Details/186958/
+EXCLUDE_FROM_WORLD_libc-musl = "1"

--- a/recipes-browser/chromium/chromium-x11_68.0.3440.106.bb
+++ b/recipes-browser/chromium/chromium-x11_68.0.3440.106.bb
@@ -33,3 +33,6 @@ DEPENDS += "\
 # chromium-ozone-wayland recipes, and the former used to be called just
 # "chromium".
 PROVIDES = "chromium"
+
+# http://errors.yoctoproject.org/Errors/Details/186969/
+EXCLUDE_FROM_WORLD_libc-musl = "1"

--- a/recipes-browser/firefox/firefox_52.9.0esr.bb
+++ b/recipes-browser/firefox/firefox_52.9.0esr.bb
@@ -94,3 +94,6 @@ PRIVATE_LIBS = "libmozjs.so \
                 libmozsqlite3.so \
                 libbrowsercomps.so \
                 libclearkey.so"
+
+# http://errors.yoctoproject.org/Errors/Details/186965/
+EXCLUDE_FROM_WORLD_libc-musl = "1"


### PR DESCRIPTION
These recipes don't build for musl, no need to spend
compute cycles

Signed-off-by: Khem Raj <raj.khem@gmail.com>