### PR TITLE
chromium: Add patch information to 0001-Move-the-atspi2-target-to-a-separate-BUILD.gn-file.patch

### DIFF
--- a/recipes-browser/chromium/files/0001-Move-the-atspi2-target-to-a-separate-BUILD.gn-file.patch
+++ b/recipes-browser/chromium/files/0001-Move-the-atspi2-target-to-a-separate-BUILD.gn-file.patch
@@ -1,3 +1,10 @@
+Upstream-Status: Backport
+
+This prevents a dependency on atspi2 from being added to the host
+system.
+
+Signed-off-by: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
+---
 From 32c051ee1d76c33d389492b1cee23f0d1d752c55 Mon Sep 17 00:00:00 2001
 From: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
 Date: Fri, 30 Nov 2018 23:10:19 +0000


### PR DESCRIPTION
I forgot to add upstream-status information and a signed-off-by tag to the
patch added in commit 00ecba0 ("chromium-x11: Update to 71.0.3578.80").