### PR TITLE
chromium: Check for toolchain being clang as well for deciding on is_…

### DIFF
--- a/recipes-browser/chromium/gn-utils.inc
+++ b/recipes-browser/chromium/gn-utils.inc
@@ -42,7 +42,8 @@ BUILD_LD_toolchain-clang = "clang"
 def is_default_cc_clang(d):
     """Return true if clang is default cross compiler."""
     toolchain = d.getVar("TOOLCHAIN")
-    if toolchain == "clang":
+    overrides = d.getVar("OVERRIDES")
+    if toolchain == "clang" and "toolchain-clang" in overrides.split(":"):
         return "true"
     return "false"
 


### PR DESCRIPTION
…clang

There are scenarios where someone may setup TOOLCHAIN = "clang" in
local.conf but then not have meta-clang in bblayers.conf which would
actually be ignored if meta-clang is not there, so we also need to make
sure that we have 'toolchain-clang' in OVERRIDES which is only added by
meta-clang and when we want to use clang as default compiler

Signed-off-by: Khem Raj <raj.khem@gmail.com>