### PR TITLE
chromium: Fix the x86 build with GCC 8.

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -9,6 +9,7 @@ OUTPUT_DIR = "out/Release"
 B = "${S}/${OUTPUT_DIR}"
 
 SRC_URI += " \
+        file://0001-Update-asserts-in-mojo-about-int64_t-s-alignment.patch \
         file://v8-qemu-wrapper.patch \
         file://wrapper-extra-flags.patch \
 "

--- a/recipes-browser/chromium/files/0001-Update-asserts-in-mojo-about-int64_t-s-alignment.patch
+++ b/recipes-browser/chromium/files/0001-Update-asserts-in-mojo-about-int64_t-s-alignment.patch
@@ -1,0 +1,94 @@
+Upstream-Status: Backport
+
+This fixes the x86 build with GCC 8, which updated its alignof() implementation
+to do exactly what was described for clang below. See issue #192.
+
+Signed-off-by: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
+---
+From 16035729f1ca7fcc5815caf702c457f7f5257689 Mon Sep 17 00:00:00 2001
+From: Hans Wennborg <hans@chromium.org>
+Date: Tue, 6 Nov 2018 16:13:27 +0000
+Subject: [PATCH] Update asserts in mojo about int64_t's alignment
+
+The purpose of these asserts is to check that the options structs are aligned
+sufficiently that an int64_t (or similar) could be added to them. The asserts
+were added in https://codereview.chromium.org/295383012
+
+However, the alignment of int64_t on 32-bit x86 is actually 4 bytes, not 8. So
+how did this ever work? Before Clang r345419, the alignof() operator (which is what
+MOJO_ALIGNOF maps to) would return the *preferred alignment* of a type, not
+the *ABI alignment*. That's not what the C and C++ standards specify, so the
+bug was fixed and the asserts started firing. (See also
+https://llvm.org/pr26547)
+
+To fix the build, change the asserts to check that int64_t requires 8 bytes
+alignment *or less*.
+
+Bug: 900406
+Change-Id: Icf80cea80ac31082423faab8c192420d0b98d515
+Reviewed-on: https://chromium-review.googlesource.com/c/1318971
+Commit-Queue: Ken Rockot <rockot@google.com>
+Reviewed-by: Ken Rockot <rockot@google.com>
+Cr-Commit-Position: refs/heads/master@{#605699}
+---
+ mojo/core/options_validation_unittest.cc | 2 +-
+ mojo/public/c/system/buffer.h            | 2 +-
+ mojo/public/c/system/data_pipe.h         | 2 +-
+ mojo/public/c/system/message_pipe.h      | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/mojo/core/options_validation_unittest.cc b/mojo/core/options_validation_unittest.cc
+index 52e0032a898d..b4b02dc7351d 100644
+--- a/mojo/core/options_validation_unittest.cc
++++ b/mojo/core/options_validation_unittest.cc
+@@ -18,7 +18,7 @@ namespace {
+ 
+ using TestOptionsFlags = uint32_t;
+ 
+-static_assert(MOJO_ALIGNOF(int64_t) == 8, "int64_t has weird alignment");
++static_assert(MOJO_ALIGNOF(int64_t) <= 8, "int64_t has weird alignment");
+ struct MOJO_ALIGNAS(8) TestOptions {
+   uint32_t struct_size;
+   TestOptionsFlags flags;
+diff --git a/mojo/public/c/system/buffer.h b/mojo/public/c/system/buffer.h
+index 2cc54270ad1f..83b198b2a89a 100644
+--- a/mojo/public/c/system/buffer.h
++++ b/mojo/public/c/system/buffer.h
+@@ -30,7 +30,7 @@ struct MOJO_ALIGNAS(8) MojoCreateSharedBufferOptions {
+   // See |MojoCreateSharedBufferFlags|.
+   MojoCreateSharedBufferFlags flags;
+ };
+-MOJO_STATIC_ASSERT(MOJO_ALIGNOF(int64_t) == 8, "int64_t has weird alignment");
++MOJO_STATIC_ASSERT(MOJO_ALIGNOF(int64_t) <= 8, "int64_t has weird alignment");
+ MOJO_STATIC_ASSERT(sizeof(MojoCreateSharedBufferOptions) == 8,
+                    "MojoCreateSharedBufferOptions has wrong size");
+ 
+diff --git a/mojo/public/c/system/data_pipe.h b/mojo/public/c/system/data_pipe.h
+index 3702cdb62493..c72f55387ad0 100644
+--- a/mojo/public/c/system/data_pipe.h
++++ b/mojo/public/c/system/data_pipe.h
+@@ -40,7 +40,7 @@ struct MOJO_ALIGNAS(8) MojoCreateDataPipeOptions {
+   // system-dependent capacity of at least one element in size.
+   uint32_t capacity_num_bytes;
+ };
+-MOJO_STATIC_ASSERT(MOJO_ALIGNOF(int64_t) == 8, "int64_t has weird alignment");
++MOJO_STATIC_ASSERT(MOJO_ALIGNOF(int64_t) <= 8, "int64_t has weird alignment");
+ MOJO_STATIC_ASSERT(sizeof(MojoCreateDataPipeOptions) == 16,
+                    "MojoCreateDataPipeOptions has wrong size");
+ 
+diff --git a/mojo/public/c/system/message_pipe.h b/mojo/public/c/system/message_pipe.h
+index 9f222f9aa819..0f642dd9658a 100644
+--- a/mojo/public/c/system/message_pipe.h
++++ b/mojo/public/c/system/message_pipe.h
+@@ -35,7 +35,7 @@ struct MOJO_ALIGNAS(8) MojoCreateMessagePipeOptions {
+   // See |MojoCreateMessagePipeFlags|.
+   MojoCreateMessagePipeFlags flags;
+ };
+-MOJO_STATIC_ASSERT(MOJO_ALIGNOF(int64_t) == 8, "int64_t has weird alignment");
++MOJO_STATIC_ASSERT(MOJO_ALIGNOF(int64_t) <= 8, "int64_t has weird alignment");
+ MOJO_STATIC_ASSERT(sizeof(MojoCreateMessagePipeOptions) == 8,
+                    "MojoCreateMessagePipeOptions has wrong size");
+ 
+-- 
+2.19.1
+


### PR DESCRIPTION
GCC 8 changed the behavior of alignof() to return the minimum alignment
required by the target ABI, instead of the preferred alignment. On x86, this
means alignof(int64_t) started returning 4 instead of 8, which led to a
build failure like

    In file included from ../../mojo/public/c/system/types.h:15,
    from ../../mojo/public/c/system/platform_handle.h:16,
    from ../../mojo/public/cpp/platform/platform_handle.h:12,
    from ../../mojo/public/cpp/platform/platform_channel_endpoint.h:10,
    from ../../mojo/core/connection_params.h:11,
    from ../../mojo/core/channel.h:15,
    from ../../mojo/core/node_channel.h:19,
    from ../../mojo/core/node_controller.h:25,
    from ../../mojo/core/node_controller.cc:5:
    ../../mojo/public/c/system/buffer.h:33:42: error: static assertion failed: int64_t has weird alignment
    MOJO_STATIC_ASSERT(MOJO_ALIGNOF(int64_t) == 8, "int64_t has weird alignment");
    ../../mojo/public/c/system/macros.h:15:53: note: in definition of macro 'MOJO_STATIC_ASSERT'
    #define MOJO_STATIC_ASSERT(expr, msg) static_assert(expr, msg)
    ^~~~
    ../../mojo/public/c/system/data_pipe.h:43:42: error: static assertion failed: int64_t has weird alignment
    MOJO_STATIC_ASSERT(MOJO_ALIGNOF(int64_t) == 8, "int64_t has weird alignment");
    ../../mojo/public/c/system/macros.h:15:53: note: in definition of macro 'MOJO_STATIC_ASSERT'
    #define MOJO_STATIC_ASSERT(expr, msg) static_assert(expr, msg)
    ^~~~
    ../../mojo/public/c/system/message_pipe.h:38:42: error: static assertion failed: int64_t has weird alignment
    MOJO_STATIC_ASSERT(MOJO_ALIGNOF(int64_t) == 8, "int64_t has weird alignment");
    ../../mojo/public/c/system/macros.h:15:53: note: in definition of macro 'MOJO_STATIC_ASSERT'
    #define MOJO_STATIC_ASSERT(expr, msg) static_assert(expr, msg)

The GCC change was actually correct, and clang was recently updated to
behave the same way. Backport a patch from upstream that fixes the Chromium
checks now that clang started hitting the same issues.

Fixes #192.