### PR TITLE
firefox-l10n: Fix extension filename extraction

### DIFF
--- a/recipes-browser/firefox-l10n/firefox-l10n.inc
+++ b/recipes-browser/firefox-l10n/firefox-l10n.inc
@@ -33,13 +33,18 @@ do_configure() {
     xpi-unpack ${LANGUAGE}.xpi ${LANGUAGE}
 }
 
-do_install() {
-    EXTENSION=`sed --posix '/"id"/!d;s/[ ]*"id": "//;s/".*//' ${LANGUAGE}/manifest.json`
+python do_install() {
+    manifest = d.getVar("LANGUAGE") + "/manifest.json"
+    import json
+    with open(manifest) as f:
+        data = json.load(f)
+    d.setVar("EXTENSION", data["applications"]["gecko"]["id"])
+    bb.build.exec_func("do_install_xpi_pack", d)
+}
 
+do_install_xpi_pack() {
     xpi-pack ${LANGUAGE} ${EXTENSION}.xpi
-
-    mkdir -p ${D}${libdir}/firefox/browser/extensions/
-    install -m 0644 ${EXTENSION}.xpi ${D}${libdir}/firefox/browser/extensions/${EXTENSION}.xpi
+    install -D -m 0644 ${EXTENSION}.xpi ${D}${libdir}/firefox/browser/extensions/${EXTENSION}.xpi
 }
 
 FILES_${PN} += "${libdir}/firefox"


### PR DESCRIPTION
Current logic falls short for langpacks containing 'id' in its name the
reason is that it colludes with the sed expression used to extract the
xpi extension name from manifest. This results in errors like

Packing langpack-id@firefox.mozilla.org
Packed XPI file. It is located in
TOPDIR/build/tmp/work/all-yoe-linux/firefox-l10n-id/60.1.0esr-r3
install: target '.xpi' is not a directory

Convert this to a python function and use the json python module to
parse the manifest.json and extract the right key-value pair

Signed-off-by: Khem Raj <raj.khem@gmail.com>