### PR TITLE
firefox: Fix build break after rust dependency was added

### DIFF
--- a/classes/mozilla.bbclass
+++ b/classes/mozilla.bbclass
@@ -27,7 +27,9 @@ export HOST_AR = "${BUILD_AR}"
 
 mozilla_run_mach() {
 	export SHELL="/bin/sh"
-	export RUST_TARGET="${RUST_TARGET_SYS}"
+	export RUSTSTDLIB="${STAGING_LIBDIR}/rust"
+	export RUSTFLAGS="${RUSTFLAGS} -Cpanic=unwind"
+	export RUST_TARGET="${TARGET_SYS}"
 	export RUST_TARGET_PATH="${STAGING_LIBDIR_NATIVE}/rustlib"
 	export BINDGEN_MFLOAT="${@bb.utils.contains('TUNE_CCARGS_MFLOAT', 'hard', '-mfloat-abi=hard', '', d)}"
 	export BINDGEN_CFLAGS="--target=${TARGET_SYS} --sysroot=${RECIPE_SYSROOT} ${BINDGEN_MFLOAT}"

--- a/recipes-browser/firefox/firefox/fixes/rustc_cross_flags.patch
+++ b/recipes-browser/firefox/firefox/fixes/rustc_cross_flags.patch
@@ -1,0 +1,46 @@
+Add RUSTSTDLIB variable to configure
+
+Firefox expects rust to work from standard install, which is not the
+case for OE cross compiled rust. We need to suggest the path for
+rustlibs using -L option
+
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Index: firefox-60.1.0/build/moz.configure/rust.configure
+===================================================================
+--- firefox-60.1.0.orig/build/moz.configure/rust.configure
++++ firefox-60.1.0/build/moz.configure/rust.configure
+@@ -202,14 +202,22 @@ option(env='RUST_TARGET',
+ def rust_target(value):
+     return value[0]
+ 
+-@depends(target, rustc, rust_target, when=rust_compiler)
++option(env='RUSTSTDLIB',
++       nargs=1,
++       help='Rust std lib')
++@depends('RUSTSTDLIB')
++@checking('rust std lib', lambda target: target)
++def ruststdlib(value):
++    return value[0]
++
++@depends(target, rustc, rust_target, ruststdlib, when=rust_compiler)
+ @imports('os')
+ @imports('subprocess')
+ @imports(_from='mozbuild.configure.util', _import='LineIO')
+ @imports(_from='mozbuild.shellutil', _import='quote')
+ @imports(_from='tempfile', _import='mkstemp')
+ @imports(_from='textwrap', _import='dedent')
+-def available_rust_target(target, rustc, rust_target):
++def available_rust_target(target, rustc, rust_target, ruststdlib):
+     # Check to see whether our rustc has a reasonably functional stdlib
+     # for our chosen target.
+     target_arg = '--target=' + rust_target
+@@ -228,6 +236,7 @@ def available_rust_target(target, rustc,
+         cmd = [
+             rustc,
+             '--crate-type', 'staticlib',
++            '-L', ruststdlib,
+             target_arg,
+             '-o', out_path,
+             in_path,

--- a/recipes-browser/firefox/firefox_60.1.0esr.bb
+++ b/recipes-browser/firefox/firefox_60.1.0esr.bb
@@ -4,7 +4,7 @@
 DESCRIPTION ?= "Browser made by mozilla"
 DEPENDS += "curl startup-notification libevent cairo libnotify \
             virtual/libgl pulseaudio yasm-native icu unzip-native \
-            rust-cross-${TARGET_ARCH} cargo-native \
+            virtual/${TARGET_PREFIX}rust cargo-native ${RUSTLIB_DEP} \
            "
 RDEPENDS_${PN}-dev = "dbus"
 
@@ -20,6 +20,7 @@ SRC_URI = "https://ftp.mozilla.org/pub/firefox/releases/${PV}/source/${PN}-${PV}
            file://fixes/link-with-libpangoft.patch \
            file://fixes/bug1433081-fix-with-gl-provider-option.patch \
            file://fixes/0001-Enable-to-specify-RUST_TARGET-via-enviroment-variabl.patch \
+           file://fixes/rustc_cross_flags.patch \
            file://fixes/0001-Add-clang-s-include-path-on-cross-compiling.patch \
            file://fixes/0001-Add-a-preference-to-force-enable-touch-events-withou.patch \
            file://fixes/fix-get-cpu-feature-definition-conflict.patch \
@@ -69,7 +70,7 @@ inherit mozilla rust-common
 DISABLE_STATIC=""
 EXTRA_OEMAKE += "installdir=${libdir}/${PN}"
 
-ARM_INSTRUCTION_SET = "arm"
+ARM_INSTRUCTION_SET_armv5 = "arm"
 
 PACKAGECONFIG ??= "${@bb.utils.contains("DISTRO_FEATURES", "alsa", "alsa", "", d)} \
                    ${@bb.utils.contains("DISTRO_FEATURES", "wayland", "wayland", "", d)} \


### PR DESCRIPTION
When we added dependency on rust from meta-rust, firefox failed to build
for arm platforms since we needed to make firefox configury to
understand how to use the rust compiler and rust build environment that
is provided.

Firefox 60 builds fine with thumb2 ISA, therefore use arm ISA only for
arm <= v5 arches which uses thumb1

Use unwind model for rust panic mode, default is to use abort mode

Signed-off-by: Khem Raj <raj.khem@gmail.com>