### PR TITLE
chromium: Explicitly disable linking with LLD

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -119,6 +119,12 @@ GN_ARGS += "is_debug=false is_official_build=true"
 # https://groups.google.com/a/chromium.org/d/msg/chromium-packagers/8aYO3me2SCE/SZ8pJXhZAwAJ
 GN_ARGS += "use_custom_libcxx=false"
 
+# Pulling in meta-clang and enabling it does not automatically bring in lld,
+# but using clang does make GN enable |use_lld| by default when targeting
+# x86-64 (i.e. even builds targeting other architectures will fail to link host
+# tools because of -fuse-ld=lld).
+GN_ARGS += "use_lld=false"
+
 # By default, passing is_official_build=true to GN causes its symbol_level
 # variable to be set to "2". This means the compiler will be passed "-g2" and
 # we will end up with a very large chrome binary (around 5Gb as of M58)


### PR DESCRIPTION
There is nothing wrong with LLD itself, but most of the time it is not
present on either the host system (where it is used by default if it's a
x86-64 system using clang) or the target system (as TOOLCHAIN="clang" does
not bring it in).

This fixes errors such as

    python "../../build/toolchain/gcc_link_wrapper.py" --output="yocto_native/brotli" -- clang++ -Wl,--fatal-warnings -Wl,--build-id=sha1 -fPIC -Wl,-z,noexecstack -Wl,-z,now -Wl,-z,relro -Wl,-z,defs -Wl,--as-needed -fuse-ld=lld -Wl,--icf=all -Wl,--color-diagnostics -m64 -Wl,-O2 -Wl,--gc-sections -rdynamic -Wl,-rpath-link=yocto_native -Wl,--disable-new-dtags -L/data/src/yocto/poky/build-sumo-raspiberrypi3-clang/tmp/work/cortexa7hf-neon-vfpv4-poky-linux-gnueabi/chromium-x11/70.0.3538.110-r0/recipe-sysroot-native/usr/lib -L/data/src/yocto/poky/build-sumo-raspiberrypi3-clang/tmp/work/cortexa7hf-neon-vfpv4-poky-linux-gnueabi/chromium-x11/70.0.3538.110-r0/recipe-sysroot-native/lib -Wl,-rpath-link,/data/src/yocto/poky/build-sumo-raspiberrypi3-clang/tmp/work/cortexa7hf-neon-vfpv4-poky-linux-gnueabi/chromium-x11/70.0.3538.110-r0/recipe-sysroot-native/usr/lib -Wl,-rpath-link,/data/src/yocto/poky/build-sumo-raspiberrypi3-clang/tmp/work/cortexa7hf-neon-vfpv4-poky-linux-gnueabi/chromium-x11/70.0.3538.110-r0/recipe-sysroot-native/lib -Wl,-rpath,/data/src/yocto/poky/build-sumo-raspiberrypi3-clang/tmp/work/cortexa7hf-neon-vfpv4-poky-linux-gnueabi/chromium-x11/70.0.3538.110-r0/recipe-sysroot-native/usr/lib -Wl,-rpath,/data/src/yocto/poky/build-sumo-raspiberrypi3-clang/tmp/work/cortexa7hf-neon-vfpv4-poky-linux-gnueabi/chromium-x11/70.0.3538.110-r0/recipe-sysroot-native/lib -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=/data/src/yocto/poky/build-sumo-raspiberrypi3-clang/tmp/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2 -o "yocto_native/brotli" -Wl,--start-group @"yocto_native/brotli.rsp"  -Wl,--end-group   -latomic -ldl -lpthread -lrt
    clang-6.0: error: invalid linker name in argument '-fuse-ld=lld'