### PR TITLE
cef3 branch 3538 with patches to compile for chromium 69.0.3497.100

### DIFF
--- a/recipes-browser/chromium/cef3/linux_build_patch.patch
+++ b/recipes-browser/chromium/cef3/linux_build_patch.patch
@@ -1,0 +1,26 @@
+Upstream-Status: Backport
+
+- Compile compatiblity with chromium-69.0.3497.100, original version was for chromium-69.0.3497.0
+
+--- a/cef/patch/patches/linux_build.patch	2018-10-05 15:09:02.769739700 +0200
++++ b/cef/patch/patches/linux_build.patch	2018-10-05 15:09:17.491119649 +0200
+@@ -60,19 +60,6 @@
+  
+    ScopedStyleContext child_context(gtk_style_context_new());
+    gtk_style_context_set_path(child_context, path);
+-diff --git chrome/browser/ui/libgtkui/native_theme_gtk2.cc chrome/browser/ui/libgtkui/native_theme_gtk2.cc
+-index b24ff4b95f97..49e80717b1d6 100644
+---- chrome/browser/ui/libgtkui/native_theme_gtk2.cc
+-+++ chrome/browser/ui/libgtkui/native_theme_gtk2.cc
+-@@ -163,6 +163,8 @@ SkColor NativeThemeGtk2::GetSystemColor(ColorId color_id) const {
+-       return GetBgColor(GetMenu(), NORMAL);
+- 
+-     // Label
+-+    case kColorId_ActionableSubmenuVerticalSeparatorColor:
+-+    case kColorId_TouchableMenuItemLabelColor:
+-     case kColorId_LabelEnabledColor:
+-       return GetTextColor(GetEntry(), NORMAL);
+-     case kColorId_LabelDisabledColor:
+ diff --git ui/accessibility/platform/atk_util_auralinux_gtk2.cc ui/accessibility/platform/atk_util_auralinux_gtk2.cc
+ index ac11b5626f67..6355d0283de1 100644
+ --- ui/accessibility/platform/atk_util_auralinux_gtk2.cc

--- a/recipes-browser/chromium/cef3/network_delegate_cookies.patch
+++ b/recipes-browser/chromium/cef3/network_delegate_cookies.patch
@@ -1,0 +1,47 @@
+Upstream-Status: Backport
+
+- Compile compatiblity with chromium-69.0.3497.100, original version was for chromium-69.0.3497.0
+
+--- chromium-69.0.3497.100/cef/libcef/browser/net/network_delegate.h.org	2018-10-08 10:03:24.577115270 +0200
++++ chromium-69.0.3497.100/cef/libcef/browser/net/network_delegate.h	2018-10-08 10:03:42.818914741 +0200
+@@ -41,12 +41,10 @@
+                    bool started,
+                    int net_error) override;
+   bool OnCanGetCookies(const net::URLRequest& request,
+-                       const net::CookieList& cookie_list,
+-                       bool allowed_from_caller) override;
++                       const net::CookieList& cookie_list) override;
+   bool OnCanSetCookie(const net::URLRequest& request,
+                       const net::CanonicalCookie& cookie,
+-                      net::CookieOptions* options,
+-                      bool allowed_from_caller) override;
++                      net::CookieOptions* options) override;
+   bool OnCanAccessFile(const net::URLRequest& request,
+                        const base::FilePath& original_path,
+                        const base::FilePath& absolute_path) const override;
+--- chromium-69.0.3497.100/cef/libcef/browser/net/network_delegate.cc.org	2018-10-08 10:02:46.129442186 +0200
++++ chromium-69.0.3497.100/cef/libcef/browser/net/network_delegate.cc	2018-10-08 10:03:13.980067286 +0200
+@@ -445,10 +445,7 @@
+ }
+ 
+ bool CefNetworkDelegate::OnCanGetCookies(const net::URLRequest& request,
+-                                         const net::CookieList& cookie_list,
+-                                         bool allowed_from_caller) {
+-  if (!allowed_from_caller)
+-    return false;
++                                         const net::CookieList& cookie_list) {
+   if (net_util::IsInternalRequest(&request))
+     return true;
+ 
+@@ -475,10 +472,7 @@
+ 
+ bool CefNetworkDelegate::OnCanSetCookie(const net::URLRequest& request,
+                                         const net::CanonicalCookie& cookie,
+-                                        net::CookieOptions* options,
+-                                        bool allowed_from_caller) {
+-  if (!allowed_from_caller)
+-    return false;
++                                        net::CookieOptions* options) {
+   if (net_util::IsInternalRequest(&request))
+     return true;
+ 

--- a/recipes-browser/chromium/cef3/no_gtkglext.patch
+++ b/recipes-browser/chromium/cef3/no_gtkglext.patch
@@ -1,0 +1,36 @@
+Upstream-Status: Inappropriate [OE-Specific]
+
+- Disable gtkglext missing OE dependency needed by cefclient
+
+diff --git a/cef/BUILD.gn b/cef/BUILD.gn
+index 46f5698a..dbc0b8a1 100644
+--- a/cef/BUILD.gn
++++ b/cef/BUILD.gn
+@@ -140,7 +140,6 @@ if (is_win) {
+ 
+ # Set ENABLE_PRINTING=1 ENABLE_BASIC_PRINTING=1.
+ assert(enable_basic_printing)
+-assert(!enable_print_preview)
+ 
+ # Enable support for Widevine CDM.
+ assert(enable_widevine)
+@@ -1894,11 +1893,6 @@ if (is_mac) {
+       ]
+     }
+ 
+-    pkg_config("gtkglext") {
+-      packages = [
+-        "gtkglext-1.0",
+-      ]
+-    }
+   }
+ 
+   if (is_linux) {
+@@ -1982,7 +1976,6 @@ if (is_mac) {
+       if (!use_sysroot) {
+         configs += [
+           ":gtk",
+-          ":gtkglext",
+         ]
+       }
+ 

--- a/recipes-browser/chromium/cef3/patch_apply.patch
+++ b/recipes-browser/chromium/cef3/patch_apply.patch
@@ -1,0 +1,66 @@
+Upstream-Status: Inappropriate [OE-Specific]
+
+- Apply patch using patch command instead of git apply,
+  because on OE build whe do not have git info about chromium 
+
+diff --git a/cef/tools/patcher.py b/cef/tools/patcher.py
+index 942d2116..5b11af02 100644
+--- a/cef/tools/patcher.py
++++ b/cef/tools/patcher.py
+@@ -7,7 +7,8 @@ from optparse import OptionParser
+ import os
+ import sys
+ from file_util import *
+-from git_util import git_apply_patch_file
++#from git_util import git_apply_patch_file
++from exec_util import exec_cmd
+ 
+ # Cannot be loaded as a module.
+ if __name__ != "__main__":
+@@ -26,6 +27,37 @@ def write_note(type, note):
+   sys.stdout.write('!!!! %s: %s\n' % (type, note))
+   sys.stdout.write(separator)
+ 
++def write_indented_output(output):
++  """ Apply a fixed amount of intent to lines before printing. """
++  if output == '':
++    return
++  for line in output.split('\n'):
++    line = line.strip()
++    if len(line) == 0:
++      continue
++    sys.stdout.write('\t%s\n' % line)
++
++def patch_apply_patch_file(patch_path, patch_dir):
++  """ Apply |patch_path| to files in |patch_dir|. """
++  patch_name = os.path.basename(patch_path)
++  sys.stdout.write('\nApply %s in %s\n' % (patch_name, patch_dir))
++
++  if not os.path.isfile(patch_path):
++    sys.stdout.write('... patch file does not exist.\n')
++    return 'fail'
++
++  config = '-p0 --ignore-whitespace'
++
++  # Apply the patch file. This should always succeed because the previous
++  # command succeeded.
++  cmd = 'patch %s -i %s' % (config, patch_path)
++  result = exec_cmd(cmd, patch_dir)
++  if result['err'] == '':
++    sys.stdout.write('... successfully applied.\n')
++  else:
++    sys.stdout.write('... successfully applied (with warnings):\n')
++    write_indented_output(result['err'].replace('<stdin>', patch_name))
++  return 'apply'
+ 
+ def apply_patch_file(patch_file, patch_dir):
+   ''' Apply a specific patch file in optional patch directory. '''
+@@ -39,7 +71,7 @@ def apply_patch_file(patch_file, patch_dir):
+       patch_dir = os.path.join(src_dir, patch_dir)
+     patch_dir = os.path.abspath(patch_dir)
+ 
+-  result = git_apply_patch_file(patch_path, patch_dir)
++  result = patch_apply_patch_file(patch_path, patch_dir)
+   if result == 'fail':
+     write_note('ERROR',
+                'This patch failed to apply. Your build will not be correct.')

--- a/recipes-browser/chromium/cef3/renderer_url_requeste_create_url_loader.patch
+++ b/recipes-browser/chromium/cef3/renderer_url_requeste_create_url_loader.patch
@@ -1,0 +1,16 @@
+Upstream-Status: Backport
+
+- Compile compatiblity with chromium-69.0.3497.100, original version was for chromium-69.0.3497.0
+
+--- chromium-69.0.3497.100/cef/libcef/renderer/render_urlrequest_impl.cc.org	2018-10-08 10:11:50.993509351 +0200
++++ chromium-69.0.3497.100/cef/libcef/renderer/render_urlrequest_impl.cc	2018-10-08 10:12:25.612733024 +0200
+@@ -117,7 +117,8 @@
+ 
+     loader_ =
+         CefContentRendererClient::Get()->url_loader_factory()->CreateURLLoader(
+-            urlRequest, task_runner_.get());
++            urlRequest, blink::scheduler::WebResourceLoadingTaskRunnerHandle::
++                            CreateUnprioritized(task_runner_.get()));
+     loader_->LoadAsynchronously(urlRequest, url_client_.get());
+     return true;
+   }

--- a/recipes-browser/chromium/cef3_69.0.3497.100.bb
+++ b/recipes-browser/chromium/cef3_69.0.3497.100.bb
@@ -1,0 +1,87 @@
+require chromium-upstream-tarball.inc
+require chromium-gn.inc
+
+SRC_URI += " git://bitbucket.org/chromiumembedded/cef.git;protocol=https;branch=3538;destsuffix=chromium-${PV}/cef;name=cef \
+             file://0001-vpx_sum_squares_2d_i16_neon-Make-s2-a-uint64x1_t.patch \
+             file://aarch64-skia-build-fix.patch \
+             file://oe-clang-fixes.patch \
+             file://patch_apply.patch \
+             file://no_gtkglext.patch \
+             file://linux_build_patch.patch \
+             file://network_delegate_cookies.patch \
+             file://renderer_url_requeste_create_url_loader.patch \
+"
+
+SRCREV_cef = "7d096429250cc4a47fa641337f0db3820e74736d"
+
+PACKAGECONFIG = "use-egl cups"
+
+REQUIRED_DISTRO_FEATURES = "x11"
+
+DEPENDS += "\
+        libx11 \
+        libxcomposite \
+        libxcursor \
+        libxdamage \
+        libxext \
+        libxfixes \
+        libxi \
+        libxrandr \
+        libxrender \
+        libxscrnsaver \
+        libxtst \
+        gtk+ \
+        libgnome-keyring \
+"
+
+do_configure_append() {
+  ln -s Release out/Release_GN_x64
+  cd cef
+  bbnote "create cef3 projects"
+  export PATH="$PATH:${S}/third_party/depot_tools:"
+  export GN_DEFINES="${GN_ARGS}"
+  ./cef_create_projects.sh
+  bbnote "created cef3 projects"
+  cd -
+}
+
+do_compile() {
+  ninja -v ${PARALLEL_MAKE} cefsimple
+}
+
+do_install() {
+	install -d ${D}${libdir}/cef3
+	install -d ${D}${libdir}/cef3/locales
+	install -d ${D}${includedir}/cef
+
+	install -m 0755 cefsimple ${D}${libdir}/cef3/cefsimple
+	install -m 0644 *.bin ${D}${libdir}/cef3/
+	install -m 0644 icudtl.dat ${D}${libdir}/cef3/icudtl.dat
+
+	# Cef *.pak files
+	install -m 0644 *.pak ${D}${libdir}/cef3/
+
+	# Locales.
+	install -m 0644 locales/*.pak ${D}${libdir}/cef3/locales/
+
+	install -m 0755 *.so ${D}${libdir}/cef3/
+
+	# Swiftshader is only built for x86 and x86-64.
+	if [ -d "swiftshader" ]; then
+		install -d ${D}${libdir}/cef3/swiftshader
+		install -m 0644 swiftshader/libEGL.so ${D}${libdir}/cef3/swiftshader/
+		install -m 0644 swiftshader/libGLESv2.so ${D}${libdir}/cef3/swiftshader/
+	fi
+
+	# Header files
+	cp -r ${S}/cef/include ${D}${includedir}/cef/
+}
+
+RDEPENDS_${PN} += " pango cairo fontconfig pciutils pulseaudio freetype fontconfig-utils "
+
+# http://errors.yoctoproject.org/Errors/Details/186969/
+EXCLUDE_FROM_WORLD_libc-musl = "1"
+
+PACKAGES = "libcef3 libcef3-dbg libcef3-dev"
+FILES_libcef3 = "${libdir}"
+FILES_libcef3-dev = "${includedir}"


### PR DESCRIPTION
Added recipe to compile Chromium Embedded Framework branck 3583 with current chromium release 69.0.3497.100.

Sure can be better: point that can be fix (I don't know how):
- clean method disable gtkglext dependency needed by cefclient (now done with no_gtkglext.patch), or create a recipe for gtkglext
- more clean bb recipe for cef3, now derived buy copy of chromium recipe and readapted
- clean method to set out folder for cef3 compile (see ln -s Relase out/Release_GN_x64 on do_configure_append that works only in x64)
 
Patched patch apply that works with git, and source to be patched in yocto build ha no git files (patch_apply.patch)
