### PR TITLE
chromium-ozone-wayland: Fix build on aarch64

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland/0001-Exclude-CRC32-define-for-the-Renesas-M3-board.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0001-Exclude-CRC32-define-for-the-Renesas-M3-board.patch
@@ -1,0 +1,30 @@
+Upstream-status: Inappropriate [embedded specific]
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From f59799ef353e4221e61ec565b4b03c1fc1ea127b Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Mon, 17 Sep 2018 09:54:31 +0300
+Subject: [PATCH] Exclude CRC32 define for the Renesas M3 board
+
+The CRC32 APIs are optional for armv8-a. They became mandatory since
+armv8.1-a. The Renesas board doesn't have them implemented. Thus,
+just disable them.
+---
+ third_party/zlib/BUILD.gn | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: chromium-ozone-wayland-dev-71.0.3545.0.r589108.igalia.1/third_party/zlib/BUILD.gn
+===================================================================
+--- chromium-ozone-wayland-dev-71.0.3545.0.r589108.igalia.1.orig/third_party/zlib/BUILD.gn
++++ chromium-ozone-wayland-dev-71.0.3545.0.r589108.igalia.1/third_party/zlib/BUILD.gn
+@@ -65,9 +65,6 @@ config("zlib_arm_crc32_config") {
+     # TODO(cavalcantii): crbug.com/810125.
+     if (!is_ios && !is_chromeos && !is_fuchsia) {
+       defines = []
+-      if (current_cpu == "arm64") {
+-        defines = [ "CRC32_ARMV8_CRC32" ]
+-      }
+       if (is_android) {
+         defines += [ "ARMV8_OS_ANDROID" ]
+       } else if (is_linux || is_chromeos) {

--- a/recipes-browser/chromium/chromium-ozone-wayland/aarch64-skia-build-fix.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/aarch64-skia-build-fix.patch
@@ -1,0 +1,48 @@
+Upstream-Status: Inappropriate
+
+GCC (tested rocko's 7.3.0) cannot find these intrinsics and the build fails:
+
+../../third_party/skia/src/opts/SkRasterPipeline_opts.h: In function 'neon::F neon::from_half(neon::U16)':
+../../third_party/skia/src/opts/SkRasterPipeline_opts.h:657:26: error: cannot convert 'neon::U16 {aka short unsigned int}' to 'float16x4_t {aka __vector(4) __fp16}' for argument '1' to '
+float32x4_t vcvt_f32_f16(float16x4_t)'
+     return vcvt_f32_f16(h);
+                          ^
+../../third_party/skia/src/opts/SkRasterPipeline_opts.h: In function 'neon::U16 neon::to_half(neon::F)':
+../../third_party/skia/src/opts/SkRasterPipeline_opts.h:677:26: error: cannot convert 'neon::F {aka float}' to 'float32x4_t {aka __vector(4) float}' for argument '1' to 'float16x4_t vcvt
+_f16_f32(float32x4_t)'
+     return vcvt_f16_f32(f);
+                          ^
+
+Upstream seems to have had similar issues according to
+https://skia-review.googlesource.com/c/skia/+/84222, but there is no fix at the
+moment.
+
+Signed-off-by: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
+Index: chromium-ozone-wayland-dev-71.0.3545.0.r589108.igalia.1/third_party/skia/src/opts/SkRasterPipeline_opts.h
+===================================================================
+--- chromium-ozone-wayland-dev-71.0.3545.0.r589108.igalia.1.orig/third_party/skia/src/opts/SkRasterPipeline_opts.h
++++ chromium-ozone-wayland-dev-71.0.3545.0.r589108.igalia.1/third_party/skia/src/opts/SkRasterPipeline_opts.h
+@@ -658,10 +658,7 @@ SI F approx_powf(F x, F y) {
+ }
+ 
+ SI F from_half(U16 h) {
+-#if defined(SK_CPU_ARM64) && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
+-    return vcvt_f32_f16(h);
+-
+-#elif defined(JUMPER_IS_HSW) || defined(JUMPER_IS_AVX512)
++#if defined(JUMPER_IS_HSW) || defined(JUMPER_IS_AVX512)
+     return _mm256_cvtph_ps(h);
+ 
+ #else
+@@ -678,10 +675,7 @@ SI F from_half(U16 h) {
+ }
+ 
+ SI U16 to_half(F f) {
+-#if defined(SK_CPU_ARM64) && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
+-    return vcvt_f16_f32(f);
+-
+-#elif defined(JUMPER_IS_HSW) || defined(JUMPER_IS_AVX512)
++#if defined(JUMPER_IS_HSW) || defined(JUMPER_IS_AVX512)
+     return _mm256_cvtps_ph(f, _MM_FROUND_CUR_DIRECTION);
+ 
+ #else

--- a/recipes-browser/chromium/chromium-ozone-wayland/libdrm-fixes.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/libdrm-fixes.patch
@@ -1,0 +1,15 @@
+This ensures that major/minor is picked from correct header in glibc 2.24+ onwards
+Index: chromium-ozone-wayland-dev-71.0.3545.0.r589108.igalia.1/third_party/libdrm/BUILD.gn
+===================================================================
+--- chromium-ozone-wayland-dev-71.0.3545.0.r589108.igalia.1.orig/third_party/libdrm/BUILD.gn
++++ chromium-ozone-wayland-dev-71.0.3545.0.r589108.igalia.1/third_party/libdrm/BUILD.gn
+@@ -58,6 +58,9 @@ if (!use_system_libdrm) {
+       # glibc-2.24.  This causes a build error when using the Debian
+       # Stretch sysroot.
+       "-Wno-deprecated-declarations",
++      # This is a autoconf check in libdrm here we make sure that check is
++      # cached
++      "-DMAJOR_IN_SYSMACROS",
+     ]
+ 
+     public_configs = [ ":libdrm_config" ]

--- a/recipes-browser/chromium/chromium-ozone-wayland_71.0.3545.0.r589108.igalia.1.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_71.0.3545.0.r589108.igalia.1.bb
@@ -10,6 +10,7 @@ SRC_URI += " \
  file://oe-clang-fixes.patch \
  file://aarch64-skia-build-fix.patch \
  file://0001-Exclude-CRC32-define-for-the-Renesas-M3-board.patch \
+ file://libdrm-fixes.patch \
 "
 
 REQUIRED_DISTRO_FEATURES = "wayland"

--- a/recipes-browser/chromium/chromium-ozone-wayland_71.0.3545.0.r589108.igalia.1.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_71.0.3545.0.r589108.igalia.1.bb
@@ -9,6 +9,7 @@ SRC_URI += " \
  file://0001-ozone-wayland-Fix-fpermissive-problem-for-GCC.patch \
  file://oe-clang-fixes.patch \
  file://aarch64-skia-build-fix.patch \
+ file://0001-Exclude-CRC32-define-for-the-Renesas-M3-board.patch \
 "
 
 REQUIRED_DISTRO_FEATURES = "wayland"

--- a/recipes-browser/chromium/chromium-ozone-wayland_71.0.3545.0.r589108.igalia.1.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_71.0.3545.0.r589108.igalia.1.bb
@@ -8,6 +8,7 @@ SRC_URI += " \
  file://0001-Fix-a-GCC-error-about-undeclared-std-unique_ptr.patch \
  file://0001-ozone-wayland-Fix-fpermissive-problem-for-GCC.patch \
  file://oe-clang-fixes.patch \
+ file://aarch64-skia-build-fix.patch \
 "
 
 REQUIRED_DISTRO_FEATURES = "wayland"


### PR DESCRIPTION
This fixes build failures(compile time) however there remains one link
time failure still which is about detecting crc32 support on aarch64
wrongly, this could be OE or cross compile specific. However, these
patch are a progress from compile errors to link time errors.

Signed-off-by: Khem Raj <raj.khem@gmail.com>