### PR TITLE
chromium-ozone-wayland: Backport more patches.

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland/0001-fixup-ozone-move-gbm-wrapper-into-a-separate-source-.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0001-fixup-ozone-move-gbm-wrapper-into-a-separate-source-.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From e96597372969dc31ae86f7d3e08af93be45ed617 Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Tue, 4 Dec 2018 08:40:20 +0000
-Subject: [PATCH 01/16] fixup! [ozone] move gbm wrapper into a separate source
+Subject: [PATCH 01/35] fixup! [ozone] move gbm wrapper into a separate source
  set.
 
 Add accidentelly removed libdrm dep.

--- a/recipes-browser/chromium/chromium-ozone-wayland/0002-ozone-Rename-ClipboardDelegate-to-PlatformClipboard.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0002-ozone-Rename-ClipboardDelegate-to-PlatformClipboard.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From 903f3617968496b7300eba258dbc15dd9bd72aff Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Mon, 17 Dec 2018 22:38:55 +0000
-Subject: [PATCH 02/16] [ozone] Rename ClipboardDelegate to PlatformClipboard.
+Subject: [PATCH 02/35] [ozone] Rename ClipboardDelegate to PlatformClipboard.
 
 In order to comply with other interfaces, rename the ClipboardDelegate
 to PlatformClipboard, and add OzonePlatform::GetPlatformClipboard()

--- a/recipes-browser/chromium/chromium-ozone-wayland/0003-ozone-wayland-WaylandScreen-return-widget-on-screen-.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0003-ozone-wayland-WaylandScreen-return-widget-on-screen-.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From c42eee720220fb5a6f09220b57a172bee373dcd8 Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Mon, 14 Jan 2019 07:48:48 +0000
-Subject: [PATCH 03/16] [ozone/wayland]: WaylandScreen: return widget on screen
+Subject: [PATCH 03/35] [ozone/wayland]: WaylandScreen: return widget on screen
  point.
 
 This change implements a method, which returns a widget on

--- a/recipes-browser/chromium/chromium-ozone-wayland/0004-ozone-wayland-Switch-to-wl_output-version-2.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0004-ozone-wayland-Switch-to-wl_output-version-2.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From 4269fc2f389f7b79dfaabb9c957526b9880ce418 Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Mon, 14 Jan 2019 16:49:52 +0000
-Subject: [PATCH 04/16] [ozone/wayland]: Switch to wl_output version 2.
+Subject: [PATCH 04/35] [ozone/wayland]: Switch to wl_output version 2.
 
 wl_output version 2 has some benefits over the previous
 version we used to bind to: support of scale values

--- a/recipes-browser/chromium/chromium-ozone-wayland/0005-ozone-wayland-Use-nearest-to-origin-display-as-a-pri.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0005-ozone-wayland-Use-nearest-to-origin-display-as-a-pri.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From f66c9b45e9305b4e446f4739ca7e3d431b1fecb2 Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Fri, 25 Jan 2019 20:52:31 +0000
-Subject: [PATCH 05/16] [ozone/wayland] Use nearest to origin display as a
+Subject: [PATCH 05/35] [ozone/wayland] Use nearest to origin display as a
  primary one.
 
 This CL changes the concept of choosing a primary display.

--- a/recipes-browser/chromium/chromium-ozone-wayland/0006-ozone-wayland-Fix-event-routing-issue-when-multiple-.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0006-ozone-wayland-Fix-event-routing-issue-when-multiple-.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From d2dca30aeac3ab753a3e04a77cc26446b89d9494 Mon Sep 17 00:00:00 2001
 From: Nick Diego Yamane <nickdiego@igalia.com>
 Date: Mon, 14 Jan 2019 15:10:52 +0000
-Subject: [PATCH 06/16] [ozone/wayland] Fix event routing issue when multiple
+Subject: [PATCH 06/35] [ozone/wayland] Fix event routing issue when multiple
  windows are open
 
 Currently ozone wayland implementation uses singletons for bridging

--- a/recipes-browser/chromium/chromium-ozone-wayland/0007-Fix-ime-linux-export-include-and-fix-dtor.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0007-Fix-ime-linux-export-include-and-fix-dtor.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From 8e852c23a9a2770fc6601f85f59f805102d1681b Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Wed, 16 Jan 2019 07:14:29 +0000
-Subject: [PATCH 07/16] Fix ime linux export include and fix dtor.
+Subject: [PATCH 07/35] Fix ime linux export include and fix dtor.
 
 This fixes the following error:
 

--- a/recipes-browser/chromium/chromium-ozone-wayland/0008-ui-base-move-clipboard-to-own-folder.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0008-ui-base-move-clipboard-to-own-folder.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From 207c4d75c612fc77b836439e82fc7cfa7f06b57c Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Thu, 24 Jan 2019 15:44:25 +0000
-Subject: [PATCH 08/16] ui/base: move clipboard to own folder.
+Subject: [PATCH 08/35] ui/base: move clipboard to own folder.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/recipes-browser/chromium/chromium-ozone-wayland/0009-ozone-wayland-Implement-GetDisplayMatching.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0009-ozone-wayland-Implement-GetDisplayMatching.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From 183f0e55ee0869f0312d6ecd40d1b895846984c6 Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Mon, 28 Jan 2019 10:42:02 +0000
-Subject: [PATCH 09/16] [ozone/wayland] Implement GetDisplayMatching.
+Subject: [PATCH 09/35] [ozone/wayland] Implement GetDisplayMatching.
 
 Use display::FindDisplayWithBiggestIntersection to find
 a display with biggest intersection with the specified rect.

--- a/recipes-browser/chromium/chromium-ozone-wayland/0010-ozone-wayland-Use-surface-listener-to-get-display-fo.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0010-ozone-wayland-Use-surface-listener-to-get-display-fo.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From 0ef604f38de77ade15031a1cb69fe2070f01b990 Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Mon, 28 Jan 2019 13:02:00 +0000
-Subject: [PATCH 10/16] [ozone/wayland] Use surface listener to get display for
+Subject: [PATCH 10/35] [ozone/wayland] Use surface listener to get display for
  widget.
 
 Implement and start using wl_surface_listener, which tells the surface

--- a/recipes-browser/chromium/chromium-ozone-wayland/0011-ozone-Implement-Clipboard-for-Ozone-platforms.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0011-ozone-Implement-Clipboard-for-Ozone-platforms.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From a22869e3887cb2620869ec07b11f1c3c71835efe Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Thu, 31 Jan 2019 11:58:37 +0200
-Subject: [PATCH 11/16] [ozone] Implement Clipboard for Ozone platforms.
+Subject: [PATCH 11/35] [ozone] Implement Clipboard for Ozone platforms.
 
 This patch provides a general clipboard implementation for Ozone.
 

--- a/recipes-browser/chromium/chromium-ozone-wayland/0012-ozone-wayland-Implement-GetCursorScreenPoint.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0012-ozone-wayland-Implement-GetCursorScreenPoint.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From 91eff0cc01162d236f5585a2d0c206d999a169e9 Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Thu, 31 Jan 2019 10:47:58 +0200
-Subject: [PATCH 12/16] [ozone/wayland] Implement GetCursorScreenPoint.
+Subject: [PATCH 12/35] [ozone/wayland] Implement GetCursorScreenPoint.
 
 Wayland does not provide either location of surfaces in global space
 coordinate system or location of a pointer. Instead, only locations of

--- a/recipes-browser/chromium/chromium-ozone-wayland/0013-ozone-wayland-Fix-default-window-bounds.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0013-ozone-wayland-Fix-default-window-bounds.patch
@@ -7,7 +7,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From c6737c4bcaf04545f1cc98d3b40c9c6436ebf5ea Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Thu, 31 Jan 2019 14:09:06 +0200
-Subject: [PATCH 13/16] [ozone/wayland] Fix default window bounds.
+Subject: [PATCH 13/35] [ozone/wayland] Fix default window bounds.
 
 If a previous browsing session is empty, WindowSizer calculates
 default window bounds by calling GetDisplayMatching with empty bounds.

--- a/recipes-browser/chromium/chromium-ozone-wayland/0014-Reland-ozone-common-Make-gbm_wrapper-to-be-compiled-.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0014-Reland-ozone-common-Make-gbm_wrapper-to-be-compiled-.patch
@@ -1,13 +1,13 @@
-Upstream-Status: Submitted [https://crrev.com/c/1273059]
+Upstream-Status: Backport 
 
-* Submitted to upstream, waiting approval
+* Backported from https://crrev.com/c/1273059
 
 Signed-off-by: Maksim Sisov <msisov@igalia.com>
 ---
-From 8343545c9c57eb3ace93799eab3b40d29d3c617a Mon Sep 17 00:00:00 2001
+From 9260c7b152118ac71ec0291125baa6f6569f3ded Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
-Date: Tue, 4 Dec 2018 10:19:10 +0200
-Subject: [PATCH 14/16] Reland [ozone/common] Make gbm_wrapper to be compiled
+Date: Fri, 22 Feb 2019 17:27:00 +0200
+Subject: [PATCH 14/35] Reland [ozone/common] Make gbm_wrapper to be compiled
  with system libgbm
 
 Now, it is based on the https://crrev.com/c/1273455 patch
@@ -39,28 +39,31 @@ The previous CL's commit message:
 Bug: 869206, 578890, 820047
 Change-Id: I7b21ea2c3fc3300823459e31b72c9304b4967bce
 ---
- ui/ozone/common/linux/gbm_wrapper.cc | 92 ++++++++++++++++++++++++----
- 1 file changed, 80 insertions(+), 12 deletions(-)
+ ui/ozone/common/linux/gbm_wrapper.cc | 114 +++++++++++++++++++++------
+ 1 file changed, 89 insertions(+), 25 deletions(-)
 
 diff --git a/ui/ozone/common/linux/gbm_wrapper.cc b/ui/ozone/common/linux/gbm_wrapper.cc
-index 15efd7bfeb32..fdf5aa62aa1a 100644
+index 15efd7bfeb32..00f381c902a4 100644
 --- a/ui/ozone/common/linux/gbm_wrapper.cc
 +++ b/ui/ozone/common/linux/gbm_wrapper.cc
-@@ -4,7 +4,10 @@
- 
+@@ -5,6 +5,10 @@
  #include "ui/ozone/common/linux/gbm_wrapper.h"
  
-+#include <drm_fourcc.h>
-+#include <fcntl.h>
  #include <gbm.h>
++#if !defined(MINIGBM)
++#include <fcntl.h>
 +#include <xf86drm.h>
++#endif
  
  #include "base/posix/eintr_wrapper.h"
  #include "third_party/skia/include/core/SkSurface.h"
-@@ -21,6 +24,48 @@ namespace {
- #define GBM_BO_IMPORT_FD_PLANAR_5504 0x5504
- #define GBM_BO_IMPORT_FD_PLANAR_5505 0x5505
+@@ -17,9 +21,57 @@ namespace gbm_wrapper {
  
+ namespace {
+ 
+-// Temporary defines while we migrate to GBM_BO_IMPORT_FD_MODIFIER.
+-#define GBM_BO_IMPORT_FD_PLANAR_5504 0x5504
+-#define GBM_BO_IMPORT_FD_PLANAR_5505 0x5505
 +int GetPlaneFdForBo(gbm_bo* bo, size_t plane) {
 +#if defined(MINIGBM)
 +  return gbm_bo_get_plane_fd(bo, plane);
@@ -90,23 +93,32 @@ index 15efd7bfeb32..fdf5aa62aa1a 100644
 +#endif
 +}
 +
-+size_t GetSizeOfPlane(gbm_bo* bo, size_t plane) {
++size_t GetSizeOfPlane(gbm_bo* bo,
++                      uint32_t format,
++                      const gfx::Size& size,
++                      size_t plane) {
 +#if defined(MINIGBM)
 +  return gbm_bo_get_plane_size(bo, plane);
 +#else
-+  // System linux gbm (or Mesa gbm) does not provide plane size. Thus, calculate
-+  // it by ourselves and avoid having two different branches for minigbm and
-+  // Mesa gbm here.
-+  //
-+  // TODO(msisov): Handle subsampled formats
-+  return gbm_bo_get_height(bo) * gbm_bo_get_stride_for_plane(bo, plane);
++  DCHECK(!size.IsEmpty());
++
++  // Get row size of the plane.
++  const gfx::BufferFormat buffer_format =
++      ui::GetBufferFormatFromFourCCFormat(format);
++  const size_t stride_for_plane =
++      static_cast<size_t>(gbm_bo_get_stride_for_plane(bo, plane));
++
++  // Apply subsampling factor to get size in bytes.
++  base::CheckedNumeric<size_t> checked_plane_size = stride_for_plane;
++  checked_plane_size *= size.height() / gfx::SubsamplingFactorForBufferFormat(
++                                            buffer_format, plane);
++  return checked_plane_size.ValueOrDie();
 +#endif
 +}
-+
+ 
  }  // namespace
  
- class Buffer final : public ui::GbmBuffer {
-@@ -84,7 +129,7 @@ class Buffer final : public ui::GbmBuffer {
+@@ -84,7 +136,7 @@ class Buffer final : public ui::GbmBuffer {
    }
    uint32_t GetPlaneHandle(size_t plane) const override {
      DCHECK_LT(plane, planes_.size());
@@ -115,7 +127,7 @@ index 15efd7bfeb32..fdf5aa62aa1a 100644
    }
    uint32_t GetHandle() const override { return gbm_bo_get_handle(bo_).u32; }
    gfx::NativePixmapHandle ExportHandle() const override {
-@@ -113,8 +158,14 @@ class Buffer final : public ui::GbmBuffer {
+@@ -113,8 +165,14 @@ class Buffer final : public ui::GbmBuffer {
      DCHECK(!mmap_data_);
      uint32_t stride;
      void* addr;
@@ -132,7 +144,7 @@ index 15efd7bfeb32..fdf5aa62aa1a 100644
  
      if (!addr)
        return nullptr;
-@@ -155,11 +206,18 @@ std::unique_ptr<Buffer> CreateBufferForBO(struct gbm_bo* bo,
+@@ -155,11 +213,18 @@ std::unique_ptr<Buffer> CreateBufferForBO(struct gbm_bo* bo,
    std::vector<base::ScopedFD> fds;
    std::vector<gfx::NativePixmapPlane> planes;
  
@@ -154,7 +166,7 @@ index 15efd7bfeb32..fdf5aa62aa1a 100644
  
      // TODO(dcastagna): support multiple fds.
      // crbug.com/642410
-@@ -172,9 +230,9 @@ std::unique_ptr<Buffer> CreateBufferForBO(struct gbm_bo* bo,
+@@ -172,9 +237,9 @@ std::unique_ptr<Buffer> CreateBufferForBO(struct gbm_bo* bo,
        fds.emplace_back(std::move(fd));
      }
  
@@ -162,12 +174,12 @@ index 15efd7bfeb32..fdf5aa62aa1a 100644
 -                        gbm_bo_get_plane_offset(bo, i),
 -                        gbm_bo_get_plane_size(bo, i), modifier);
 +    planes.emplace_back(gbm_bo_get_stride_for_plane(bo, i),
-+                        gbm_bo_get_offset(bo, i), GetSizeOfPlane(bo, i),
-+                        modifier);
++                        gbm_bo_get_offset(bo, i),
++                        GetSizeOfPlane(bo, format, size, i), modifier);
    }
    return std::make_unique<Buffer>(bo, format, flags, modifier, std::move(fds),
                                    size, std::move(planes));
-@@ -221,7 +279,10 @@ class Device final : public ui::GbmDevice {
+@@ -221,7 +286,10 @@ class Device final : public ui::GbmDevice {
      DCHECK_EQ(planes[0].offset, 0);
  
      // Try to use scanout if supported.
@@ -179,7 +191,7 @@ index 15efd7bfeb32..fdf5aa62aa1a 100644
      if (!gbm_device_is_format_supported(device_, format, gbm_flags))
        gbm_flags &= ~GBM_BO_USE_SCANOUT;
  
-@@ -231,17 +292,24 @@ class Device final : public ui::GbmDevice {
+@@ -231,32 +299,28 @@ class Device final : public ui::GbmDevice {
        return nullptr;
      }
  
@@ -188,7 +200,8 @@ index 15efd7bfeb32..fdf5aa62aa1a 100644
      fd_data.width = size.width();
      fd_data.height = size.height();
      fd_data.format = format;
-+    fd_data.modifier = DRM_FORMAT_MOD_NONE;
++    fd_data.num_fds = planes.size();
++    fd_data.modifier = planes[0].modifier;
  
      DCHECK_LE(planes.size(), 3u);
      for (size_t i = 0; i < planes.size(); ++i) {
@@ -196,16 +209,29 @@ index 15efd7bfeb32..fdf5aa62aa1a 100644
        fd_data.strides[i] = planes[i].stride;
        fd_data.offsets[i] = planes[i].offset;
 -      fd_data.format_modifiers[i] = planes[i].modifier;
-+      if (fd_data.modifier == DRM_FORMAT_MOD_NONE)
-+        fd_data.modifier = planes[i].modifier;
-+
-+      if (fd_data.modifier != planes[i].modifier) {
-+        LOG(ERROR) << "Format modifier must be the same for all the planes";
-+        return nullptr;
-+      }
++      // Make sure the modifier is the same for all the planes.
++      DCHECK_EQ(fd_data.modifier, planes[i].modifier);
      }
  
      // The fd passed to gbm_bo_import is not ref-counted and need to be
+     // kept open for the lifetime of the buffer.
+-    //
+-    // See the comment regarding the GBM_BO_IMPORT_FD_PLANAR_550X above.
+-    bo = gbm_bo_import(device_, GBM_BO_IMPORT_FD_PLANAR_5505, &fd_data,
+-                       gbm_flags);
++    bo = gbm_bo_import(device_, GBM_BO_IMPORT_FD_MODIFIER, &fd_data, gbm_flags);
+     if (!bo) {
+-      bo = gbm_bo_import(device_, GBM_BO_IMPORT_FD_PLANAR_5504, &fd_data,
+-                         gbm_flags);
+-      if (!bo) {
+-        LOG(ERROR) << "nullptr returned from gbm_bo_import";
+-        return nullptr;
+-      }
++      LOG(ERROR) << "nullptr returned from gbm_bo_import";
++      return nullptr;
+     }
+ 
+     return std::make_unique<Buffer>(bo, format, gbm_flags, planes[0].modifier,
 -- 
 2.17.1
 

--- a/recipes-browser/chromium/chromium-ozone-wayland/0015-Add-support-for-V4L2VDA-on-Linux.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0015-Add-support-for-V4L2VDA-on-Linux.patch
@@ -13,7 +13,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From 7e702234cb0e0c947e04bf568acd0820d3a410e1 Mon Sep 17 00:00:00 2001
 From: Maksim Sisov <msisov@igalia.com>
 Date: Mon, 11 Feb 2019 11:34:34 +0200
-Subject: [PATCH 15/16] Add support for V4L2VDA on Linux
+Subject: [PATCH 15/35] Add support for V4L2VDA on Linux
 
 This patch enables hardware assisted video decoding via the
 Chromium V4L2VDA. Including changes when Linux is used. In

--- a/recipes-browser/chromium/chromium-ozone-wayland/0016-Add-mmap-via-libv4l-to-generic_v4l2_device.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0016-Add-mmap-via-libv4l-to-generic_v4l2_device.patch
@@ -13,7 +13,7 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
 From f06d438dec7f03038308ecfa7ac575e78d5a81ec Mon Sep 17 00:00:00 2001
 From: Damian Hobson-Garcia <dhobsong@igel.co.jp>
 Date: Wed, 21 Mar 2018 13:18:17 +0200
-Subject: [PATCH 16/16] Add mmap via libv4l to generic_v4l2_device
+Subject: [PATCH 16/35] Add mmap via libv4l to generic_v4l2_device
 
 Issue #437
 

--- a/recipes-browser/chromium/chromium-ozone-wayland/0017-Move-CharacterComposer-into-ui-base-ime.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0017-Move-CharacterComposer-into-ui-base-ime.patch
@@ -1,0 +1,294 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1446477
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From cbb45ee2270b278a21ad2f778e276d1a17eb6803 Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nickdiego@igalia.com>
+Date: Thu, 31 Jan 2019 17:08:31 +0000
+Subject: [PATCH 17/35] Move CharacterComposer into //ui/base/ime
+
+This patch makes CharacterComposer class reusable by other
+platforms, by moving character_composer{.h,.cc} files and its
+tests and auxiliary scripts out from ui/base/ime/chromeos
+into ui/base/ime so that it can be reused by other platforms.
+
+In particular, we intend to use it to properly handle dead keys
+in ozone/wayland configuration. The ozone/wayland integration
+will be done in a follow-up CL. In the future, ozone/x11 could
+also benefit from this.
+
+BUG=921947
+
+Change-Id: Iff6cd82da9696279c0cd21afad7aba79a58baa8d
+Reviewed-on: https://chromium-review.googlesource.com/c/1446477
+Commit-Queue: Nick Yamane <nickdiego@igalia.com>
+Reviewed-by: Shu Chen <shuchen@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#627991}
+---
+ ui/base/BUILD.gn                                 |  6 +++++-
+ ui/base/ime/BUILD.gn                             | 11 ++++++++---
+ ui/base/ime/{chromeos => }/PRESUBMIT.py          |  2 +-
+ ui/base/ime/{chromeos => }/character_composer.cc | 11 +++++------
+ ui/base/ime/{chromeos => }/character_composer.h  |  9 +++++----
+ .../ime/{chromeos => }/character_composer_data.h |  0
+ .../character_composer_sequences.txt             |  0
+ .../character_composer_unittest.cc               | 16 +++++++---------
+ .../generate_character_composer_data.py          |  0
+ ui/base/ime/input_method_chromeos.h              |  2 +-
+ 10 files changed, 32 insertions(+), 25 deletions(-)
+ rename ui/base/ime/{chromeos => }/PRESUBMIT.py (98%)
+ rename ui/base/ime/{chromeos => }/character_composer.cc (98%)
+ rename ui/base/ime/{chromeos => }/character_composer.h (94%)
+ rename ui/base/ime/{chromeos => }/character_composer_data.h (100%)
+ rename ui/base/ime/{chromeos => }/character_composer_sequences.txt (100%)
+ rename ui/base/ime/{chromeos => }/character_composer_unittest.cc (98%)
+ rename ui/base/ime/{chromeos => }/generate_character_composer_data.py (100%)
+
+diff --git a/ui/base/BUILD.gn b/ui/base/BUILD.gn
+index f1c9532d36a7..26b3f1b528f5 100644
+--- a/ui/base/BUILD.gn
++++ b/ui/base/BUILD.gn
+@@ -828,7 +828,6 @@ test("ui_base_unittests") {
+   if (build_ime) {
+     sources += [
+       "ime/candidate_window_unittest.cc",
+-      "ime/chromeos/character_composer_unittest.cc",
+       "ime/chromeos/extension_ime_util_unittest.cc",
+       "ime/chromeos/ime_keyboard_unittest.cc",
+       "ime/chromeos/input_method_util_unittest.cc",
+@@ -850,6 +849,11 @@ test("ui_base_unittests") {
+     if (use_x11) {
+       sources += [ "ime/composition_text_util_pango_unittest.cc" ]
+     }
++    if (is_chromeos || use_ozone) {
++      sources += [
++        "ime/character_composer_unittest.cc",
++      ]
++    }
+   }
+ 
+   # TODO(jschuh): crbug.com/167187 fix size_t to int truncations.
+diff --git a/ui/base/ime/BUILD.gn b/ui/base/ime/BUILD.gn
+index df6079261fdd..204fd89cfbd0 100644
+--- a/ui/base/ime/BUILD.gn
++++ b/ui/base/ime/BUILD.gn
+@@ -98,8 +98,6 @@ jumbo_component("ime") {
+ 
+   if (is_chromeos) {
+     sources += [
+-      "chromeos/character_composer.cc",
+-      "chromeos/character_composer.h",
+       "chromeos/component_extension_ime_manager.cc",
+       "chromeos/component_extension_ime_manager.h",
+       "chromeos/extension_ime_util.cc",
+@@ -176,6 +174,14 @@ jumbo_component("ime") {
+     ]
+   }
+ 
++  if (is_chromeos || use_ozone) {
++    sources += [
++      "character_composer.cc",
++      "character_composer.h",
++    ]
++    deps += [ "//ui/events:dom_keycode_converter" ]
++  }
++
+   if (!toolkit_views && !use_aura) {
+     sources -= [
+       "input_method_factory.cc",
+@@ -190,7 +196,6 @@ jumbo_component("ime") {
+       "//chromeos",
+       "//services/ws/public/cpp/input_devices",
+       "//ui/chromeos/strings",
+-      "//ui/events:dom_keycode_converter",
+     ]
+     sources += [
+       "chromeos/ime_keyboard_mus.cc",
+diff --git a/ui/base/ime/chromeos/PRESUBMIT.py b/ui/base/ime/PRESUBMIT.py
+similarity index 98%
+rename from ui/base/ime/chromeos/PRESUBMIT.py
+rename to ui/base/ime/PRESUBMIT.py
+index ed44dfbee641..e9f33bbe89b7 100644
+--- a/ui/base/ime/chromeos/PRESUBMIT.py
++++ b/ui/base/ime/PRESUBMIT.py
+@@ -2,7 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-"""Presubmit script for ui/base/ime/chromeos
++"""Presubmit script for ui/base/ime
+ 
+ See http://dev.chromium.org/developers/how-tos/depottools/presubmit-scripts
+ for more details about the presubmit API built into depot_tools.
+diff --git a/ui/base/ime/chromeos/character_composer.cc b/ui/base/ime/character_composer.cc
+similarity index 98%
+rename from ui/base/ime/chromeos/character_composer.cc
+rename to ui/base/ime/character_composer.cc
+index e0026255464c..d1ddcaa826a4 100644
+--- a/ui/base/ime/chromeos/character_composer.cc
++++ b/ui/base/ime/character_composer.cc
+@@ -2,10 +2,11 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/base/ime/chromeos/character_composer.h"
++#include "ui/base/ime/character_composer.h"
+ 
+ #include <algorithm>
+ #include <iterator>
++#include <string>
+ 
+ #include "base/strings/string_util.h"
+ #include "base/strings/utf_string_conversion_utils.h"
+@@ -18,7 +19,7 @@
+ 
+ namespace {
+ 
+-#include "ui/base/ime/chromeos/character_composer_data.h"
++#include "ui/base/ime/character_composer_data.h"
+ 
+ bool CheckCharacterComposeTable(
+     const ui::CharacterComposer::ComposeBuffer& compose_sequence,
+@@ -58,11 +59,9 @@ int KeycodeToHexDigit(unsigned int keycode) {
+ 
+ namespace ui {
+ 
+-CharacterComposer::CharacterComposer() : composition_mode_(KEY_SEQUENCE_MODE) {
+-}
++CharacterComposer::CharacterComposer() : composition_mode_(KEY_SEQUENCE_MODE) {}
+ 
+-CharacterComposer::~CharacterComposer() {
+-}
++CharacterComposer::~CharacterComposer() {}
+ 
+ void CharacterComposer::Reset() {
+   compose_buffer_.clear();
+diff --git a/ui/base/ime/chromeos/character_composer.h b/ui/base/ime/character_composer.h
+similarity index 94%
+rename from ui/base/ime/chromeos/character_composer.h
+rename to ui/base/ime/character_composer.h
+index d1befb6c275e..b3845c3d669c 100644
+--- a/ui/base/ime/chromeos/character_composer.h
++++ b/ui/base/ime/character_composer.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_BASE_IME_CHROMEOS_CHARACTER_COMPOSER_H_
+-#define UI_BASE_IME_CHROMEOS_CHARACTER_COMPOSER_H_
++#ifndef UI_BASE_IME_CHARACTER_COMPOSER_H_
++#define UI_BASE_IME_CHARACTER_COMPOSER_H_
+ 
+ #include <stddef.h>
+ #include <stdint.h>
+@@ -102,6 +102,7 @@ class ComposeChecker {
+   virtual CheckSequenceResult CheckSequence(
+       const ui::CharacterComposer::ComposeBuffer& sequence,
+       uint32_t* composed_character) const = 0;
++
+  private:
+   DISALLOW_COPY_AND_ASSIGN(ComposeChecker);
+ };
+@@ -115,7 +116,7 @@ class TreeComposeChecker : public ComposeChecker {
+     const uint16_t* tree;
+   };
+ 
+-  TreeComposeChecker(const CompositionData& data) : data_(data) {}
++  explicit TreeComposeChecker(const CompositionData& data) : data_(data) {}
+   CheckSequenceResult CheckSequence(
+       const ui::CharacterComposer::ComposeBuffer& sequence,
+       uint32_t* composed_character) const override;
+@@ -127,4 +128,4 @@ class TreeComposeChecker : public ComposeChecker {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_BASE_IME_CHROMEOS_CHARACTER_COMPOSER_H_
++#endif  // UI_BASE_IME_CHARACTER_COMPOSER_H_
+diff --git a/ui/base/ime/chromeos/character_composer_data.h b/ui/base/ime/character_composer_data.h
+similarity index 100%
+rename from ui/base/ime/chromeos/character_composer_data.h
+rename to ui/base/ime/character_composer_data.h
+diff --git a/ui/base/ime/chromeos/character_composer_sequences.txt b/ui/base/ime/character_composer_sequences.txt
+similarity index 100%
+rename from ui/base/ime/chromeos/character_composer_sequences.txt
+rename to ui/base/ime/character_composer_sequences.txt
+diff --git a/ui/base/ime/chromeos/character_composer_unittest.cc b/ui/base/ime/character_composer_unittest.cc
+similarity index 98%
+rename from ui/base/ime/chromeos/character_composer_unittest.cc
+rename to ui/base/ime/character_composer_unittest.cc
+index b15abe3959b4..554dc5f54566 100644
+--- a/ui/base/ime/chromeos/character_composer_unittest.cc
++++ b/ui/base/ime/character_composer_unittest.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/base/ime/chromeos/character_composer.h"
++#include "ui/base/ime/character_composer.h"
+ 
+ #include <stdint.h>
+ 
+@@ -64,9 +64,9 @@ class CharacterComposerTest : public testing::Test {
+                             DomCode code,
+                             int flags,
+                             base::char16 character) const {
+-    KeyEvent* event = new KeyEvent(ET_KEY_PRESSED, vkey, code, flags,
+-                                   DomKey::FromCharacter(character),
+-                                   EventTimeForNow());
++    KeyEvent* event =
++        new KeyEvent(ET_KEY_PRESSED, vkey, code, flags,
++                     DomKey::FromCharacter(character), EventTimeForNow());
+     return event;
+   }
+ 
+@@ -234,7 +234,7 @@ TEST_F(CharacterComposerTest, MainTableIsCorrectlyOrdered) {
+ // This file is included here intentionally, instead of the top of the file,
+ // because including this file at the top of the file will define a
+ // global constant and contaminate the global namespace.
+-#include "ui/base/ime/chromeos/character_composer_data.h"
++#include "ui/base/ime/character_composer_data.h"
+   const int kTypes = 2;
+ 
+   // Record the subtree locations and check subtable sizes.
+@@ -332,8 +332,7 @@ TEST_F(CharacterComposerTest, HexadecimalCompositionPreedit) {
+   ExpectUnicodeKeyFiltered(VKEY_BACK, DomCode::BACKSPACE, EF_NONE, '\b');
+   EXPECT_EQ(ASCIIToUTF16("u304"), character_composer_.preedit_string());
+   ExpectUnicodeKeyFiltered(VKEY_2, DomCode::DIGIT2, EF_NONE, '2');
+-  ExpectUnicodeKeyComposed(VKEY_RETURN, DomCode::ENTER, EF_NONE,
+-                           '\r',
++  ExpectUnicodeKeyComposed(VKEY_RETURN, DomCode::ENTER, EF_NONE, '\r',
+                            base::string16(1, 0x3042));
+   EXPECT_EQ(ASCIIToUTF16(""), character_composer_.preedit_string());
+ 
+@@ -463,8 +462,7 @@ TEST_F(CharacterComposerTest,
+   EXPECT_EQ(ASCIIToUTF16("u304"), character_composer_.preedit_string());
+   ExpectUnicodeKeyFiltered(ui::VKEY_2, DomCode::DIGIT2, kControlShift, 0);
+   EXPECT_EQ(ASCIIToUTF16("u3042"), character_composer_.preedit_string());
+-  ExpectUnicodeKeyComposed(VKEY_RETURN, DomCode::ENTER, kControlShift,
+-                           '\r',
++  ExpectUnicodeKeyComposed(VKEY_RETURN, DomCode::ENTER, kControlShift, '\r',
+                            base::string16(1, 0x3042));
+   EXPECT_EQ(ASCIIToUTF16(""), character_composer_.preedit_string());
+ 
+diff --git a/ui/base/ime/chromeos/generate_character_composer_data.py b/ui/base/ime/generate_character_composer_data.py
+similarity index 100%
+rename from ui/base/ime/chromeos/generate_character_composer_data.py
+rename to ui/base/ime/generate_character_composer_data.py
+diff --git a/ui/base/ime/input_method_chromeos.h b/ui/base/ime/input_method_chromeos.h
+index 893ac1139d23..8304e14c89c3 100644
+--- a/ui/base/ime/input_method_chromeos.h
++++ b/ui/base/ime/input_method_chromeos.h
+@@ -15,7 +15,7 @@
+ #include "base/compiler_specific.h"
+ #include "base/macros.h"
+ #include "base/memory/weak_ptr.h"
+-#include "ui/base/ime/chromeos/character_composer.h"
++#include "ui/base/ime/character_composer.h"
+ #include "ui/base/ime/composition_text.h"
+ #include "ui/base/ime/ime_input_context_handler_interface.h"
+ #include "ui/base/ime/input_method_base.h"
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0018-ozone-wayland-Support-dead-keys.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0018-ozone-wayland-Support-dead-keys.patch
@@ -1,0 +1,94 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1448136
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 2c68b6a506ae34308edfead740f23369a187bccd Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nickdiego@igalia.com>
+Date: Tue, 5 Feb 2019 15:53:28 +0000
+Subject: [PATCH 18/35] ozone/wayland: Support dead keys
+
+This patch adds character composition capabilities to ozone
+wayland text input backend. To accomplish this it modifies
+WaylandInputMethodContext, reusing ui::CharacterComposer
+(previously chromeos-only) to handle key events forwared
+by InputMethodAuraLinux.
+
+BUG=921947
+
+Change-Id: I9f06ed253ad0ba67b437ef683a6ed235cb57a1f2
+Reviewed-on: https://chromium-review.googlesource.com/c/1448136
+Reviewed-by: Shu Chen <shuchen@chromium.org>
+Reviewed-by: Robert Kroeger <rjkroege@chromium.org>
+Commit-Queue: Nick Yamane <nickdiego@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#629160}
+---
+ ui/ozone/platform/wayland/DEPS                        |  1 +
+ .../platform/wayland/wayland_input_method_context.cc  | 11 ++++++++++-
+ .../platform/wayland/wayland_input_method_context.h   |  5 +++++
+ 3 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/ui/ozone/platform/wayland/DEPS b/ui/ozone/platform/wayland/DEPS
+index 56a383a0459a..df586f144773 100644
+--- a/ui/ozone/platform/wayland/DEPS
++++ b/ui/ozone/platform/wayland/DEPS
+@@ -2,6 +2,7 @@ include_rules = [
+   "+ui/base/hit_test.h", # UI hit test doesn't bring in all of ui/base.
+   "+ui/base/ui_features.h",  # UI features doesn't bring in all of ui/base.
+   "+ui/base/ui_base_features.h",
++  "+ui/base/ime/character_composer.h",
+   "+ui/base/ime/composition_text.h",
+   "+ui/base/ime/linux/linux_input_method_context.h",
+   "+ui/base/ime/linux/linux_input_method_context_factory.h",
+diff --git a/ui/ozone/platform/wayland/wayland_input_method_context.cc b/ui/ozone/platform/wayland/wayland_input_method_context.cc
+index 959a8e331dba..f5e57bb3aab3 100644
+--- a/ui/ozone/platform/wayland/wayland_input_method_context.cc
++++ b/ui/ozone/platform/wayland/wayland_input_method_context.cc
+@@ -70,10 +70,19 @@ void WaylandInputMethodContext::Init(bool initialize_for_testing) {
+ 
+ bool WaylandInputMethodContext::DispatchKeyEvent(
+     const ui::KeyEvent& key_event) {
+-  return false;
++  if (key_event.type() != ET_KEY_PRESSED ||
++      !character_composer_.FilterKeyPress(key_event))
++    return false;
++
++  // TODO(nickdiego): Handle preedit string
++  auto composed = character_composer_.composed_character();
++  if (!composed.empty())
++    delegate_->OnCommit(composed);
++  return true;
+ }
+ 
+ void WaylandInputMethodContext::Reset() {
++  character_composer_.Reset();
+   if (text_input_)
+     text_input_->Reset();
+ }
+diff --git a/ui/ozone/platform/wayland/wayland_input_method_context.h b/ui/ozone/platform/wayland/wayland_input_method_context.h
+index 1023ecca5850..7fd0e9455299 100644
+--- a/ui/ozone/platform/wayland/wayland_input_method_context.h
++++ b/ui/ozone/platform/wayland/wayland_input_method_context.h
+@@ -6,6 +6,7 @@
+ #define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_INPUT_METHOD_CONTEXT_H_
+ 
+ #include "base/macros.h"
++#include "ui/base/ime/character_composer.h"
+ #include "ui/base/ime/linux/linux_input_method_context.h"
+ #include "ui/events/ozone/evdev/event_dispatch_callback.h"
+ #include "ui/ozone/platform/wayland/zwp_text_input_wrapper.h"
+@@ -51,6 +52,10 @@ class WaylandInputMethodContext : public LinuxInputMethodContext,
+ 
+   std::unique_ptr<ZWPTextInputWrapper> text_input_;
+ 
++  // An object to compose a character from a sequence of key presses
++  // including dead key etc.
++  CharacterComposer character_composer_;
++
+   DISALLOW_COPY_AND_ASSIGN(WaylandInputMethodContext);
+ };
+ 
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0019-ozone-wayland-Pass-0-modifier-on-DRM_FORMAT_MOD_INVA.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0019-ozone-wayland-Pass-0-modifier-on-DRM_FORMAT_MOD_INVA.patch
@@ -1,0 +1,79 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1454496
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 01557da31bc1286400e833fb4647f61daecc9754 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Wed, 6 Feb 2019 08:28:29 +0000
+Subject: [PATCH 19/35] [ozone/wayland] Pass 0 modifier on
+ DRM_FORMAT_MOD_INVALID
+
+Depending on the gpu driver, gbm_bo_get_format_modifier
+may return DRM_FORMAT_MOD_INVALID, which resulted in
+empty |modifiers| container passed to WaylandBufferManager.
+
+The empty container resulted in the gpu process being terminated
+as long as data validation expects all the three containers
+with offsets, strides and modifiers be of the same size.
+
+Thus, in order to fix the issue, store DRM_FORMAT_MOD_INVALID and
+check for it on the WaylandBufferManager side. If that value
+exists, pass 0 modifier_lo and modifier_hi to zwp dmabuf params
+and DCHECK that the size of planes is 1. Otherwise, multiplanar
+formats require modifiers.
+
+Bug: 928261
+Change-Id: I1e57dc604a616ae77dc88e08e3f65693d6e58818
+Reviewed-on: https://chromium-review.googlesource.com/c/1454496
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Reviewed-by: Michael Spang <spang@chromium.org>
+Reviewed-by: Robert Kroeger <rjkroege@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#629502}
+---
+ ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc |  3 +--
+ ui/ozone/platform/wayland/wayland_buffer_manager.cc | 12 ++++++++++--
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+index 62d42fcc06f2..6382310c6124 100644
+--- a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
++++ b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+@@ -162,8 +162,7 @@ void GbmPixmapWayland::CreateZwpLinuxDmabuf() {
+   for (size_t i = 0; i < plane_count; ++i) {
+     strides.push_back(GetDmaBufPitch(i));
+     offsets.push_back(GetDmaBufOffset(i));
+-    if (modifier != DRM_FORMAT_MOD_INVALID)
+-      modifiers.push_back(modifier);
++    modifiers.push_back(modifier);
+   }
+ 
+   base::ScopedFD fd(HANDLE_EINTR(dup(GetDmaBufFd(0))));
+diff --git a/ui/ozone/platform/wayland/wayland_buffer_manager.cc b/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+index 393336d13714..77f974cd88f5 100644
+--- a/ui/ozone/platform/wayland/wayland_buffer_manager.cc
++++ b/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+@@ -105,9 +105,17 @@ bool WaylandBufferManager::CreateBuffer(base::File file,
+ 
+   uint32_t fd = file.TakePlatformFile();
+   for (size_t i = 0; i < planes_count; i++) {
++    uint32_t modifier_lo = 0;
++    uint32_t modifier_hi = 0;
++    if (modifiers[i] != DRM_FORMAT_MOD_INVALID) {
++      modifier_lo = modifiers[i] & UINT32_MAX;
++      modifier_hi = modifiers[i] >> 32;
++    } else {
++      DCHECK_EQ(planes_count, 1u) << "Invalid modifier may be passed only in "
++                                     "case of single plane format being used";
++    }
+     zwp_linux_buffer_params_v1_add(params, fd, i /* plane id */, offsets[i],
+-                                   strides[i], modifiers[i] >> 32,
+-                                   modifiers[i] & UINT32_MAX);
++                                   strides[i], modifier_hi, modifier_lo);
+   }
+   zwp_linux_buffer_params_v1_add_listener(params, &params_listener, this);
+   zwp_linux_buffer_params_v1_create(params, width, height, format, 0);
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0020-ozone-wayland-The-fuzzer-for-wayland-buffers-is-intr.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0020-ozone-wayland-The-fuzzer-for-wayland-buffers-is-intr.patch
@@ -1,0 +1,293 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1454530
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 83a349880db95fd065025cff084d2abca1d07ccd Mon Sep 17 00:00:00 2001
+From: Alexander Dunaev <adunaev@igalia.com>
+Date: Wed, 6 Feb 2019 15:55:33 +0000
+Subject: [PATCH 20/35] [ozone/wayland] The fuzzer for wayland buffers is
+ introduced.
+
+Two issues have been discovered and resolved:
+- The client is now destroyed properly when the test server thread is stopped, so the socket descriptors are freed.
+- The buffer manager now handles the passed file properly so the file descriptor is freed.
+
+R=msisov@igalia.com
+
+Bug: 873132
+Change-Id: I8aabc38da915b61987a995a94fe7c343ce982f06
+Reviewed-on: https://chromium-review.googlesource.com/c/1454530
+Commit-Queue: Alexander Dunaev <adunaev@igalia.com>
+Reviewed-by: Maksim Sisov <msisov@igalia.com>
+Reviewed-by: Robert Kroeger <rjkroege@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#629586}
+---
+ ui/ozone/platform/wayland/BUILD.gn            |  16 ++
+ .../platform/wayland/wayland_buffer_fuzzer.cc | 141 ++++++++++++++++++
+ .../wayland/wayland_buffer_manager.cc         |  19 +--
+ .../platform/wayland/wayland_connection.cc    |   6 +-
+ 4 files changed, 171 insertions(+), 11 deletions(-)
+ create mode 100644 ui/ozone/platform/wayland/wayland_buffer_fuzzer.cc
+
+diff --git a/ui/ozone/platform/wayland/BUILD.gn b/ui/ozone/platform/wayland/BUILD.gn
+index 332af4c3146e..f06ba6ea7a18 100644
+--- a/ui/ozone/platform/wayland/BUILD.gn
++++ b/ui/ozone/platform/wayland/BUILD.gn
+@@ -5,6 +5,7 @@
+ visibility = [ "//ui/ozone/*" ]
+ 
+ import("//build/config/linux/pkg_config.gni")
++import("//testing/libfuzzer/fuzzer_test.gni")
+ import("//ui/ozone/platform/wayland/wayland.gni")
+ 
+ pkg_config("wayland-egl") {
+@@ -192,3 +193,18 @@ source_set("wayland_unittests") {
+     defines += [ "WAYLAND_GBM" ]
+   }
+ }
++
++fuzzer_test("wayland_buffer_fuzzer") {
++  defines = [ "WL_HIDE_DEPRECATED" ]
++  sources = [
++    "wayland_buffer_fuzzer.cc",
++  ]
++  deps = [
++    ":wayland",
++    "//base/test:test_support",
++    "//build/config/linux/libdrm",
++    "//testing/gmock:gmock",
++    "//ui/gfx:test_support",
++    "//ui/platform_window:platform_window",
++  ]
++}
+diff --git a/ui/ozone/platform/wayland/wayland_buffer_fuzzer.cc b/ui/ozone/platform/wayland/wayland_buffer_fuzzer.cc
+new file mode 100644
+index 000000000000..84395c43da58
+--- /dev/null
++++ b/ui/ozone/platform/wayland/wayland_buffer_fuzzer.cc
+@@ -0,0 +1,141 @@
++// Copyright 2019 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// This fuzzer tests browser-side implementation of
++// ozone::mojom::WaylandConnection.
++
++#include <drm_fourcc.h>
++#include <stddef.h>
++#include <stdint.h>
++
++#include <memory>
++#include <vector>
++
++#include "base/files/file_path.h"
++#include "base/files/file_util.h"
++#include "base/message_loop/message_loop.h"
++#include "base/test/fuzzed_data_provider.h"
++#include "testing/gmock/include/gmock/gmock.h"
++#include "ui/gfx/geometry/rect.h"
++#include "ui/ozone/platform/wayland/test/test_wayland_server_thread.h"
++#include "ui/ozone/platform/wayland/wayland_connection.h"
++#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/platform_window/platform_window_delegate.h"
++#include "ui/platform_window/platform_window_init_properties.h"
++
++using testing::_;
++
++namespace {
++
++// Off-class equivalent of WaylandTest::Sync.
++void Sync(wl::TestWaylandServerThread* server) {
++  DCHECK(server);
++
++  server->Resume();
++  base::RunLoop().RunUntilIdle();
++  server->Pause();
++}
++
++// Copied from ui/ozone/test/mock_platform_window_delegate.h to avoid
++// dependency from the whole library (it causes link problems).
++class MockPlatformWindowDelegate : public ui::PlatformWindowDelegate {
++ public:
++  MockPlatformWindowDelegate() = default;
++  ~MockPlatformWindowDelegate() = default;
++
++  MOCK_METHOD1(OnBoundsChanged, void(const gfx::Rect& new_bounds));
++  MOCK_METHOD1(OnDamageRect, void(const gfx::Rect& damaged_region));
++  MOCK_METHOD1(DispatchEvent, void(ui::Event* event));
++  MOCK_METHOD0(OnCloseRequest, void());
++  MOCK_METHOD0(OnClosed, void());
++  MOCK_METHOD1(OnWindowStateChanged, void(ui::PlatformWindowState new_state));
++  MOCK_METHOD0(OnLostCapture, void());
++  MOCK_METHOD1(OnAcceleratedWidgetAvailable,
++               void(gfx::AcceleratedWidget widget));
++  MOCK_METHOD0(OnAcceleratedWidgetDestroyed, void());
++  MOCK_METHOD1(OnActivationChanged, void(bool active));
++
++ private:
++  DISALLOW_COPY_AND_ASSIGN(MockPlatformWindowDelegate);
++};
++
++}  // namespace
++
++extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
++  base::FuzzedDataProvider data_provider(data, size);
++
++  std::vector<uint32_t> known_fourccs{
++      DRM_FORMAT_R8,          DRM_FORMAT_GR88,        DRM_FORMAT_ABGR8888,
++      DRM_FORMAT_XBGR8888,    DRM_FORMAT_ARGB8888,    DRM_FORMAT_XRGB8888,
++      DRM_FORMAT_XRGB2101010, DRM_FORMAT_XBGR2101010, DRM_FORMAT_RGB565,
++      DRM_FORMAT_UYVY,        DRM_FORMAT_NV12,        DRM_FORMAT_YVU420};
++
++  base::MessageLoopForUI message_loop;
++
++  MockPlatformWindowDelegate delegate;
++  std::unique_ptr<ui::WaylandConnection> connection =
++      std::make_unique<ui::WaylandConnection>();
++  std::unique_ptr<ui::WaylandWindow> window =
++      std::make_unique<ui::WaylandWindow>(&delegate, connection.get());
++  gfx::AcceleratedWidget widget = gfx::kNullAcceleratedWidget;
++
++  wl::TestWaylandServerThread server;
++  CHECK(server.Start(6));
++  CHECK(connection->Initialize());
++
++  EXPECT_CALL(delegate, OnAcceleratedWidgetAvailable(_))
++      .WillOnce(testing::SaveArg<0>(&widget));
++  ui::PlatformWindowInitProperties properties;
++  properties.bounds = gfx::Rect(0, 0, 800, 600);
++  properties.type = ui::PlatformWindowType::kWindow;
++  CHECK(window->Initialize(std::move(properties)));
++  CHECK_NE(widget, gfx::kNullAcceleratedWidget);
++
++  base::RunLoop().RunUntilIdle();
++  server.Pause();
++
++  base::FilePath temp_path;
++  EXPECT_TRUE(base::CreateTemporaryFile(&temp_path));
++  base::File temp(temp_path,
++                  base::File::FLAG_WRITE | base::File::FLAG_CREATE_ALWAYS);
++
++  // 10K screens are reality these days.
++  const uint32_t kWidth = data_provider.ConsumeIntegralInRange(1U, 20000U);
++  const uint32_t kHeight = data_provider.ConsumeIntegralInRange(1U, 20000U);
++  // The buffer manager opens a file descriptor for each plane so |plane_count|
++  // cannot be really large.  Technically, the maximum is |ulimit| minus number
++  // of file descriptors opened by this process already (which is 17 at the time
++  // of writing) but there is little sense in having more than a few planes in a
++  // real system so here is a hard limit of 500.
++  const uint32_t kPlaneCount = data_provider.ConsumeIntegralInRange(1U, 500U);
++  const uint32_t kFormat = known_fourccs[data_provider.ConsumeIntegralInRange(
++      0UL, known_fourccs.size() - 1)];
++
++  std::vector<uint32_t> strides(kPlaneCount);
++  std::vector<uint32_t> offsets(kPlaneCount);
++  std::vector<uint64_t> modifiers(kPlaneCount);
++  for (uint32_t i = 0; i < kPlaneCount; ++i) {
++    strides[i] = data_provider.ConsumeIntegralInRange(1U, UINT_MAX);
++    offsets[i] = data_provider.ConsumeIntegralInRange(0U, UINT_MAX);
++    modifiers[i] =
++        data_provider.ConsumeIntegralInRange(uint64_t(0), UINT64_MAX);
++  }
++
++  const uint32_t kBufferId = 1;
++
++  EXPECT_CALL(*server.zwp_linux_dmabuf_v1(), CreateParams(_, _, _));
++
++  connection->CreateZwpLinuxDmabuf(std::move(temp), kWidth, kHeight, strides,
++                                   offsets, kFormat, modifiers, kPlaneCount,
++                                   kBufferId);
++
++  Sync(&server);
++  Sync(&server);
++
++  connection->DestroyZwpLinuxDmabuf(kBufferId);
++
++  Sync(&server);
++
++  return 0;
++}
+diff --git a/ui/ozone/platform/wayland/wayland_buffer_manager.cc b/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+index 77f974cd88f5..405424951c98 100644
+--- a/ui/ozone/platform/wayland/wayland_buffer_manager.cc
++++ b/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+@@ -54,7 +54,8 @@ WaylandBufferManager::WaylandBufferManager(
+     WaylandConnection* connection)
+     : zwp_linux_dmabuf_(zwp_linux_dmabuf), connection_(connection) {
+   static const zwp_linux_dmabuf_v1_listener dmabuf_listener = {
+-      &WaylandBufferManager::Format, &WaylandBufferManager::Modifiers,
++      &WaylandBufferManager::Format,
++      &WaylandBufferManager::Modifiers,
+   };
+   zwp_linux_dmabuf_v1_add_listener(zwp_linux_dmabuf_.get(), &dmabuf_listener,
+                                    this);
+@@ -87,23 +88,22 @@ bool WaylandBufferManager::CreateBuffer(base::File file,
+                            modifiers, planes_count, buffer_id)) {
+     // base::File::Close() has an assertion that checks if blocking operations
+     // are allowed. Thus, manually close the fd here.
+-    base::ScopedFD fd(file.TakePlatformFile());
+-    fd.reset();
++    base::ScopedFD deleter(file.TakePlatformFile());
+     return false;
+   }
+ 
++  base::ScopedFD fd(file.TakePlatformFile());
++
+   // Store |params| connected to |buffer_id| to track buffer creation and
+   // identify, which buffer a client wants to use.
+   DCHECK(zwp_linux_dmabuf_);
+   struct zwp_linux_buffer_params_v1* params =
+       zwp_linux_dmabuf_v1_create_params(zwp_linux_dmabuf_.get());
+ 
+-  std::unique_ptr<Buffer> buffer =
+-      std::make_unique<Buffer>(buffer_id, params, gfx::Size(width, height));
+   buffers_.insert(std::pair<uint32_t, std::unique_ptr<Buffer>>(
+-      buffer_id, std::move(buffer)));
++      buffer_id,
++      std::make_unique<Buffer>(buffer_id, params, gfx::Size(width, height))));
+ 
+-  uint32_t fd = file.TakePlatformFile();
+   for (size_t i = 0; i < planes_count; i++) {
+     uint32_t modifier_lo = 0;
+     uint32_t modifier_hi = 0;
+@@ -114,8 +114,9 @@ bool WaylandBufferManager::CreateBuffer(base::File file,
+       DCHECK_EQ(planes_count, 1u) << "Invalid modifier may be passed only in "
+                                      "case of single plane format being used";
+     }
+-    zwp_linux_buffer_params_v1_add(params, fd, i /* plane id */, offsets[i],
+-                                   strides[i], modifier_hi, modifier_lo);
++    zwp_linux_buffer_params_v1_add(params, fd.get(), i /* plane id */,
++                                   offsets[i], strides[i], modifier_hi,
++                                   modifier_lo);
+   }
+   zwp_linux_buffer_params_v1_add_listener(params, &params_listener, this);
+   zwp_linux_buffer_params_v1_create(params, width, height, format, 0);
+diff --git a/ui/ozone/platform/wayland/wayland_connection.cc b/ui/ozone/platform/wayland/wayland_connection.cc
+index 6d36968c69f9..2ce29f20ba53 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/wayland_connection.cc
+@@ -52,7 +52,8 @@ WaylandConnection::~WaylandConnection() = default;
+ 
+ bool WaylandConnection::Initialize() {
+   static const wl_registry_listener registry_listener = {
+-      &WaylandConnection::Global, &WaylandConnection::GlobalRemove,
++      &WaylandConnection::Global,
++      &WaylandConnection::GlobalRemove,
+   };
+ 
+   display_.reset(wl_display_connect(nullptr));
+@@ -376,7 +377,8 @@ void WaylandConnection::Global(void* data,
+                                const char* interface,
+                                uint32_t version) {
+   static const wl_seat_listener seat_listener = {
+-      &WaylandConnection::Capabilities, &WaylandConnection::Name,
++      &WaylandConnection::Capabilities,
++      &WaylandConnection::Name,
+   };
+   static const xdg_shell_listener shell_listener = {
+       &WaylandConnection::Ping,
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0021-ozone-wayland-Remove-WaylandXkbKeyboardLayoutEngine.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0021-ozone-wayland-Remove-WaylandXkbKeyboardLayoutEngine.patch
@@ -1,0 +1,622 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1454308
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 5bcc857dd0719dcddfc7ab02c3076b393cf715d2 Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nickdiego@igalia.com>
+Date: Fri, 8 Feb 2019 07:39:12 +0000
+Subject: [PATCH 21/35] ozone/wayland: Remove WaylandXkbKeyboardLayoutEngine
+
+Ozone/wayland keyboard input implementation uses libxkbcommon
+to properly handle different keyboard layouts. More specifically,
+it has been using a specialization of XkbKeyboardLayoutEngine,
+whose main functionalities are:
+
+  (1) Feed libxkbcommon with modifier events/masks (e.g: shift, ctrl, etc),
+  so that it can properly convert keys codes into key symbols later on. [1]
+
+  (2) Keep track of modifiers' state using an EventModifiers variable owned
+  by WaylandKeyboard singleton.
+
+Even though this approach works pretty well, the Wayland specialization
+of XkbKeyboardLayoutEngine has a weird API and it is actually not needed.
+In this patch, WaylandKeyboard is cleaned up so that WaylandXkbKeyboardLayoutEngine
+can be removed, and functionalities mentioned above are moved to XkbKeyboardLayoutEngine,
+and adpted to (re)use some of its internal structures, thus reducing code replication.
+Additionally, this CL modifies the way WaylandKeyboard interacts with KeyboardLayoutEngine,
+injecting it via its constructor, instead of directly accessing it through
+KeyboardLayoutEngineManager, what is more aligned with KeyboardEvdev implementation
+and general chromium practices.
+
+[1] https://xkbcommon.org/doc/current/group__state.html#ga566677517a286527e05efc5680adbe6b
+
+Bug: 921947
+Change-Id: I5c294e61711d0bf55db95b0e57d1466d00464706
+Reviewed-on: https://chromium-review.googlesource.com/c/1454308
+Commit-Queue: Nick Yamane <nickdiego@igalia.com>
+Reviewed-by: Michael Spang <spang@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#630238}
+---
+ ui/events/ozone/evdev/keyboard_util_evdev.h   |  6 +-
+ .../layout/xkb/xkb_keyboard_layout_engine.cc  | 20 ++++-
+ .../layout/xkb/xkb_keyboard_layout_engine.h   |  9 ++-
+ ui/ozone/platform/wayland/BUILD.gn            |  4 -
+ .../wayland/ozone_platform_wayland.cc         | 10 ++-
+ .../platform/wayland/wayland_connection.cc    |  6 +-
+ ui/ozone/platform/wayland/wayland_keyboard.cc | 75 +++++++++----------
+ ui/ozone/platform/wayland/wayland_keyboard.h  | 23 ++++--
+ ui/ozone/platform/wayland/wayland_test.cc     |  5 +-
+ .../wayland_xkb_keyboard_layout_engine.cc     | 58 --------------
+ .../wayland_xkb_keyboard_layout_engine.h      | 46 ------------
+ 11 files changed, 98 insertions(+), 164 deletions(-)
+ delete mode 100644 ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.cc
+ delete mode 100644 ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h
+
+diff --git a/ui/events/ozone/evdev/keyboard_util_evdev.h b/ui/events/ozone/evdev/keyboard_util_evdev.h
+index 3460ff56e476..56bde0ce8cd2 100644
+--- a/ui/events/ozone/evdev/keyboard_util_evdev.h
++++ b/ui/events/ozone/evdev/keyboard_util_evdev.h
+@@ -5,10 +5,12 @@
+ #ifndef UI_EVENTS_OZONE_EVDEV_KEYBOARD_UTIL_EVDEV_H_
+ #define UI_EVENTS_OZONE_EVDEV_KEYBOARD_UTIL_EVDEV_H_
+ 
++#include "ui/events/ozone/evdev/events_ozone_evdev_export.h"
++
+ namespace ui {
+ 
+-int NativeCodeToEvdevCode(int native_code);
+-int EvdevCodeToNativeCode(int evdev_code);
++int EVENTS_OZONE_EVDEV_EXPORT NativeCodeToEvdevCode(int native_code);
++int EVENTS_OZONE_EVDEV_EXPORT EvdevCodeToNativeCode(int evdev_code);
+ 
+ }  // namespace ui
+ 
+diff --git a/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.cc b/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.cc
+index afeec925722f..c1f5c10e7734 100644
+--- a/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.cc
++++ b/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.cc
+@@ -8,6 +8,7 @@
+ #include <xkbcommon/xkbcommon-names.h>
+ 
+ #include <algorithm>
++#include <utility>
+ 
+ #include "base/bind.h"
+ #include "base/location.h"
+@@ -832,7 +833,7 @@ void XkbKeyboardLayoutEngine::SetKeymap(xkb_keymap* keymap) {
+       DVLOG(3) << "XKB keyboard layout does not contain " << flags[i].xkb_name;
+     } else {
+       xkb_mod_mask_t flag = static_cast<xkb_mod_mask_t>(1) << index;
+-      XkbFlagMapEntry e = {flags[i].ui_flag, flag};
++      XkbFlagMapEntry e = {flags[i].ui_flag, flag, index};
+       xkb_flag_map_.push_back(e);
+     }
+   }
+@@ -857,6 +858,23 @@ xkb_mod_mask_t XkbKeyboardLayoutEngine::EventFlagsToXkbFlags(
+   return xkb_flags;
+ }
+ 
++int XkbKeyboardLayoutEngine::GetModifierFlags(uint32_t depressed,
++                                              uint32_t latched,
++                                              uint32_t locked,
++                                              uint32_t group) const {
++  auto* state = xkb_state_.get();
++  xkb_state_update_mask(state, depressed, latched, locked, 0, 0, group);
++  auto component = static_cast<xkb_state_component>(XKB_STATE_MODS_DEPRESSED |
++                                                    XKB_STATE_MODS_LATCHED |
++                                                    XKB_STATE_MODS_LOCKED);
++  int ui_flags = 0;
++  for (const auto& entry : xkb_flag_map_) {
++    if (xkb_state_mod_index_is_active(state, entry.xkb_index, component))
++      ui_flags |= entry.ui_flag;
++  }
++  return ui_flags;
++}
++
+ bool XkbKeyboardLayoutEngine::XkbLookup(xkb_keycode_t xkb_keycode,
+                                         xkb_mod_mask_t xkb_flags,
+                                         xkb_keysym_t* xkb_keysym,
+diff --git a/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h b/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h
+index 4869af535e7b..fd33e76ce8eb 100644
+--- a/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h
++++ b/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h
+@@ -9,6 +9,7 @@
+ #include <xkbcommon/xkbcommon.h>
+ 
+ #include <memory>
++#include <string>
+ #include <vector>
+ 
+ #include "base/containers/hash_tables.h"
+@@ -27,7 +28,7 @@ namespace ui {
+ class EVENTS_OZONE_LAYOUT_EXPORT XkbKeyboardLayoutEngine
+     : public KeyboardLayoutEngine {
+  public:
+-  XkbKeyboardLayoutEngine(const XkbKeyCodeConverter& converter);
++  explicit XkbKeyboardLayoutEngine(const XkbKeyCodeConverter& converter);
+   ~XkbKeyboardLayoutEngine() override;
+ 
+   // KeyboardLayoutEngine:
+@@ -46,6 +47,11 @@ class EVENTS_OZONE_LAYOUT_EXPORT XkbKeyboardLayoutEngine
+               DomKey* dom_key,
+               KeyboardCode* key_code) const override;
+ 
++  int GetModifierFlags(uint32_t depressed,
++                       uint32_t latched,
++                       uint32_t locked,
++                       uint32_t group) const;
++
+   static void ParseLayoutName(const std::string& layout_name,
+                               std::string* layout_id,
+                               std::string* layout_variant);
+@@ -55,6 +61,7 @@ class EVENTS_OZONE_LAYOUT_EXPORT XkbKeyboardLayoutEngine
+   struct XkbFlagMapEntry {
+     int ui_flag;
+     xkb_mod_mask_t xkb_flag;
++    xkb_mod_index_t xkb_index;
+   };
+   std::vector<XkbFlagMapEntry> xkb_flag_map_;
+ 
+diff --git a/ui/ozone/platform/wayland/BUILD.gn b/ui/ozone/platform/wayland/BUILD.gn
+index f06ba6ea7a18..c5e8783cd350 100644
+--- a/ui/ozone/platform/wayland/BUILD.gn
++++ b/ui/ozone/platform/wayland/BUILD.gn
+@@ -82,10 +82,6 @@ source_set("wayland") {
+ 
+   import("//ui/base/ui_features.gni")
+   if (use_xkbcommon) {
+-    sources += [
+-      "wayland_xkb_keyboard_layout_engine.cc",
+-      "wayland_xkb_keyboard_layout_engine.h",
+-    ]
+     configs += [ "//ui/events/ozone:xkbcommon" ]
+   }
+ 
+diff --git a/ui/ozone/platform/wayland/ozone_platform_wayland.cc b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+index 50c61375472c..671c948323b1 100644
+--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
++++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+@@ -4,6 +4,11 @@
+ 
+ #include "ui/ozone/platform/wayland/ozone_platform_wayland.h"
+ 
++#include <memory>
++#include <string>
++#include <utility>
++#include <vector>
++
+ #include "base/memory/ptr_util.h"
+ #include "ui/base/cursor/ozone/bitmap_cursor_factory_ozone.h"
+ #include "ui/base/ui_features.h"
+@@ -26,7 +31,7 @@
+ 
+ #if BUILDFLAG(USE_XKBCOMMON)
+ #include "ui/events/ozone/layout/xkb/xkb_evdev_codes.h"
+-#include "ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h"
++#include "ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h"
+ #else
+ #include "ui/events/ozone/layout/stub/stub_keyboard_layout_engine.h"
+ #endif
+@@ -139,8 +144,7 @@ class OzonePlatformWayland : public OzonePlatform {
+   void InitializeUI(const InitParams& args) override {
+ #if BUILDFLAG(USE_XKBCOMMON)
+     KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(
+-        std::make_unique<WaylandXkbKeyboardLayoutEngine>(
+-            xkb_evdev_code_converter_));
++        std::make_unique<XkbKeyboardLayoutEngine>(xkb_evdev_code_converter_));
+ #else
+     KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(
+         std::make_unique<StubKeyboardLayoutEngine>());
+diff --git a/ui/ozone/platform/wayland/wayland_connection.cc b/ui/ozone/platform/wayland/wayland_connection.cc
+index 2ce29f20ba53..6fbe0515c1f8 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/wayland_connection.cc
+@@ -14,6 +14,7 @@
+ #include "base/message_loop/message_loop_current.h"
+ #include "base/strings/string_util.h"
+ #include "base/threading/thread_task_runner_handle.h"
++#include "ui/events/ozone/layout/keyboard_layout_engine_manager.h"
+ #include "ui/gfx/swap_result.h"
+ #include "ui/ozone/platform/wayland/wayland_buffer_manager.h"
+ #include "ui/ozone/platform/wayland/wayland_input_method_context.h"
+@@ -551,8 +552,9 @@ void WaylandConnection::Capabilities(void* data,
+         return;
+       }
+       connection->keyboard_ = std::make_unique<WaylandKeyboard>(
+-          keyboard, base::BindRepeating(&WaylandConnection::DispatchUiEvent,
+-                                        base::Unretained(connection)));
++          keyboard, KeyboardLayoutEngineManager::GetKeyboardLayoutEngine(),
++          base::BindRepeating(&WaylandConnection::DispatchUiEvent,
++                              base::Unretained(connection)));
+       connection->keyboard_->set_connection(connection);
+     }
+   } else if (connection->keyboard_) {
+diff --git a/ui/ozone/platform/wayland/wayland_keyboard.cc b/ui/ozone/platform/wayland/wayland_keyboard.cc
+index b65685966839..737212b6c722 100644
+--- a/ui/ozone/platform/wayland/wayland_keyboard.cc
++++ b/ui/ozone/platform/wayland/wayland_keyboard.cc
+@@ -5,6 +5,7 @@
+ #include "ui/ozone/platform/wayland/wayland_keyboard.h"
+ 
+ #include <sys/mman.h>
++#include <utility>
+ 
+ #include "base/files/scoped_file.h"
+ #include "ui/base/ui_features.h"
+@@ -12,6 +13,7 @@
+ #include "ui/events/event.h"
+ #include "ui/events/keycodes/dom/dom_code.h"
+ #include "ui/events/keycodes/dom/keycode_converter.h"
++#include "ui/events/ozone/evdev/keyboard_util_evdev.h"
+ #include "ui/events/ozone/layout/keyboard_layout_engine.h"
+ #include "ui/events/ozone/layout/keyboard_layout_engine_manager.h"
+ #include "ui/events/ozone/layout/layout_util.h"
+@@ -19,37 +21,33 @@
+ #include "ui/ozone/platform/wayland/wayland_window.h"
+ 
+ #if BUILDFLAG(USE_XKBCOMMON)
+-#include "ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h"
++#include "ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h"
+ #endif
+ 
+ namespace ui {
+ 
+-namespace {
+-
+-const int kXkbKeycodeOffset = 8;
+-
+-}  // namespace
+-
+ // static
+ const wl_callback_listener WaylandKeyboard::callback_listener_ = {
+     WaylandKeyboard::SyncCallback,
+ };
+ 
+ WaylandKeyboard::WaylandKeyboard(wl_keyboard* keyboard,
++                                 KeyboardLayoutEngine* layout_engine,
+                                  const EventDispatchCallback& callback)
+-    : obj_(keyboard), callback_(callback), auto_repeat_handler_(this) {
++    : obj_(keyboard),
++      callback_(callback),
++      auto_repeat_handler_(this),
++#if BUILDFLAG(USE_XKBCOMMON)
++      layout_engine_(static_cast<XkbKeyboardLayoutEngine*>(layout_engine)) {
++#else
++      layout_engine_(layout_engine) {
++#endif
+   static const wl_keyboard_listener listener = {
+       &WaylandKeyboard::Keymap,    &WaylandKeyboard::Enter,
+       &WaylandKeyboard::Leave,     &WaylandKeyboard::Key,
+       &WaylandKeyboard::Modifiers, &WaylandKeyboard::RepeatInfo,
+   };
+ 
+-#if BUILDFLAG(USE_XKBCOMMON)
+-  auto* engine = static_cast<WaylandXkbKeyboardLayoutEngine*>(
+-      KeyboardLayoutEngineManager::GetKeyboardLayoutEngine());
+-  engine->SetEventModifiers(&event_modifiers_);
+-#endif
+-
+   wl_keyboard_add_listener(obj_.get(), &listener, this);
+ 
+   // TODO(tonikitoo): Default auto-repeat to ON here?
+@@ -62,6 +60,9 @@ void WaylandKeyboard::Keymap(void* data,
+                              uint32_t format,
+                              int32_t raw_fd,
+                              uint32_t size) {
++  WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
++  DCHECK(keyboard);
++
+   base::ScopedFD fd(raw_fd);
+   if (!data || format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1)
+     return;
+@@ -71,9 +72,9 @@ void WaylandKeyboard::Keymap(void* data,
+   if (keymap_str == MAP_FAILED)
+     return;
+ 
++  auto length = strnlen(keymap_str, size);
+   bool success =
+-      KeyboardLayoutEngineManager::GetKeyboardLayoutEngine()
+-          ->SetCurrentLayoutFromBuffer(keymap_str, strnlen(keymap_str, size));
++      keyboard->layout_engine_->SetCurrentLayoutFromBuffer(keymap_str, length);
+   DCHECK(success) << "Failed to set the XKB keyboard mapping.";
+   munmap(keymap_str, size);
+ }
+@@ -128,14 +129,16 @@ void WaylandKeyboard::Key(void* data,
+ void WaylandKeyboard::Modifiers(void* data,
+                                 wl_keyboard* obj,
+                                 uint32_t serial,
+-                                uint32_t mods_depressed,
+-                                uint32_t mods_latched,
+-                                uint32_t mods_locked,
++                                uint32_t depressed,
++                                uint32_t latched,
++                                uint32_t locked,
+                                 uint32_t group) {
+ #if BUILDFLAG(USE_XKBCOMMON)
+-  auto* engine = static_cast<WaylandXkbKeyboardLayoutEngine*>(
+-      KeyboardLayoutEngineManager::GetKeyboardLayoutEngine());
+-  engine->UpdateModifiers(mods_depressed, mods_latched, mods_locked, group);
++  WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
++  DCHECK(keyboard);
++
++  keyboard->modifiers_ = keyboard->layout_engine_->GetModifierFlags(
++      depressed, latched, locked, group);
+ #endif
+ }
+ 
+@@ -171,15 +174,13 @@ void WaylandKeyboard::DispatchKey(uint32_t key,
+                                   base::TimeTicks timestamp,
+                                   int device_id) {
+   DomCode dom_code =
+-      KeycodeConverter::NativeKeycodeToDomCode(key + kXkbKeycodeOffset);
++      KeycodeConverter::NativeKeycodeToDomCode(EvdevCodeToNativeCode(key));
+   if (dom_code == ui::DomCode::NONE)
+     return;
+ 
+-  uint8_t flags = event_modifiers_.GetModifierFlags();
+   DomKey dom_key;
+   KeyboardCode key_code;
+-  if (!KeyboardLayoutEngineManager::GetKeyboardLayoutEngine()->Lookup(
+-          dom_code, flags, &dom_key, &key_code))
++  if (!layout_engine_->Lookup(dom_code, modifiers_, &dom_key, &key_code))
+     return;
+ 
+   if (!repeat) {
+@@ -188,8 +189,7 @@ void WaylandKeyboard::DispatchKey(uint32_t key,
+   }
+ 
+   ui::KeyEvent event(down ? ET_KEY_PRESSED : ET_KEY_RELEASED, key_code,
+-                     dom_code, event_modifiers_.GetModifierFlags(), dom_key,
+-                     timestamp);
++                     dom_code, modifiers_, dom_key, timestamp);
+   event.set_source_device_id(device_id);
+   callback_.Run(&event);
+ }
+@@ -205,25 +205,22 @@ void WaylandKeyboard::SyncCallback(void* data,
+   keyboard->sync_callback_.reset();
+ }
+ 
+-void WaylandKeyboard::UpdateModifier(int modifier_flag, bool down) {
+-  if (modifier_flag == EF_NONE)
+-    return;
+-
+-  int modifier = EventModifiers::GetModifierFromEventFlag(modifier_flag);
+-  if (modifier == MODIFIER_NONE)
++void WaylandKeyboard::UpdateModifier(int modifier, bool down) {
++  if (modifier == EF_NONE)
+     return;
+ 
+-  // This mimics KeyboardEvDev, which matches chrome/x11.
++  // TODO(nickdiego): ChromeOS-specific keyboard remapping logic.
++  // Remove this once it is properly guarded under OS_CHROMEOS.
++  //
+   // Currently EF_MOD3_DOWN means that the CapsLock key is currently down,
+   // and EF_CAPS_LOCK_ON means the caps lock state is enabled (and the
+   // key may or may not be down, but usually isn't). There does need to
+   // to be two different flags, since the physical CapsLock key is subject
+   // to remapping, but the caps lock state (which can be triggered in a
+   // variety of ways) is not.
+-  if (modifier == MODIFIER_CAPS_LOCK)
+-    event_modifiers_.UpdateModifier(MODIFIER_MOD3, down);
+-  else
+-    event_modifiers_.UpdateModifier(modifier, down);
++  if (modifier == EF_CAPS_LOCK_ON)
++    modifier = (modifier & ~EF_CAPS_LOCK_ON) | EF_MOD3_DOWN;
++  modifiers_ = down ? (modifiers_ | modifier) : (modifiers_ & ~modifier);
+ }
+ 
+ }  // namespace ui
+diff --git a/ui/ozone/platform/wayland/wayland_keyboard.h b/ui/ozone/platform/wayland/wayland_keyboard.h
+index 18b535a6051d..60de33f1f59f 100644
+--- a/ui/ozone/platform/wayland/wayland_keyboard.h
++++ b/ui/ozone/platform/wayland/wayland_keyboard.h
+@@ -7,25 +7,32 @@
+ 
+ #include <wayland-client.h>
+ 
+-#include "ui/events/event_modifiers.h"
++#include "build/buildflag.h"
++#include "ui/base/ui_features.h"
+ #include "ui/events/ozone/evdev/event_dispatch_callback.h"
+ #include "ui/events/ozone/keyboard/event_auto_repeat_handler.h"
+ #include "ui/ozone/platform/wayland/wayland_object.h"
+ 
+ namespace ui {
+ 
++class KeyboardLayoutEngine;
++#if BUILDFLAG(USE_XKBCOMMON)
++class XkbKeyboardLayoutEngine;
++#endif
+ class WaylandConnection;
+ 
+ class WaylandKeyboard : public EventAutoRepeatHandler::Delegate {
+  public:
+-  WaylandKeyboard(wl_keyboard* keyboard, const EventDispatchCallback& callback);
++  WaylandKeyboard(wl_keyboard* keyboard,
++                  KeyboardLayoutEngine* keyboard_layout_engine,
++                  const EventDispatchCallback& callback);
+   virtual ~WaylandKeyboard();
+ 
+   void set_connection(WaylandConnection* connection) {
+     connection_ = connection;
+   }
+ 
+-  int modifiers() { return event_modifiers_.GetModifierFlags(); }
++  int modifiers() { return modifiers_; }
+ 
+  private:
+   // wl_keyboard_listener
+@@ -63,7 +70,7 @@ class WaylandKeyboard : public EventAutoRepeatHandler::Delegate {
+ 
+   static void SyncCallback(void* data, struct wl_callback* cb, uint32_t time);
+ 
+-  void UpdateModifier(int modifier_flag, bool down);
++  void UpdateModifier(int modifier, bool down);
+ 
+   // EventAutoRepeatHandler::Delegate
+   void FlushInput(base::OnceClosure closure) override;
+@@ -76,13 +83,19 @@ class WaylandKeyboard : public EventAutoRepeatHandler::Delegate {
+   WaylandConnection* connection_ = nullptr;
+   wl::Object<wl_keyboard> obj_;
+   EventDispatchCallback callback_;
+-  EventModifiers event_modifiers_;
++  int modifiers_ = 0;
+ 
+   // Key repeat handler.
+   static const wl_callback_listener callback_listener_;
+   EventAutoRepeatHandler auto_repeat_handler_;
+   base::OnceClosure auto_repeat_closure_;
+   wl::Object<wl_callback> sync_callback_;
++
++#if BUILDFLAG(USE_XKBCOMMON)
++  XkbKeyboardLayoutEngine* layout_engine_;
++#else
++  KeyboardLayoutEngine* layout_engine_;
++#endif
+ };
+ 
+ }  // namespace ui
+diff --git a/ui/ozone/platform/wayland/wayland_test.cc b/ui/ozone/platform/wayland/wayland_test.cc
+index 8db81477fcb2..c15bc87efa15 100644
+--- a/ui/ozone/platform/wayland/wayland_test.cc
++++ b/ui/ozone/platform/wayland/wayland_test.cc
+@@ -9,7 +9,7 @@
+ #include "ui/platform_window/platform_window_init_properties.h"
+ 
+ #if BUILDFLAG(USE_XKBCOMMON)
+-#include "ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h"
++#include "ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h"
+ #else
+ #include "ui/events/ozone/layout/stub/stub_keyboard_layout_engine.h"
+ #endif
+@@ -22,8 +22,7 @@ namespace ui {
+ WaylandTest::WaylandTest() {
+ #if BUILDFLAG(USE_XKBCOMMON)
+   KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(
+-      std::make_unique<WaylandXkbKeyboardLayoutEngine>(
+-          xkb_evdev_code_converter_));
++      std::make_unique<XkbKeyboardLayoutEngine>(xkb_evdev_code_converter_));
+ #else
+   KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(
+       std::make_unique<StubKeyboardLayoutEngine>());
+diff --git a/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.cc b/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.cc
+deleted file mode 100644
+index b2600adbbd75..000000000000
+--- a/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.cc
++++ /dev/null
+@@ -1,58 +0,0 @@
+-// Copyright 2017 The Chromium Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style license that can be
+-// found in the LICENSE file.
+-
+-#include "ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h"
+-
+-#include "ui/events/event_constants.h"
+-#include "ui/events/event_modifiers.h"
+-
+-namespace ui {
+-
+-void WaylandXkbKeyboardLayoutEngine::SetKeymap(xkb_keymap* keymap) {
+-  XkbKeyboardLayoutEngine::SetKeymap(keymap);
+-
+-  xkb_mod_indexes_.control =
+-      xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_CTRL);
+-  xkb_mod_indexes_.alt = xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_ALT);
+-  xkb_mod_indexes_.shift = xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_SHIFT);
+-  xkb_mod_indexes_.caps = xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_CAPS);
+-}
+-
+-void WaylandXkbKeyboardLayoutEngine::UpdateModifiers(uint32_t depressed_mods,
+-                                                     uint32_t latched_mods,
+-                                                     uint32_t locked_mods,
+-                                                     uint32_t group) {
+-  xkb_state_update_mask(xkb_state_.get(), depressed_mods, latched_mods,
+-                        locked_mods, 0, 0, group);
+-
+-  event_modifiers_->ResetKeyboardModifiers();
+-
+-  auto component = static_cast<xkb_state_component>(XKB_STATE_MODS_DEPRESSED |
+-                                                    XKB_STATE_MODS_LATCHED |
+-                                                    XKB_STATE_MODS_LOCKED);
+-  if (xkb_state_mod_index_is_active(xkb_state_.get(), xkb_mod_indexes_.control,
+-                                    component))
+-    event_modifiers_->UpdateModifier(MODIFIER_CONTROL, true);
+-
+-  if (xkb_state_mod_index_is_active(xkb_state_.get(), xkb_mod_indexes_.alt,
+-                                    component))
+-    event_modifiers_->UpdateModifier(MODIFIER_ALT, true);
+-
+-  if (xkb_state_mod_index_is_active(xkb_state_.get(), xkb_mod_indexes_.shift,
+-                                    component))
+-    event_modifiers_->UpdateModifier(MODIFIER_SHIFT, true);
+-
+-  if (xkb_state_mod_index_is_active(xkb_state_.get(), xkb_mod_indexes_.caps,
+-                                    component))
+-    event_modifiers_->SetModifierLock(MODIFIER_CAPS_LOCK, true);
+-  else
+-    event_modifiers_->SetModifierLock(MODIFIER_CAPS_LOCK, false);
+-}
+-
+-void WaylandXkbKeyboardLayoutEngine::SetEventModifiers(
+-    EventModifiers* event_modifiers) {
+-  event_modifiers_ = event_modifiers;
+-}
+-
+-}  // namespace ui
+diff --git a/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h b/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h
+deleted file mode 100644
+index 18c8f8c53a69..000000000000
+--- a/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h
++++ /dev/null
+@@ -1,46 +0,0 @@
+-// Copyright 2017 The Chromium Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style license that can be
+-// found in the LICENSE file.
+-
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_XKB_KEYBOARD_LAYOUT_ENGINE_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_XKB_KEYBOARD_LAYOUT_ENGINE_H_
+-
+-#include "ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h"
+-
+-#include "ui/events/ozone/layout/xkb/xkb_key_code_converter.h"
+-
+-namespace ui {
+-
+-class EventModifiers;
+-
+-class WaylandXkbKeyboardLayoutEngine : public XkbKeyboardLayoutEngine {
+- public:
+-  WaylandXkbKeyboardLayoutEngine(const XkbKeyCodeConverter& converter)
+-      : XkbKeyboardLayoutEngine(converter) {}
+-
+-  // Used to sync up client side 'xkb_state' instance with modifiers status
+-  // update from the compositor.
+-  void UpdateModifiers(uint32_t depressed_mods,
+-                       uint32_t latched_mods,
+-                       uint32_t locked_mods,
+-                       uint32_t group);
+-
+-  void SetEventModifiers(EventModifiers* event_modifiers);
+-
+- private:
+-  void SetKeymap(xkb_keymap* keymap) override;
+-
+-  // Cache to access modifiers xkb_mode_index_t value.
+-  struct {
+-    xkb_mod_index_t control = 0;
+-    xkb_mod_index_t alt = 0;
+-    xkb_mod_index_t shift = 0;
+-    xkb_mod_index_t caps = 0;
+-  } xkb_mod_indexes_;
+-
+-  EventModifiers* event_modifiers_ = nullptr;  // Owned by WaylandKeyboard.
+-};
+-
+-}  // namespace ui
+-
+-#endif  // UI_EVENTS_OZONE_LAYOUT_XKB_XKB_KEYBOARD_LAYOUT_ENGINE_H_
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0022-ozone-wayland-Fix-wl_pointer-enter-event-handling.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0022-ozone-wayland-Fix-wl_pointer-enter-event-handling.patch
@@ -1,0 +1,175 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1460357
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From b99b3a537153ca30d4ec5b7b4361071add9f0fe9 Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nickdiego@igalia.com>
+Date: Fri, 8 Feb 2019 20:50:13 +0000
+Subject: [PATCH 22/35] ozone/wayland: Fix wl_pointer::enter event handling
+
+Currently, WaylandPointer is not emitting MOUSE_ENTERED events. This
+has been causing a couple of issues, among them:
+
+- When you open a new window using keyboard shortcut for example, the
+mouse cursor is invisible until you start moving the pointer around.
+
+- When a window looses focus with no movement events fired and one
+tries to open a new window (e.g: using keyboard shortcut), the browser
+crashes (in builds with dchecks enabled) when it tries to reset cursor
+for that window. This happens because cursor is not set in this case
+for the first window (holding a CursorType::kNull in this case), because
+WaylandWindow::SetCursor is only being triggered when WaylandPointer::Motion
+events are fired (what doesn't happen in this case).
+
+This patch fixes these issues by dispatching a MOUSE_ENTERED platform
+event in WaylandPointer::Entered() function.
+
+Bug: 928272
+Change-Id: I13e01f28116fd6ce3a47ce8dc14cedcd51ed72ed
+Reviewed-on: https://chromium-review.googlesource.com/c/1460357
+Reviewed-by: Antonio Gomes <tonikitoo@igalia.com>
+Commit-Queue: Nick Yamane <nickdiego@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#630461}
+---
+ ui/ozone/platform/wayland/wayland_pointer.cc  | 35 +++++++++++++------
+ ui/ozone/platform/wayland/wayland_pointer.h   |  2 ++
+ .../wayland/wayland_pointer_unittest.cc       | 30 +++++++++++++---
+ 3 files changed, 51 insertions(+), 16 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/wayland_pointer.cc b/ui/ozone/platform/wayland/wayland_pointer.cc
+index 4e7940cd8e95..41ec5c58e755 100644
+--- a/ui/ozone/platform/wayland/wayland_pointer.cc
++++ b/ui/ozone/platform/wayland/wayland_pointer.cc
+@@ -61,11 +61,12 @@ void WaylandPointer::Enter(void* data,
+   WaylandPointer* pointer = static_cast<WaylandPointer*>(data);
+   pointer->location_.SetPoint(wl_fixed_to_double(surface_x),
+                               wl_fixed_to_double(surface_y));
+-  if (surface) {
+-    WaylandWindow* window = WaylandWindow::FromSurface(surface);
+-    window->set_pointer_focus(true);
+-    pointer->window_with_pointer_focus_ = window;
+-  }
++  pointer->FocusWindow(surface);
++  MouseEvent event(ET_MOUSE_ENTERED, gfx::Point(), gfx::Point(),
++                   EventTimeForNow(), pointer->flags_, 0);
++  event.set_location_f(pointer->location_);
++  event.set_root_location_f(pointer->location_);
++  pointer->callback_.Run(&event);
+ }
+ 
+ // static
+@@ -77,12 +78,7 @@ void WaylandPointer::Leave(void* data,
+   MouseEvent event(ET_MOUSE_EXITED, gfx::Point(), gfx::Point(),
+                    EventTimeForNow(), pointer->flags_, 0);
+   pointer->callback_.Run(&event);
+-  if (surface) {
+-    WaylandWindow* window = WaylandWindow::FromSurface(surface);
+-    window->set_pointer_focus(false);
+-    window->set_has_implicit_grab(false);
+-    pointer->window_with_pointer_focus_ = nullptr;
+-  }
++  pointer->UnfocusWindow(surface);
+ }
+ 
+ // static
+@@ -218,4 +214,21 @@ void WaylandPointer::ResetFlags() {
+   keyboard_modifiers_ = 0;
+ }
+ 
++void WaylandPointer::FocusWindow(wl_surface* surface) {
++  if (surface) {
++    WaylandWindow* window = WaylandWindow::FromSurface(surface);
++    window->set_pointer_focus(true);
++    window_with_pointer_focus_ = window;
++  }
++}
++
++void WaylandPointer::UnfocusWindow(wl_surface* surface) {
++  if (surface) {
++    WaylandWindow* window = WaylandWindow::FromSurface(surface);
++    window->set_pointer_focus(false);
++    window->set_has_implicit_grab(false);
++    window_with_pointer_focus_ = nullptr;
++  }
++}
++
+ }  // namespace ui
+diff --git a/ui/ozone/platform/wayland/wayland_pointer.h b/ui/ozone/platform/wayland/wayland_pointer.h
+index 0c398d19a83e..1af7b9703c1a 100644
+--- a/ui/ozone/platform/wayland/wayland_pointer.h
++++ b/ui/ozone/platform/wayland/wayland_pointer.h
+@@ -65,6 +65,8 @@ class WaylandPointer {
+                    wl_fixed_t value);
+ 
+   void MaybeSetOrResetImplicitGrab();
++  void FocusWindow(wl_surface* surface);
++  void UnfocusWindow(wl_surface* surface);
+ 
+   WaylandConnection* connection_ = nullptr;
+   std::unique_ptr<WaylandCursor> cursor_;
+diff --git a/ui/ozone/platform/wayland/wayland_pointer_unittest.cc b/ui/ozone/platform/wayland/wayland_pointer_unittest.cc
+index 52fe40fb226e..1e584c52bbf0 100644
+--- a/ui/ozone/platform/wayland/wayland_pointer_unittest.cc
++++ b/ui/ozone/platform/wayland/wayland_pointer_unittest.cc
+@@ -42,6 +42,27 @@ class WaylandPointerTest : public WaylandTest {
+   DISALLOW_COPY_AND_ASSIGN(WaylandPointerTest);
+ };
+ 
++ACTION_P(CloneEvent, ptr) {
++  *ptr = Event::Clone(*arg0);
++}
++
++TEST_P(WaylandPointerTest, Enter) {
++  wl_pointer_send_enter(pointer_->resource(), 1, surface_->resource(), 0, 0);
++
++  std::unique_ptr<Event> event;
++  EXPECT_CALL(delegate_, DispatchEvent(_)).WillOnce(CloneEvent(&event));
++
++  Sync();
++
++  ASSERT_TRUE(event);
++  ASSERT_TRUE(event->IsMouseEvent());
++  auto* mouse_event = event->AsMouseEvent();
++  EXPECT_EQ(ET_MOUSE_ENTERED, mouse_event->type());
++  EXPECT_EQ(0, mouse_event->button_flags());
++  EXPECT_EQ(0, mouse_event->changed_button_flags());
++  EXPECT_EQ(gfx::PointF(0, 0), mouse_event->location_f());
++}
++
+ TEST_P(WaylandPointerTest, Leave) {
+   MockPlatformWindowDelegate other_delegate;
+   WaylandWindow other_window(&other_delegate, connection_.get());
+@@ -66,17 +87,13 @@ TEST_P(WaylandPointerTest, Leave) {
+                         0);
+   wl_pointer_send_button(pointer_->resource(), 4, 1004, BTN_LEFT,
+                          WL_POINTER_BUTTON_STATE_PRESSED);
+-  EXPECT_CALL(delegate_, DispatchEvent(_)).Times(1);
++  EXPECT_CALL(delegate_, DispatchEvent(_)).Times(2);
+ 
+   // Do an extra Sync() here so that we process the second enter event before we
+   // destroy |other_window|.
+   Sync();
+ }
+ 
+-ACTION_P(CloneEvent, ptr) {
+-  *ptr = Event::Clone(*arg0);
+-}
+-
+ ACTION_P3(CloneEventAndCheckCapture, window, result, ptr) {
+   ASSERT_TRUE(window->HasCapture() == result);
+   *ptr = Event::Clone(*arg0);
+@@ -84,6 +101,9 @@ ACTION_P3(CloneEventAndCheckCapture, window, result, ptr) {
+ 
+ TEST_P(WaylandPointerTest, Motion) {
+   wl_pointer_send_enter(pointer_->resource(), 1, surface_->resource(), 0, 0);
++  Sync();  // We're interested in checking Motion event in this test case, so
++           // skip Enter event here.
++
+   wl_pointer_send_motion(pointer_->resource(), 1002,
+                          wl_fixed_from_double(10.75),
+                          wl_fixed_from_double(20.375));
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0023-ozone-wayland-Handle-preedit-string-in-WaylandInputM.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0023-ozone-wayland-Handle-preedit-string-in-WaylandInputM.patch
@@ -1,0 +1,115 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1454297
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 965e49a055311624c7b47dbc41a0f61768a7f946 Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nickdiego@igalia.com>
+Date: Mon, 11 Feb 2019 03:04:33 +0000
+Subject: [PATCH 23/35] ozone/wayland: Handle preedit string in
+ WaylandInputMethodContext
+
+As of [1], UTF characteres are correctly composed on Ozone/wayland,
+taking as input raw key events from InputMethod classes. That is
+possible thanks to previously ChromeOS-only CharacterComposer component.
+This patch fixes the preedit text handling in WaylandInputMethodContext,
+which basically properly support HEX_MODE in CharacterComposer.
+
+[1] https://chromium-review.googlesource.com/c/chromium/src/+/1448136
+
+R=rjkroege@chromium.org, shuchen@chromium.org
+
+Bug: 921947
+Change-Id: I7cf750df2bf43273464f52a726719d50d74075f8
+Reviewed-on: https://chromium-review.googlesource.com/c/1454297
+Reviewed-by: Michael Spang <spang@chromium.org>
+Reviewed-by: Robert Kroeger <rjkroege@chromium.org>
+Reviewed-by: Shu Chen <shuchen@chromium.org>
+Commit-Queue: Nick Yamane <nickdiego@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#630679}
+---
+ ui/ozone/platform/wayland/DEPS                  |  1 +
+ .../wayland/wayland_input_method_context.cc     | 17 ++++++++++++++++-
+ .../wayland/wayland_input_method_context.h      |  5 +++++
+ 3 files changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/ui/ozone/platform/wayland/DEPS b/ui/ozone/platform/wayland/DEPS
+index df586f144773..89e965626cf0 100644
+--- a/ui/ozone/platform/wayland/DEPS
++++ b/ui/ozone/platform/wayland/DEPS
+@@ -4,6 +4,7 @@ include_rules = [
+   "+ui/base/ui_base_features.h",
+   "+ui/base/ime/character_composer.h",
+   "+ui/base/ime/composition_text.h",
++  "+ui/base/ime/ime_text_span.h",
+   "+ui/base/ime/linux/linux_input_method_context.h",
+   "+ui/base/ime/linux/linux_input_method_context_factory.h",
+   "+mojo/public",
+diff --git a/ui/ozone/platform/wayland/wayland_input_method_context.cc b/ui/ozone/platform/wayland/wayland_input_method_context.cc
+index f5e57bb3aab3..fadb28c260ca 100644
+--- a/ui/ozone/platform/wayland/wayland_input_method_context.cc
++++ b/ui/ozone/platform/wayland/wayland_input_method_context.cc
+@@ -10,6 +10,7 @@
+ #include "base/strings/string_util.h"
+ #include "base/strings/utf_string_conversions.h"
+ #include "ui/base/ime/composition_text.h"
++#include "ui/base/ime/ime_text_span.h"
+ #include "ui/events/base_event_utils.h"
+ #include "ui/events/event.h"
+ #include "ui/events/keycodes/dom/dom_code.h"
+@@ -74,13 +75,27 @@ bool WaylandInputMethodContext::DispatchKeyEvent(
+       !character_composer_.FilterKeyPress(key_event))
+     return false;
+ 
+-  // TODO(nickdiego): Handle preedit string
++  // CharacterComposer consumed the key event. Update the composition text.
++  UpdatePreeditText(character_composer_.preedit_string());
+   auto composed = character_composer_.composed_character();
+   if (!composed.empty())
+     delegate_->OnCommit(composed);
+   return true;
+ }
+ 
++void WaylandInputMethodContext::UpdatePreeditText(
++    const base::string16& preedit_text) {
++  CompositionText preedit;
++  preedit.text = preedit_text;
++  auto length = preedit.text.size();
++
++  preedit.selection = gfx::Range(length);
++  preedit.ime_text_spans.push_back(
++      ImeTextSpan(ImeTextSpan::Type::kComposition, 0, length,
++                  ImeTextSpan::Thickness::kThin, SK_ColorTRANSPARENT));
++  delegate_->OnPreeditChanged(preedit);
++}
++
+ void WaylandInputMethodContext::Reset() {
+   character_composer_.Reset();
+   if (text_input_)
+diff --git a/ui/ozone/platform/wayland/wayland_input_method_context.h b/ui/ozone/platform/wayland/wayland_input_method_context.h
+index 7fd0e9455299..bee874c609be 100644
+--- a/ui/ozone/platform/wayland/wayland_input_method_context.h
++++ b/ui/ozone/platform/wayland/wayland_input_method_context.h
+@@ -5,6 +5,9 @@
+ #ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_INPUT_METHOD_CONTEXT_H_
+ #define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_INPUT_METHOD_CONTEXT_H_
+ 
++#include <memory>
++#include <string>
++
+ #include "base/macros.h"
+ #include "ui/base/ime/character_composer.h"
+ #include "ui/base/ime/linux/linux_input_method_context.h"
+@@ -43,6 +46,8 @@ class WaylandInputMethodContext : public LinuxInputMethodContext,
+   void OnKeysym(uint32_t key, uint32_t state, uint32_t modifiers) override;
+ 
+  private:
++  void UpdatePreeditText(const base::string16& preedit_text);
++
+   WaylandConnection* connection_ = nullptr;  // TODO(jani) Handle this better
+ 
+   // Delegate interface back to IME code in ui.
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0024-ozone-wayland-Use-gbm-with-in-process-gpu-mode.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0024-ozone-wayland-Use-gbm-with-in-process-gpu-mode.patch
@@ -1,0 +1,215 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1463139
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 3ba2717a693e7b70e9cef60b916045f74cab0b17 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Tue, 12 Feb 2019 08:06:03 +0000
+Subject: [PATCH 24/35] [ozone/wayland] Use gbm with in-process-gpu mode
+
+This CL makes Ozone/Wayland use gbm with and without
+--in-process-gpu flag. Though, whenever gbm is not available and
+the mentioned flag is passed, a SurfaceViewGL will be used
+instead.
+
+By doing so, users can use NativeGpuMemory buffers whenever
+a separate gpu process is spawned or not.
+
+Bug: 928269
+Change-Id: I0db754e2d4d9e3ac93c361b5fcbba99287e4befb
+Reviewed-on: https://chromium-review.googlesource.com/c/1463139
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Reviewed-by: Robert Kroeger <rjkroege@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#631145}
+---
+ .../gpu/drm_render_node_path_finder.cc        |  9 ++--
+ .../wayland/gpu/drm_render_node_path_finder.h |  6 +--
+ .../wayland/gpu/gbm_pixmap_wayland.cc         |  7 ++-
+ .../wayland/gpu/wayland_connection_proxy.cc   |  9 ++--
+ .../wayland/ozone_platform_wayland.cc         | 47 ++++++++++---------
+ 5 files changed, 40 insertions(+), 38 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.cc b/ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.cc
+index c3367aeef5ec..c89309b6bab1 100644
+--- a/ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.cc
++++ b/ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.cc
+@@ -23,14 +23,13 @@ constexpr uint32_t kRenderNodeEnd = kRenderNodeStart + kDrmMaxMinor + 1;
+ 
+ }  // namespace
+ 
+-DrmRenderNodePathFinder::DrmRenderNodePathFinder() = default;
++DrmRenderNodePathFinder::DrmRenderNodePathFinder() {
++  FindDrmRenderNodePath();
++}
+ 
+ DrmRenderNodePathFinder::~DrmRenderNodePathFinder() = default;
+ 
+-base::FilePath DrmRenderNodePathFinder::GetDrmRenderNodePath() {
+-  if (drm_render_node_path_.empty())
+-    FindDrmRenderNodePath();
+-
++base::FilePath DrmRenderNodePathFinder::GetDrmRenderNodePath() const {
+   return drm_render_node_path_;
+ }
+ 
+diff --git a/ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.h b/ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.h
+index a6408e7b510b..0ea3be697293 100644
+--- a/ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.h
++++ b/ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.h
+@@ -13,12 +13,12 @@ namespace ui {
+ // A helper class that finds a DRM render node device and returns a path to it.
+ class DrmRenderNodePathFinder {
+  public:
++  // Triggers FindDrmRenderNodePath.
+   DrmRenderNodePathFinder();
+   ~DrmRenderNodePathFinder();
+ 
+-  // Returns a path to a drm render node device. If it hasn't been found yet,
+-  // triggers FindDrmRenderNodePath and returns the path.
+-  base::FilePath GetDrmRenderNodePath();
++  // Returns a path to a drm render node device.
++  base::FilePath GetDrmRenderNodePath() const;
+ 
+  private:
+   void FindDrmRenderNodePath();
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+index 6382310c6124..2c9a281fa667 100644
+--- a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
++++ b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+@@ -31,7 +31,8 @@ GbmPixmapWayland::GbmPixmapWayland(WaylandSurfaceFactory* surface_manager,
+     : surface_manager_(surface_manager), connection_(connection) {}
+ 
+ GbmPixmapWayland::~GbmPixmapWayland() {
+-  connection_->DestroyZwpLinuxDmabuf(GetUniqueId());
++  if (gbm_bo_)
++    connection_->DestroyZwpLinuxDmabuf(GetUniqueId());
+ }
+ 
+ bool GbmPixmapWayland::InitializeBuffer(gfx::Size size,
+@@ -39,6 +40,10 @@ bool GbmPixmapWayland::InitializeBuffer(gfx::Size size,
+                                         gfx::BufferUsage usage) {
+   TRACE_EVENT1("Wayland", "GbmPixmapWayland::InitializeBuffer", "size",
+                size.ToString());
++
++  if (!connection_->gbm_device())
++    return false;
++
+   uint32_t flags = 0;
+   switch (usage) {
+     case gfx::BufferUsage::GPU_READ:
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+index 226f6d42ccf8..a9f1e3fa7dce 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+@@ -13,8 +13,7 @@ namespace ui {
+ 
+ WaylandConnectionProxy::WaylandConnectionProxy(WaylandConnection* connection)
+     : connection_(connection),
+-      gpu_thread_runner_(connection_ ? nullptr
+-                                     : base::ThreadTaskRunnerHandle::Get()) {}
++      gpu_thread_runner_(base::ThreadTaskRunnerHandle::Get()) {}
+ 
+ WaylandConnectionProxy::~WaylandConnectionProxy() = default;
+ 
+@@ -124,12 +123,10 @@ intptr_t WaylandConnectionProxy::Display() {
+     return reinterpret_cast<intptr_t>(connection_->display());
+ 
+ #if defined(WAYLAND_GBM)
+-  // It must not be a single process mode. Thus, shared dmabuf approach is used,
+-  // which requires |gbm_device_|.
+-  DCHECK(gbm_device_);
+   return EGL_DEFAULT_DISPLAY;
+-#endif
++#else
+   return 0;
++#endif
+ }
+ 
+ void WaylandConnectionProxy::AddBindingWaylandConnectionClient(
+diff --git a/ui/ozone/platform/wayland/ozone_platform_wayland.cc b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+index 671c948323b1..5636df534525 100644
+--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
++++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+@@ -131,6 +131,11 @@ class OzonePlatformWayland : public OzonePlatform {
+ 
+   bool IsNativePixmapConfigSupported(gfx::BufferFormat format,
+                                      gfx::BufferUsage usage) const override {
++    // If there is no drm render node device available, native pixmaps are not
++    // supported.
++    if (path_finder_.GetDrmRenderNodePath().empty())
++      return false;
++
+     if (std::find(supported_buffer_formats_.begin(),
+                   supported_buffer_formats_.end(),
+                   format) == supported_buffer_formats_.end()) {
+@@ -153,11 +158,7 @@ class OzonePlatformWayland : public OzonePlatform {
+     if (!connection_->Initialize())
+       LOG(FATAL) << "Failed to initialize Wayland platform";
+ 
+-#if defined(WAYLAND_GBM)
+-    if (!args.single_process)
+-      connector_.reset(new WaylandConnectionConnector(connection_.get()));
+-#endif
+-
++    connector_.reset(new WaylandConnectionConnector(connection_.get()));
+     cursor_factory_.reset(new BitmapCursorFactoryOzone);
+     overlay_manager_.reset(new StubOverlayManager);
+     input_controller_ = CreateStubInputController();
+@@ -166,27 +167,23 @@ class OzonePlatformWayland : public OzonePlatform {
+   }
+ 
+   void InitializeGPU(const InitParams& args) override {
+-    if (!args.single_process) {
+-      proxy_.reset(new WaylandConnectionProxy(nullptr));
++    proxy_.reset(new WaylandConnectionProxy(connection_.get()));
+ #if defined(WAYLAND_GBM)
+-      DrmRenderNodePathFinder path_finder;
+-      const base::FilePath drm_node_path = path_finder.GetDrmRenderNodePath();
+-      if (drm_node_path.empty())
+-        LOG(FATAL) << "Failed to find drm render node path.";
+-
+-      DrmRenderNodeHandle handle;
+-      if (!handle.Initialize(drm_node_path))
+-        LOG(FATAL) << "Failed to initialize drm render node handle.";
+-
+-      auto gbm = CreateGbmDevice(handle.PassFD().release());
+-      if (!gbm)
+-        LOG(FATAL) << "Failed to initialize gbm device.";
+-
+-      proxy_->set_gbm_device(std::move(gbm));
+-#endif
++    const base::FilePath drm_node_path = path_finder_.GetDrmRenderNodePath();
++    if (drm_node_path.empty()) {
++      LOG(WARNING) << "Failed to find drm render node path.";
+     } else {
+-      proxy_.reset(new WaylandConnectionProxy(connection_.get()));
++      DrmRenderNodeHandle handle;
++      if (!handle.Initialize(drm_node_path)) {
++        LOG(WARNING) << "Failed to initialize drm render node handle.";
++      } else {
++        auto gbm = CreateGbmDevice(handle.PassFD().release());
++        if (!gbm)
++          LOG(WARNING) << "Failed to initialize gbm device.";
++        proxy_->set_gbm_device(std::move(gbm));
++      }
+     }
++#endif
+     surface_factory_.reset(new WaylandSurfaceFactory(proxy_.get()));
+   }
+ 
+@@ -225,6 +222,10 @@ class OzonePlatformWayland : public OzonePlatform {
+ 
+   std::vector<gfx::BufferFormat> supported_buffer_formats_;
+ 
++  // This is used both in the gpu and browser processes to find out if a drm
++  // render node is available.
++  DrmRenderNodePathFinder path_finder_;
++
+   DISALLOW_COPY_AND_ASSIGN(OzonePlatformWayland);
+ };
+ 
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0025-ozone-wayland-Make-buffer-manager-resistant-to-event.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0025-ozone-wayland-Make-buffer-manager-resistant-to-event.patch
@@ -1,0 +1,110 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1465781
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 4ac45bf260c16e6422d0a32d6e3b89d223e789fd Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nickdiego@igalia.com>
+Date: Wed, 13 Feb 2019 08:54:17 +0000
+Subject: [PATCH 25/35] ozone/wayland: Make buffer manager resistant to event
+ order deviations
+
+Currently WaylandBufferManager makes assumptions regarding the
+order that frame and presentation feedback events are fired,
+particularly frame callback is expected to come before each
+feedback presented/discarded call. However, some wayland compositors
+may not always fire Presentation and Frame events in the same order,
+Sway (https://swaywm.org) is a concrete example of this.
+
+This is causing crashes at startup in builds with dcheck_always_on
+and 'Context lost because SwapBuffers failed' errors with frequent
+crashes in release builds. To fix these issues, this CL modifies
+WaylandBufferManager, getting rid of the assumptions mentioned above
+thus making it more resistant to compositor implementation differences,
+etc.
+
+Bug: 931030
+Change-Id: I23dd3e1f442a4a754a0f8bb128acce39aeffe603
+Reviewed-on: https://chromium-review.googlesource.com/c/1465781
+Commit-Queue: Nick Diego Yamane <nickdiego@igalia.com>
+Reviewed-by: Maksim Sisov <msisov@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#631604}
+---
+ .../wayland/wayland_buffer_manager.cc         | 35 +++++++++++++------
+ 1 file changed, 24 insertions(+), 11 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/wayland_buffer_manager.cc b/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+index 405424951c98..089c006d2f4b 100644
+--- a/ui/ozone/platform/wayland/wayland_buffer_manager.cc
++++ b/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+@@ -407,13 +407,16 @@ void WaylandBufferManager::FrameCallbackDone(void* data,
+       buffer->swap_result = gfx::SwapResult::SWAP_ACK;
+       buffer->wl_frame_callback.reset();
+ 
+-      // If presentation feedback is not supported, use fake feedback and
+-      // trigger the callback.
++      // If presentation feedback is not supported, use a fake feedback
+       if (!self->connection_->presentation()) {
+         buffer->feedback = gfx::PresentationFeedback(base::TimeTicks::Now(),
+                                                      base::TimeDelta(), 0);
+-        self->OnBufferSwapped(buffer);
+       }
++      // If presentation feedback event either has already been fired or
++      // has not been set, trigger swap callback.
++      if (!buffer->wp_presentation_feedback)
++        self->OnBufferSwapped(buffer);
++
+       return;
+     }
+   }
+@@ -446,16 +449,20 @@ void WaylandBufferManager::FeedbackPresented(
+   for (auto& item : self->buffers_) {
+     Buffer* buffer = item.second.get();
+     if (buffer->wp_presentation_feedback.get() == wp_presentation_feedback) {
+-      // Frame callback must come before a feedback is presented.
+-      DCHECK(!buffer->wl_frame_callback);
+-
+       buffer->feedback = gfx::PresentationFeedback(
+           GetPresentationFeedbackTimeStamp(tv_sec_hi, tv_sec_lo, tv_nsec),
+           base::TimeDelta::FromNanoseconds(refresh),
+           GetPresentationKindFlags(flags));
+-
+       buffer->wp_presentation_feedback.reset();
+-      self->OnBufferSwapped(buffer);
++
++      // Some compositors not always fire PresentationFeedback and Frame
++      // events in the same order (i.e, frame callbacks coming always before
++      // feedback presented/discaded ones). So, check FrameCallbackDone has
++      // already been called at this point, if yes, trigger the swap callback.
++      // otherwise it will be triggered in the upcoming frame callback.
++      if (!buffer->wl_frame_callback)
++        self->OnBufferSwapped(buffer);
++
+       return;
+     }
+   }
+@@ -474,11 +481,17 @@ void WaylandBufferManager::FeedbackDiscarded(
+     Buffer* buffer = item.second.get();
+     if (buffer->wp_presentation_feedback.get() == wp_presentation_feedback) {
+       // Frame callback must come before a feedback is presented.
+-      DCHECK(!buffer->wl_frame_callback);
+       buffer->feedback = gfx::PresentationFeedback::Failure();
+-
+       buffer->wp_presentation_feedback.reset();
+-      self->OnBufferSwapped(buffer);
++
++      // Some compositors not always fire PresentationFeedback and Frame
++      // events in the same order (i.e, frame callbacks coming always before
++      // feedback presented/discaded ones). So, check FrameCallbackDone has
++      // already been called at this point, if yes, trigger the swap callback.
++      // Otherwise it will be triggered in the upcoming frame callback.
++      if (!buffer->wl_frame_callback)
++        self->OnBufferSwapped(buffer);
++
+       return;
+     }
+   }
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0026-ozone-wayland-Reuse-tooltip-subsurfaces.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0026-ozone-wayland-Reuse-tooltip-subsurfaces.patch
@@ -1,0 +1,131 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1466063
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 727a465936673a2ab8ec8ed990807e54ac65088e Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nickdiego@igalia.com>
+Date: Wed, 13 Feb 2019 09:00:06 +0000
+Subject: [PATCH 26/35] ozone/wayland: Reuse tooltip subsurfaces
+
+This patch modifies WaylandWindow so that it reuses
+tooltip subsurfaces instead of recreating/destroying them
+every time show/hide functions are called.
+This change aims to boost performance of tooltips creation
+since we avoid recreating subsurfaces so frequently.
+Additionally, this avoids crashing compositors such as Sway
+[1], which is getting pretty popular and is known to have
+buggy implementation of subsurfaces handling [2]. For example,
+some sway crashes have been observed after focus -> unfocus ->
+focus again buttons with tooltips for example. This kind of issue
+haven't been observed anymore after this change.
+
+[1] https://swaywm.org
+[2] https://github.com/swaywm/sway/issues/3195
+
+Bug: 578890
+Change-Id: Ic27fb491c446f30f3d60633f4216b56799463896
+Reviewed-on: https://chromium-review.googlesource.com/c/1466063
+Commit-Queue: Nick Diego Yamane <nickdiego@igalia.com>
+Reviewed-by: Maksim Sisov <msisov@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#631605}
+---
+ ui/ozone/platform/wayland/wayland_window.cc | 28 +++++++++++----------
+ ui/ozone/platform/wayland/wayland_window.h  |  5 ++--
+ 2 files changed, 18 insertions(+), 15 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/wayland_window.cc b/ui/ozone/platform/wayland/wayland_window.cc
+index 32bf9bfea091..1e6b4648b8ff 100644
+--- a/ui/ozone/platform/wayland/wayland_window.cc
++++ b/ui/ozone/platform/wayland/wayland_window.cc
+@@ -189,7 +189,7 @@ void WaylandWindow::CreateXdgSurface() {
+   }
+ }
+ 
+-void WaylandWindow::CreateTooltipSubSurface() {
++void WaylandWindow::CreateAndShowTooltipSubSurface() {
+   // Since Aura does not not provide a reference parent window, needed by
+   // Wayland, we get the current focused window to place and show the tooltips.
+   parent_window_ = connection_->GetCurrentFocusedWindow();
+@@ -203,11 +203,14 @@ void WaylandWindow::CreateTooltipSubSurface() {
+     return;
+   }
+ 
+-  wl_subcompositor* subcompositor = connection_->subcompositor();
+-  DCHECK(subcompositor);
+-  tooltip_subsurface_.reset(wl_subcompositor_get_subsurface(
+-      subcompositor, surface_.get(), parent_window_->surface()));
++  if (!tooltip_subsurface_) {
++    wl_subcompositor* subcompositor = connection_->subcompositor();
++    DCHECK(subcompositor);
++    tooltip_subsurface_.reset(wl_subcompositor_get_subsurface(
++        subcompositor, surface_.get(), parent_window_->surface()));
++  }
+ 
++  DCHECK(tooltip_subsurface_);
+   wl_subsurface_set_position(tooltip_subsurface_.get(), bounds_.x(),
+                              bounds_.y());
+   wl_subsurface_set_desync(tooltip_subsurface_.get());
+@@ -256,11 +259,12 @@ void WaylandWindow::Show() {
+ 
+   if (xdg_surface_)
+     return;
++
+   if (is_tooltip_) {
+-    if (!tooltip_subsurface_)
+-      CreateTooltipSubSurface();
++    CreateAndShowTooltipSubSurface();
+     return;
+   }
++
+   if (!xdg_popup_) {
+     CreateXdgPopup();
+     connection_->ScheduleFlush();
+@@ -272,14 +276,12 @@ void WaylandWindow::Hide() {
+     parent_window_ = nullptr;
+     wl_surface_attach(surface_.get(), NULL, 0, 0);
+     wl_surface_commit(surface_.get());
+-    // Tooltip subsurface must be reset only after the buffer is detached.
+-    // Otherwise, gnome shell, for example, can end up with a broken event
+-    // pipe.
+-    tooltip_subsurface_.reset();
+     return;
+   }
++
+   if (child_window_)
+     child_window_->Hide();
++
+   if (xdg_popup_) {
+     parent_window_->set_child_window(nullptr);
+     xdg_popup_.reset();
+@@ -671,8 +673,8 @@ void WaylandWindow::AddEnteredOutputId(struct wl_output* output) {
+   const uint32_t entered_output_id =
+       connection_->wayland_output_manager()->GetIdForOutput(output);
+   DCHECK_NE(entered_output_id, 0u);
+-  auto entered_output_id_it = entered_outputs_ids_.insert(entered_output_id);
+-  DCHECK(entered_output_id_it.second);
++  auto result = entered_outputs_ids_.insert(entered_output_id);
++  DCHECK(result.first != entered_outputs_ids_.end());
+ }
+ 
+ void WaylandWindow::RemoveEnteredOutputId(struct wl_output* output) {
+diff --git a/ui/ozone/platform/wayland/wayland_window.h b/ui/ozone/platform/wayland/wayland_window.h
+index dc5fa34a766e..1b6a5bd910f2 100644
+--- a/ui/ozone/platform/wayland/wayland_window.h
++++ b/ui/ozone/platform/wayland/wayland_window.h
+@@ -156,8 +156,9 @@ class WaylandWindow : public PlatformWindow,
+   void CreateXdgPopup();
+   // Creates a surface window, which is visible as a main window.
+   void CreateXdgSurface();
+-  // Creates a subsurface window, to host tooltip's content.
+-  void CreateTooltipSubSurface();
++  // Creates (if necessary) and show subsurface window, to host
++  // tooltip's content.
++  void CreateAndShowTooltipSubSurface();
+ 
+   // Gets a parent window for this window.
+   WaylandWindow* GetParentWindow(gfx::AcceleratedWidget parent_widget);
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0027-ozone-Implement-receiving-dragging.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0027-ozone-Implement-receiving-dragging.patch
@@ -1,0 +1,568 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1353040
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 4c3eeb812482c1c0cf26d0922e5df6f91234cae5 Mon Sep 17 00:00:00 2001
+From: Julie Jeongeun Kim <jkim@igalia.com>
+Date: Thu, 14 Feb 2019 04:26:20 +0000
+Subject: [PATCH 27/35] [ozone] Implement receiving dragging
+
+It adds the implementation of receiving dragging. In order to
+communicate between the platform and Ozone, it adds WmDropHandler
+and it's registered with PlatformWindow. Once the dragging event
+occurs from the platform layer, it finds WmDropHandler using
+PlatformWindow and delivers the event to DesktopDragDropClientOzone.
+After DesktopDragDropClientOzone gets the event, it finds the proper
+aura::client::DragDropDelegate based on the position where the event
+occurs and passes the event and the dragged data to it.
+
+Bug: 875164
+Test: DesktopDragDropClientOzoneTest.ReceiveDrag
+Change-Id: I2f9966d0224a5171cf1e50c23634d54c6cb44c1f
+Reviewed-on: https://chromium-review.googlesource.com/c/1353040
+Commit-Queue: Julie Jeongeun Kim <jkim@igalia.com>
+Reviewed-by: Sadrul Chowdhury <sadrul@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#632077}
+---
+ .../platform/wayland/wayland_connection.cc    |   4 +
+ .../platform/wayland/wayland_connection.h     |   3 +
+ .../platform/wayland/wayland_data_device.h    |   2 +
+ ui/ozone/platform/wayland/wayland_window.cc   |  37 ++++-
+ .../platform_window_handler/BUILD.gn          |   2 +
+ .../wm_drop_handler.cc                        |  25 ++++
+ .../platform_window_handler/wm_drop_handler.h |  55 ++++++++
+ .../desktop_drag_drop_client_ozone.cc         | 131 ++++++++++++++++++
+ .../desktop_drag_drop_client_ozone.h          |  53 ++++++-
+ .../desktop_window_tree_host_platform.cc      |  10 +-
+ 10 files changed, 312 insertions(+), 10 deletions(-)
+ create mode 100644 ui/platform_window/platform_window_handler/wm_drop_handler.cc
+ create mode 100644 ui/platform_window/platform_window_handler/wm_drop_handler.h
+
+diff --git a/ui/ozone/platform/wayland/wayland_connection.cc b/ui/ozone/platform/wayland/wayland_connection.cc
+index 6fbe0515c1f8..c03b963f5b45 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/wayland_connection.cc
+@@ -308,6 +308,10 @@ void WaylandConnection::RequestDragData(
+   data_device_->RequestDragData(mime_type, std::move(callback));
+ }
+ 
++bool WaylandConnection::IsDragInProgress() {
++  return data_device_->IsDragEntered() || drag_data_source();
++}
++
+ void WaylandConnection::ResetPointerFlags() {
+   if (pointer_)
+     pointer_->ResetFlags();
+diff --git a/ui/ozone/platform/wayland/wayland_connection.h b/ui/ozone/platform/wayland/wayland_connection.h
+index cbb8d4f242bc..cfa0c92832a4 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.h
++++ b/ui/ozone/platform/wayland/wayland_connection.h
+@@ -158,6 +158,9 @@ class WaylandConnection : public PlatformEventSource,
+   void RequestDragData(const std::string& mime_type,
+                        base::OnceCallback<void(const std::string&)> callback);
+ 
++  // Returns true when dragging is entered or started.
++  bool IsDragInProgress();
++
+   // Resets flags and keyboard modifiers.
+   //
+   // This method is specially handy for cases when the WaylandPointer state is
+diff --git a/ui/ozone/platform/wayland/wayland_data_device.h b/ui/ozone/platform/wayland/wayland_data_device.h
+index f09867092469..c3953993e08b 100644
+--- a/ui/ozone/platform/wayland/wayland_data_device.h
++++ b/ui/ozone/platform/wayland/wayland_data_device.h
+@@ -58,6 +58,8 @@ class WaylandDataDevice {
+ 
+   wl_data_device* data_device() const { return data_device_.get(); }
+ 
++  bool IsDragEntered() { return drag_offer_ != nullptr; }
++
+  private:
+   void ReadClipboardDataFromFD(base::ScopedFD fd, const std::string& mime_type);
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_window.cc b/ui/ozone/platform/wayland/wayland_window.cc
+index 1e6b4648b8ff..d400c61161e7 100644
+--- a/ui/ozone/platform/wayland/wayland_window.cc
++++ b/ui/ozone/platform/wayland/wayland_window.cc
+@@ -25,6 +25,7 @@
+ #include "ui/ozone/platform/wayland/xdg_popup_wrapper_v6.h"
+ #include "ui/ozone/platform/wayland/xdg_surface_wrapper_v5.h"
+ #include "ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h"
++#include "ui/platform_window/platform_window_handler/wm_drop_handler.h"
+ #include "ui/platform_window/platform_window_init_properties.h"
+ 
+ namespace ui {
+@@ -167,6 +168,19 @@ void WaylandWindow::CreateXdgPopup() {
+   if (bounds_.IsEmpty())
+     return;
+ 
++  // TODO(jkim): Consider how to support DropArrow window on tabstrip.
++  // When it starts dragging, as described the protocol, https://goo.gl/1Mskq3,
++  // the client must have an active implicit grab. If we try to create a popup
++  // window while dragging is executed, it gets 'popup_done' directly from
++  // Wayland compositor and it's destroyed through 'popup_done'. It causes
++  // a crash when aura::Window is destroyed.
++  // https://crbug.com/875164
++  if (connection_->IsDragInProgress()) {
++    surface_.reset();
++    LOG(ERROR) << "Wayland can't create a popup window during dragging.";
++    return;
++  }
++
+   DCHECK(parent_window_ && !xdg_popup_);
+ 
+   gfx::Rect bounds =
+@@ -593,26 +607,39 @@ void WaylandWindow::OnCloseRequest() {
+ void WaylandWindow::OnDragEnter(const gfx::PointF& point,
+                                 std::unique_ptr<OSExchangeData> data,
+                                 int operation) {
+-  NOTIMPLEMENTED_LOG_ONCE();
++  WmDropHandler* drop_handler = GetWmDropHandler(*this);
++  if (!drop_handler)
++    return;
++  drop_handler->OnDragEnter(point, std::move(data), operation);
+ }
+ 
+ int WaylandWindow::OnDragMotion(const gfx::PointF& point,
+                                 uint32_t time,
+                                 int operation) {
+-  NOTIMPLEMENTED_LOG_ONCE();
+-  return 0;
++  WmDropHandler* drop_handler = GetWmDropHandler(*this);
++  if (!drop_handler)
++    return 0;
++
++  return drop_handler->OnDragMotion(point, operation);
+ }
+ 
+ void WaylandWindow::OnDragDrop(std::unique_ptr<OSExchangeData> data) {
+-  NOTIMPLEMENTED_LOG_ONCE();
++  WmDropHandler* drop_handler = GetWmDropHandler(*this);
++  if (!drop_handler)
++    return;
++  drop_handler->OnDragDrop(std::move(data));
+ }
+ 
+ void WaylandWindow::OnDragLeave() {
+-  NOTIMPLEMENTED_LOG_ONCE();
++  WmDropHandler* drop_handler = GetWmDropHandler(*this);
++  if (!drop_handler)
++    return;
++  drop_handler->OnDragLeave();
+ }
+ 
+ void WaylandWindow::OnDragSessionClose(uint32_t dnd_action) {
+   std::move(drag_closed_callback_).Run(dnd_action);
++  connection_->ResetPointerFlags();
+ }
+ 
+ bool WaylandWindow::IsMinimized() const {
+diff --git a/ui/platform_window/platform_window_handler/BUILD.gn b/ui/platform_window/platform_window_handler/BUILD.gn
+index 65ea155a800f..10e53a486463 100644
+--- a/ui/platform_window/platform_window_handler/BUILD.gn
++++ b/ui/platform_window/platform_window_handler/BUILD.gn
+@@ -10,6 +10,8 @@ jumbo_component("platform_window_handler") {
+   sources = [
+     "wm_drag_handler.cc",
+     "wm_drag_handler.h",
++    "wm_drop_handler.cc",
++    "wm_drop_handler.h",
+     "wm_move_resize_handler.cc",
+     "wm_move_resize_handler.h",
+     "wm_platform_export.h",
+diff --git a/ui/platform_window/platform_window_handler/wm_drop_handler.cc b/ui/platform_window/platform_window_handler/wm_drop_handler.cc
+new file mode 100644
+index 000000000000..27cf71abeea2
+--- /dev/null
++++ b/ui/platform_window/platform_window_handler/wm_drop_handler.cc
+@@ -0,0 +1,25 @@
++// Copyright 2019 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "ui/platform_window/platform_window_handler/wm_drop_handler.h"
++
++#include "ui/base/class_property.h"
++#include "ui/platform_window/platform_window.h"
++
++DEFINE_UI_CLASS_PROPERTY_TYPE(ui::WmDropHandler*)
++
++namespace ui {
++
++DEFINE_UI_CLASS_PROPERTY_KEY(WmDropHandler*, kWmDropHandlerKey, nullptr);
++
++void SetWmDropHandler(PlatformWindow* platform_window,
++                      WmDropHandler* drop_handler) {
++  platform_window->SetProperty(kWmDropHandlerKey, drop_handler);
++}
++
++WmDropHandler* GetWmDropHandler(const PlatformWindow& platform_window) {
++  return platform_window.GetProperty(kWmDropHandlerKey);
++}
++
++}  // namespace ui
+diff --git a/ui/platform_window/platform_window_handler/wm_drop_handler.h b/ui/platform_window/platform_window_handler/wm_drop_handler.h
+new file mode 100644
+index 000000000000..768d9e342869
+--- /dev/null
++++ b/ui/platform_window/platform_window_handler/wm_drop_handler.h
+@@ -0,0 +1,55 @@
++// Copyright 2019 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef UI_PLATFORM_WINDOW_PLATFORM_WINDOW_HANDLER_WM_DROP_HANDLER_H_
++#define UI_PLATFORM_WINDOW_PLATFORM_WINDOW_HANDLER_WM_DROP_HANDLER_H_
++
++#include <memory>
++
++#include "ui/gfx/native_widget_types.h"
++#include "ui/platform_window/platform_window_handler/wm_platform_export.h"
++
++namespace gfx {
++class PointF;
++}
++
++namespace ui {
++class OSExchangeData;
++class PlatformWindow;
++
++class WM_PLATFORM_EXPORT WmDropHandler {
++ public:
++  // Notifies that dragging is entered to the window. |point| is in the
++  // coordinate space of the PlatformWindow.
++  virtual void OnDragEnter(const gfx::PointF& point,
++                           std::unique_ptr<OSExchangeData> data,
++                           int operation) = 0;
++
++  // Notifies that dragging is moved. |widget_out| will be set with the
++  // widget located at |point|. |point| is in the coordinate space of the
++  // PlatformWindow. It returns the operation selected by client and the
++  // returned value should be from ui::DragDropTypes.
++  virtual int OnDragMotion(const gfx::PointF& point, int operation) = 0;
++
++  // Notifies that dragged data is dropped. When it doesn't deliver
++  // the dragged data on OnDragEnter, it should put it to |data|. The location
++  // of the drop is the location of the latest DragEnter/DragMotion. If
++  // OSExchangeData is provided on OnDragEnter, the |data| should be same as it.
++  virtual void OnDragDrop(std::unique_ptr<ui::OSExchangeData> data) = 0;
++
++  // Notifies that dragging is left.
++  virtual void OnDragLeave() = 0;
++
++ protected:
++  virtual ~WmDropHandler() {}
++};
++
++WM_PLATFORM_EXPORT void SetWmDropHandler(PlatformWindow* platform_window,
++                                         WmDropHandler* drop_handler);
++WM_PLATFORM_EXPORT WmDropHandler* GetWmDropHandler(
++    const PlatformWindow& platform_window);
++
++}  // namespace ui
++
++#endif  // UI_PLATFORM_WINDOW_PLATFORM_WINDOW_HANDLER_WM_DROP_HANDLER_H_
+diff --git a/ui/views/widget/desktop_aura/desktop_drag_drop_client_ozone.cc b/ui/views/widget/desktop_aura/desktop_drag_drop_client_ozone.cc
+index a5bf57fce896..dfe5f9a9f707 100644
+--- a/ui/views/widget/desktop_aura/desktop_drag_drop_client_ozone.cc
++++ b/ui/views/widget/desktop_aura/desktop_drag_drop_client_ozone.cc
+@@ -4,12 +4,21 @@
+ 
+ #include "ui/views/widget/desktop_aura/desktop_drag_drop_client_ozone.h"
+ 
++#include <memory>
++
+ #include "base/bind.h"
+ #include "base/run_loop.h"
++#include "base/strings/string16.h"
++#include "base/strings/utf_string_conversions.h"
++#include "base/threading/thread_task_runner_handle.h"
+ #include "ui/aura/client/capture_client.h"
+ #include "ui/aura/client/cursor_client.h"
++#include "ui/aura/client/drag_drop_delegate.h"
+ #include "ui/aura/window.h"
+ #include "ui/aura/window_tree_host.h"
++#include "ui/base/clipboard/clipboard.h"
++#include "ui/base/dragdrop/drag_drop_types.h"
++#include "ui/base/dragdrop/drop_target_event.h"
+ #include "ui/base/dragdrop/os_exchange_data_provider_aura.h"
+ #include "ui/platform_window/platform_window_delegate.h"
+ #include "ui/platform_window/platform_window_handler/wm_drag_handler.h"
+@@ -17,6 +26,17 @@
+ 
+ namespace views {
+ 
++namespace {
++
++aura::Window* GetTargetWindow(aura::Window* root_window,
++                              const gfx::Point& point) {
++  gfx::Point root_location(point);
++  root_window->GetHost()->ConvertScreenInPixelsToDIP(&root_location);
++  return root_window->GetEventHandlerForPoint(root_location);
++}
++
++}  // namespace
++
+ DesktopDragDropClientOzone::DesktopDragDropClientOzone(
+     aura::Window* root_window,
+     views::DesktopNativeCursorManager* cursor_manager,
+@@ -26,6 +46,8 @@ DesktopDragDropClientOzone::DesktopDragDropClientOzone(
+       drag_handler_(drag_handler) {}
+ 
+ DesktopDragDropClientOzone::~DesktopDragDropClientOzone() {
++  ResetDragDropTarget();
++
+   if (in_move_loop_)
+     DragCancel();
+ }
+@@ -86,6 +108,70 @@ void DesktopDragDropClientOzone::RemoveObserver(
+   NOTIMPLEMENTED_LOG_ONCE();
+ }
+ 
++void DesktopDragDropClientOzone::OnDragEnter(
++    const gfx::PointF& point,
++    std::unique_ptr<ui::OSExchangeData> data,
++    int operation) {
++  last_drag_point_ = point;
++  drag_operation_ = operation;
++
++  // If it doesn't have |data|, it defers sending events to
++  // |drag_drop_delegate_|. It will try again before handling drop.
++  if (!data)
++    return;
++
++  os_exchange_data_ = std::move(data);
++  std::unique_ptr<ui::DropTargetEvent> event = CreateDropTargetEvent(point);
++  if (drag_drop_delegate_ && event)
++    drag_drop_delegate_->OnDragEntered(*event);
++}
++
++int DesktopDragDropClientOzone::OnDragMotion(const gfx::PointF& point,
++                                             int operation) {
++  last_drag_point_ = point;
++  drag_operation_ = operation;
++  int client_operation =
++      ui::DragDropTypes::DRAG_COPY | ui::DragDropTypes::DRAG_MOVE;
++
++  if (os_exchange_data_) {
++    std::unique_ptr<ui::DropTargetEvent> event = CreateDropTargetEvent(point);
++    // If |os_exchange_data_| has a valid data, |drag_drop_delegate_| returns
++    // the operation which it expects.
++    if (drag_drop_delegate_ && event)
++      client_operation = drag_drop_delegate_->OnDragUpdated(*event);
++  }
++  return client_operation;
++}
++
++void DesktopDragDropClientOzone::OnDragDrop(
++    std::unique_ptr<ui::OSExchangeData> data) {
++  // If it doesn't have |os_exchange_data_|, it needs to update it with |data|.
++  if (!os_exchange_data_) {
++    DCHECK(data);
++    os_exchange_data_ = std::move(data);
++    std::unique_ptr<ui::DropTargetEvent> event =
++        CreateDropTargetEvent(last_drag_point_);
++    // Sends the deferred drag events to |drag_drop_delegate_| before handling
++    // drop.
++    if (drag_drop_delegate_ && event) {
++      drag_drop_delegate_->OnDragEntered(*event);
++      // TODO(jkim): It doesn't use the return value from 'OnDragUpdated' and
++      // doesn't have a chance to update the expected operation.
++      // https://crbug.com/875164
++      drag_drop_delegate_->OnDragUpdated(*event);
++    }
++  } else {
++    // If it has |os_exchange_data_|, it doesn't expect |data| on OnDragDrop.
++    DCHECK(!data);
++  }
++  PerformDrop();
++}
++
++void DesktopDragDropClientOzone::OnDragLeave() {
++  os_exchange_data_.reset();
++  ResetDragDropTarget();
++}
++
+ void DesktopDragDropClientOzone::OnDragSessionClosed(int dnd_action) {
+   drag_operation_ = dnd_action;
+   QuitRunLoop();
+@@ -107,4 +193,49 @@ void DesktopDragDropClientOzone::QuitRunLoop() {
+   std::move(quit_closure_).Run();
+ }
+ 
++std::unique_ptr<ui::DropTargetEvent>
++DesktopDragDropClientOzone::CreateDropTargetEvent(const gfx::PointF& location) {
++  const gfx::Point point(location.x(), location.y());
++  aura::Window* window = GetTargetWindow(root_window_, point);
++  if (!window)
++    return nullptr;
++
++  UpdateDragDropDelegate(window);
++  gfx::Point root_location(location.x(), location.y());
++  root_window_->GetHost()->ConvertScreenInPixelsToDIP(&root_location);
++  gfx::PointF target_location(root_location);
++  aura::Window::ConvertPointToTarget(root_window_, window, &target_location);
++
++  return std::make_unique<ui::DropTargetEvent>(
++      *os_exchange_data_, target_location, gfx::PointF(root_location),
++      drag_operation_);
++}
++
++void DesktopDragDropClientOzone::UpdateDragDropDelegate(aura::Window* window) {
++  aura::client::DragDropDelegate* delegate =
++      aura::client::GetDragDropDelegate(window);
++
++  if (drag_drop_delegate_ == delegate)
++    return;
++
++  ResetDragDropTarget();
++  if (delegate)
++    drag_drop_delegate_ = delegate;
++}
++
++void DesktopDragDropClientOzone::ResetDragDropTarget() {
++  if (!drag_drop_delegate_)
++    return;
++  drag_drop_delegate_->OnDragExited();
++  drag_drop_delegate_ = nullptr;
++}
++
++void DesktopDragDropClientOzone::PerformDrop() {
++  std::unique_ptr<ui::DropTargetEvent> event =
++      CreateDropTargetEvent(last_drag_point_);
++  if (drag_drop_delegate_ && event)
++    drag_operation_ = drag_drop_delegate_->OnPerformDrop(*event);
++  DragDropSessionCompleted();
++}
++
+ }  // namespace views
+diff --git a/ui/views/widget/desktop_aura/desktop_drag_drop_client_ozone.h b/ui/views/widget/desktop_aura/desktop_drag_drop_client_ozone.h
+index e3632a7a7b09..e31f41ba49ee 100644
+--- a/ui/views/widget/desktop_aura/desktop_drag_drop_client_ozone.h
++++ b/ui/views/widget/desktop_aura/desktop_drag_drop_client_ozone.h
+@@ -5,25 +5,40 @@
+ #ifndef UI_VIEWS_WIDGET_DESKTOP_AURA_DESKTOP_DRAG_DROP_CLIENT_OZONE_H_
+ #define UI_VIEWS_WIDGET_DESKTOP_AURA_DESKTOP_DRAG_DROP_CLIENT_OZONE_H_
+ 
++#include <memory>
++
+ #include "base/callback.h"
+ #include "ui/aura/client/drag_drop_client.h"
+ #include "ui/base/cursor/cursor.h"
++#include "ui/base/dragdrop/os_exchange_data.h"
++#include "ui/gfx/geometry/point_f.h"
++#include "ui/gfx/native_widget_types.h"
+ #include "ui/platform_window/platform_window_handler/wm_drag_handler.h"
++#include "ui/platform_window/platform_window_handler/wm_drop_handler.h"
+ #include "ui/views/views_export.h"
+ 
++namespace aura {
++namespace client {
++class DragDropDelegate;
++}
++}  // namespace aura
++
++namespace ui {
++class DropTargetEvent;
++}
++
+ namespace views {
+ class DesktopNativeCursorManager;
+ 
+ class VIEWS_EXPORT DesktopDragDropClientOzone
+-    : public aura::client::DragDropClient {
++    : public aura::client::DragDropClient,
++      public ui::WmDropHandler {
+  public:
+   DesktopDragDropClientOzone(aura::Window* root_window,
+                              views::DesktopNativeCursorManager* cursor_manager,
+                              ui::WmDragHandler* drag_handler);
+   ~DesktopDragDropClientOzone() override;
+ 
+-  void OnDragSessionClosed(int operation);
+-
+   // Overridden from aura::client::DragDropClient:
+   int StartDragAndDrop(const ui::OSExchangeData& data,
+                        aura::Window* root_window,
+@@ -36,16 +51,48 @@ class VIEWS_EXPORT DesktopDragDropClientOzone
+   void AddObserver(aura::client::DragDropClientObserver* observer) override;
+   void RemoveObserver(aura::client::DragDropClientObserver* observer) override;
+ 
++  // Overridden from void ui::WmDropHandler:
++  void OnDragEnter(const gfx::PointF& point,
++                   std::unique_ptr<ui::OSExchangeData> data,
++                   int operation) override;
++  int OnDragMotion(const gfx::PointF& point, int operation) override;
++  void OnDragDrop(std::unique_ptr<ui::OSExchangeData> data) override;
++  void OnDragLeave() override;
++
++  void OnDragSessionClosed(int operation);
++
+  private:
+   void DragDropSessionCompleted();
+   void QuitRunLoop();
+ 
++  // Returns a DropTargetEvent to be passed to the DragDropDelegate, or null to
++  // abort the drag.
++  std::unique_ptr<ui::DropTargetEvent> CreateDropTargetEvent(
++      const gfx::PointF& point);
++
++  // Updates |drag_drop_delegate_| along with |window|.
++  void UpdateDragDropDelegate(aura::Window* window);
++
++  // Resets |drag_drop_delegate_|.
++  void ResetDragDropTarget();
++
++  void PerformDrop();
++
+   aura::Window* const root_window_;
+ 
+   DesktopNativeCursorManager* cursor_manager_;
+ 
+   ui::WmDragHandler* const drag_handler_;
+ 
++  // The delegate corresponding to the window located at the mouse position.
++  aura::client::DragDropDelegate* drag_drop_delegate_ = nullptr;
++
++  // The data to be delivered through the drag and drop.
++  std::unique_ptr<ui::OSExchangeData> os_exchange_data_ = nullptr;
++
++  // The most recent native coordinates of a drag.
++  gfx::PointF last_drag_point_;
++
+   // Cursor in use prior to the move loop starting. Restored when the move loop
+   // quits.
+   gfx::NativeCursor initial_cursor_;
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+index 72d04d0595b0..70c99aae8934 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+@@ -126,8 +126,13 @@ std::unique_ptr<aura::client::DragDropClient>
+ DesktopWindowTreeHostPlatform::CreateDragDropClient(
+     DesktopNativeCursorManager* cursor_manager) {
+   ui::WmDragHandler* drag_handler = ui::GetWmDragHandler(*(platform_window()));
+-  return std::make_unique<DesktopDragDropClientOzone>(window(), cursor_manager,
+-                                                      drag_handler);
++  std::unique_ptr<DesktopDragDropClientOzone> drag_drop_client =
++      std::make_unique<DesktopDragDropClientOzone>(window(), cursor_manager,
++                                                   drag_handler);
++  // Set a class property key, which allows |drag_drop_client| to be used for
++  // drop action.
++  SetWmDropHandler(platform_window(), drag_drop_client.get());
++  return std::move(drag_drop_client);
+ }
+ 
+ void DesktopWindowTreeHostPlatform::Close() {
+@@ -149,6 +154,7 @@ void DesktopWindowTreeHostPlatform::Close() {
+ 
+ void DesktopWindowTreeHostPlatform::CloseNow() {
+   auto weak_ref = weak_factory_.GetWeakPtr();
++  SetWmDropHandler(platform_window(), nullptr);
+   // Deleting the PlatformWindow may not result in OnClosed() being called, if
+   // not behave as though it was.
+   SetPlatformWindow(nullptr);
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0028-ozone-wayland-Fix-includes-and-deps.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0028-ozone-wayland-Fix-includes-and-deps.patch
@@ -1,0 +1,86 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1477126
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 0cda2f5bf108e664565fcb2a00dfd2b2247dc1b2 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Tue, 19 Feb 2019 12:35:00 +0000
+Subject: [PATCH 28/35] [ozone/wayland] Fix includes and deps.
+
+Fix BUILD.gn includes and headers usages.
+
+Bug: 578890
+Change-Id: Ib8a7626f74d58f7584c8c44aff7f69a512c39a6d
+Reviewed-on: https://chromium-review.googlesource.com/c/1477126
+Reviewed-by: Antonio Gomes <tonikitoo@igalia.com>
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#633234}
+---
+ ui/ozone/platform/wayland/BUILD.gn                  | 7 +++----
+ ui/ozone/platform/wayland/ozone_platform_wayland.cc | 2 +-
+ 2 files changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/BUILD.gn b/ui/ozone/platform/wayland/BUILD.gn
+index c5e8783cd350..d98c4474a877 100644
+--- a/ui/ozone/platform/wayland/BUILD.gn
++++ b/ui/ozone/platform/wayland/BUILD.gn
+@@ -18,6 +18,8 @@ source_set("wayland") {
+     "client_native_pixmap_factory_wayland.h",
+     "gl_surface_wayland.cc",
+     "gl_surface_wayland.h",
++    "gpu/drm_render_node_path_finder.cc",
++    "gpu/drm_render_node_path_finder.h",
+     "gpu/wayland_connection_proxy.cc",
+     "gpu/wayland_connection_proxy.h",
+     "ozone_platform_wayland.cc",
+@@ -90,7 +92,6 @@ source_set("wayland") {
+     "//build/config/linux/libdrm",
+     "//mojo/public/cpp/bindings",
+     "//skia",
+-    "//third_party/minigbm",
+     "//third_party/wayland:wayland_client",
+     "//third_party/wayland-protocols:linux_dmabuf_protocol",
+     "//third_party/wayland-protocols:presentation_time_protocol",
+@@ -125,8 +126,6 @@ source_set("wayland") {
+     sources += [
+       "gpu/drm_render_node_handle.cc",
+       "gpu/drm_render_node_handle.h",
+-      "gpu/drm_render_node_path_finder.cc",
+-      "gpu/drm_render_node_path_finder.h",
+       "gpu/gbm_pixmap_wayland.cc",
+       "gpu/gbm_pixmap_wayland.h",
+       "gpu/gbm_surfaceless_wayland.cc",
+@@ -134,7 +133,7 @@ source_set("wayland") {
+     ]
+ 
+     deps += [
+-      "//build/config/linux/libdrm",
++      "//third_party/minigbm",
+       "//ui/gfx:memory_buffer",
+       "//ui/ozone/common/linux:gbm",
+     ]
+diff --git a/ui/ozone/platform/wayland/ozone_platform_wayland.cc b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+index 5636df534525..f59e909164b8 100644
+--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
++++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+@@ -17,6 +17,7 @@
+ #include "ui/events/system_input_injector.h"
+ #include "ui/gfx/linux/client_native_pixmap_dmabuf.h"
+ #include "ui/ozone/common/stub_overlay_manager.h"
++#include "ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.h"
+ #include "ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h"
+ #include "ui/ozone/platform/wayland/wayland_connection.h"
+ #include "ui/ozone/platform/wayland/wayland_connection_connector.h"
+@@ -40,7 +41,6 @@
+ #include "ui/base/ui_base_features.h"
+ #include "ui/ozone/common/linux/gbm_wrapper.h"
+ #include "ui/ozone/platform/wayland/gpu/drm_render_node_handle.h"
+-#include "ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.h"
+ #endif
+ 
+ namespace ui {
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0029-ozone-wayland-xkbcommon-Fix-layout-switching.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0029-ozone-wayland-xkbcommon-Fix-layout-switching.patch
@@ -1,0 +1,142 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1474041
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 58691a5fa93d8637eeb8d5a3afd58b9838578d7f Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nickdiego@igalia.com>
+Date: Wed, 20 Feb 2019 15:55:01 +0000
+Subject: [PATCH 29/35] ozone/wayland: xkbcommon: Fix layout switching
+
+Wayland compositors let clients know about keyboard
+layout index currently set using the "group" parameter
+in wl_keyboard::modifiers event[1]. Currently it is used
+to update the libxkbcommon modifiers mask and generate
+the corresponding event flags value, but is not used later
+on when translating keysyms into UTF characters (when
+xkb_state_update_modifiers function is used again). That
+makes the keys to be converted using incorrect layout.
+
+To fix it, this CL does the following:
+1. Rename GetModifierFlags -> UpdateModifiers; modifying it
+   to be non-const and then be able to cache 'group' value
+   (coming from wl_keyboard::modifiers event) into the new
+   layout_index_ class variable;
+2. In XkbLookup method, pass in the previously cached
+   layout_index_ when calling xkb_state_update_modifiers
+   function, making the characters to be correctly
+   converted when xkb_state_key_get_utf32 is called.
+
+[1] https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_keyboard
+
+Bug: 921947
+Change-Id: I5758da5b771bd46c6a43250439b63b0911f51fbb
+Reviewed-on: https://chromium-review.googlesource.com/c/1474041
+Reviewed-by: Michael Spang <spang@chromium.org>
+Reviewed-by: Kevin Schoedel <kpschoedel@chromium.org>
+Commit-Queue: Nick Diego Yamane <nickdiego@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#633718}
+---
+ .../layout/xkb/xkb_keyboard_layout_engine.cc  | 19 ++++++++++++-------
+ .../layout/xkb/xkb_keyboard_layout_engine.h   | 10 ++++++----
+ ui/ozone/platform/wayland/wayland_keyboard.cc |  2 +-
+ 3 files changed, 19 insertions(+), 12 deletions(-)
+
+diff --git a/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.cc b/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.cc
+index c1f5c10e7734..76105208ecff 100644
+--- a/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.cc
++++ b/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.cc
+@@ -837,6 +837,7 @@ void XkbKeyboardLayoutEngine::SetKeymap(xkb_keymap* keymap) {
+       xkb_flag_map_.push_back(e);
+     }
+   }
++  layout_index_ = 0;
+ 
+   // Update num lock mask.
+   num_lock_mod_mask_ = 0;
+@@ -858,10 +859,10 @@ xkb_mod_mask_t XkbKeyboardLayoutEngine::EventFlagsToXkbFlags(
+   return xkb_flags;
+ }
+ 
+-int XkbKeyboardLayoutEngine::GetModifierFlags(uint32_t depressed,
+-                                              uint32_t latched,
+-                                              uint32_t locked,
+-                                              uint32_t group) const {
++int XkbKeyboardLayoutEngine::UpdateModifiers(uint32_t depressed,
++                                             uint32_t latched,
++                                             uint32_t locked,
++                                             uint32_t group) {
+   auto* state = xkb_state_.get();
+   xkb_state_update_mask(state, depressed, latched, locked, 0, 0, group);
+   auto component = static_cast<xkb_state_component>(XKB_STATE_MODS_DEPRESSED |
+@@ -872,6 +873,7 @@ int XkbKeyboardLayoutEngine::GetModifierFlags(uint32_t depressed,
+     if (xkb_state_mod_index_is_active(state, entry.xkb_index, component))
+       ui_flags |= entry.ui_flag;
+   }
++  layout_index_ = group;
+   return ui_flags;
+ }
+ 
+@@ -883,11 +885,14 @@ bool XkbKeyboardLayoutEngine::XkbLookup(xkb_keycode_t xkb_keycode,
+     LOG(ERROR) << "No current XKB state";
+     return false;
+   }
+-  xkb_state_update_mask(xkb_state_.get(), xkb_flags, 0, 0, 0, 0, 0);
+-  *xkb_keysym = xkb_state_key_get_one_sym(xkb_state_.get(), xkb_keycode);
++
++  auto* state = xkb_state_.get();
++  xkb_state_update_mask(state, xkb_flags, 0, 0, 0, 0, layout_index_);
++  *xkb_keysym = xkb_state_key_get_one_sym(state, xkb_keycode);
++
+   if (*xkb_keysym == XKB_KEY_NoSymbol)
+     return false;
+-  *character = xkb_state_key_get_utf32(xkb_state_.get(), xkb_keycode);
++  *character = xkb_state_key_get_utf32(state, xkb_keycode);
+   return true;
+ }
+ 
+diff --git a/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h b/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h
+index fd33e76ce8eb..8de8d80d6f7a 100644
+--- a/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h
++++ b/ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h
+@@ -47,10 +47,10 @@ class EVENTS_OZONE_LAYOUT_EXPORT XkbKeyboardLayoutEngine
+               DomKey* dom_key,
+               KeyboardCode* key_code) const override;
+ 
+-  int GetModifierFlags(uint32_t depressed,
+-                       uint32_t latched,
+-                       uint32_t locked,
+-                       uint32_t group) const;
++  int UpdateModifiers(uint32_t depressed,
++                      uint32_t latched,
++                      uint32_t locked,
++                      uint32_t group);
+ 
+   static void ParseLayoutName(const std::string& layout_name,
+                               std::string* layout_id,
+@@ -123,6 +123,8 @@ class EVENTS_OZONE_LAYOUT_EXPORT XkbKeyboardLayoutEngine
+ 
+   std::string current_layout_name_;
+ 
++  xkb_layout_index_t layout_index_ = 0;
++
+   // Support weak pointers for attach & detach callbacks.
+   base::WeakPtrFactory<XkbKeyboardLayoutEngine> weak_ptr_factory_;
+ };
+diff --git a/ui/ozone/platform/wayland/wayland_keyboard.cc b/ui/ozone/platform/wayland/wayland_keyboard.cc
+index 737212b6c722..546256e7043e 100644
+--- a/ui/ozone/platform/wayland/wayland_keyboard.cc
++++ b/ui/ozone/platform/wayland/wayland_keyboard.cc
+@@ -137,7 +137,7 @@ void WaylandKeyboard::Modifiers(void* data,
+   WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
+   DCHECK(keyboard);
+ 
+-  keyboard->modifiers_ = keyboard->layout_engine_->GetModifierFlags(
++  keyboard->modifiers_ = keyboard->layout_engine_->UpdateModifiers(
+       depressed, latched, locked, group);
+ #endif
+ }
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0030-ozone-wayland-Fix-crash-when-there-is-no-zwp_linux_d.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0030-ozone-wayland-Fix-crash-when-there-is-no-zwp_linux_d.patch
@@ -1,0 +1,190 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1477591
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From ff00f83cd8e8ba9de2c46d0c8ddb277bdc10488e Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Mon, 25 Feb 2019 07:34:47 +0000
+Subject: [PATCH 30/35] [ozone/wayland] Fix crash when there is no
+ zwp_linux_dmabuf
+
+This fixes the case when zwp_linux_dmabuf interface is not available.
+
+The fix is to make WaylandConnectionProxy to reset gbm_device, and
+return nullptr instead. This makes the WaylandSurfaceFactory return
+nullptr for SurfacelessViewGLSurface, which results in a software
+rendering path usage when the "--in-process-gpu" flag is not
+passed and ViewGLSurface, when the flag is passed.
+
+TL;DR:
+
+This change results in the following changes in two different cases:
+  1) in-process-gpu is passed: in that mode, WaylandSurfaceFactory
+tries to create surfaceless gl surface, which uses gbm and linux dmabuf
+interface to create buffers. If neither gbm nor the interface are available,
+surfaceless gl surface can't be created and nullptr is returned. Then,
+Chromium asks to create ViewGlSurface, which uses wl_egl_surface.
+  2) the flag is not passed: in that mode, the factory creates the
+above mentioned surfaceless gl surface, which uses gbm and linux dmabuf
+interface. If those are not available, nullptr is returned and chromium
+falls back to software rendering (please note that it's impossible to create
+wl_egl_surface, because it requires accessing wl_surface on the browser
+process side). Note, software rendering CL is under review at
+crrev.com/c/1454623
+
+Bug: 932098
+Change-Id: I95f88018ded48e7a18864f957137c2b478e788ac
+Reviewed-on: https://chromium-review.googlesource.com/c/1477591
+Reviewed-by: Dominick Ng <dominickn@chromium.org>
+Reviewed-by: Robert Kroeger <rjkroege@chromium.org>
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#635044}
+---
+ .../platform/wayland/gpu/wayland_connection_proxy.cc   |  8 ++++++++
+ .../platform/wayland/gpu/wayland_connection_proxy.h    |  1 +
+ ui/ozone/platform/wayland/ozone_platform_wayland.cc    |  2 +-
+ ui/ozone/platform/wayland/wayland_connection.cc        |  6 ++++++
+ ui/ozone/platform/wayland/wayland_connection.h         |  2 ++
+ .../platform/wayland/wayland_connection_connector.cc   |  7 +++++++
+ .../public/interfaces/wayland/wayland_connection.mojom | 10 ++++++++--
+ 7 files changed, 33 insertions(+), 3 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+index a9f1e3fa7dce..63372824985a 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+@@ -24,6 +24,14 @@ void WaylandConnectionProxy::SetWaylandConnection(
+   wc_ptr_info_ = wc_ptr.PassInterface();
+ }
+ 
++void WaylandConnectionProxy::ResetGbmDevice() {
++#if defined(WAYLAND_GBM)
++  gbm_device_.reset();
++#else
++  NOTREACHED();
++#endif
++}
++
+ void WaylandConnectionProxy::CreateZwpLinuxDmabuf(
+     base::File file,
+     gfx::Size size,
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+index 7c3d0725e5f4..2f3072cbdca9 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+@@ -44,6 +44,7 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
+ 
+   // WaylandConnectionProxy overrides:
+   void SetWaylandConnection(ozone::mojom::WaylandConnectionPtr wc_ptr) override;
++  void ResetGbmDevice() override;
+ 
+   // Methods, which must be used when GPU is hosted on a different process
+   // aka gpu process.
+diff --git a/ui/ozone/platform/wayland/ozone_platform_wayland.cc b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+index f59e909164b8..be1e09da8035 100644
+--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
++++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+@@ -168,6 +168,7 @@ class OzonePlatformWayland : public OzonePlatform {
+ 
+   void InitializeGPU(const InitParams& args) override {
+     proxy_.reset(new WaylandConnectionProxy(connection_.get()));
++    surface_factory_.reset(new WaylandSurfaceFactory(proxy_.get()));
+ #if defined(WAYLAND_GBM)
+     const base::FilePath drm_node_path = path_finder_.GetDrmRenderNodePath();
+     if (drm_node_path.empty()) {
+@@ -184,7 +185,6 @@ class OzonePlatformWayland : public OzonePlatform {
+       }
+     }
+ #endif
+-    surface_factory_.reset(new WaylandSurfaceFactory(proxy_.get()));
+   }
+ 
+   const PlatformProperties& GetPlatformProperties() override {
+diff --git a/ui/ozone/platform/wayland/wayland_connection.cc b/ui/ozone/platform/wayland/wayland_connection.cc
+index c03b963f5b45..f09b061436ff 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/wayland_connection.cc
+@@ -195,6 +195,8 @@ void WaylandConnection::CreateZwpLinuxDmabuf(
+     uint32_t planes_count,
+     uint32_t buffer_id) {
+   DCHECK(base::MessageLoopCurrentForUI::IsSet());
++
++  DCHECK(buffer_manager_);
+   if (!buffer_manager_->CreateBuffer(std::move(file), width, height, strides,
+                                      offsets, format, modifiers, planes_count,
+                                      buffer_id)) {
+@@ -204,6 +206,8 @@ void WaylandConnection::CreateZwpLinuxDmabuf(
+ 
+ void WaylandConnection::DestroyZwpLinuxDmabuf(uint32_t buffer_id) {
+   DCHECK(base::MessageLoopCurrentForUI::IsSet());
++
++  DCHECK(buffer_manager_);
+   if (!buffer_manager_->DestroyBuffer(buffer_id)) {
+     TerminateGpuProcess(buffer_manager_->error_message());
+   }
+@@ -215,6 +219,8 @@ void WaylandConnection::ScheduleBufferSwap(
+     const gfx::Rect& damage_region,
+     ScheduleBufferSwapCallback callback) {
+   DCHECK(base::MessageLoopCurrentForUI::IsSet());
++
++  CHECK(buffer_manager_);
+   if (!buffer_manager_->ScheduleBufferSwap(widget, buffer_id, damage_region,
+                                            std::move(callback))) {
+     TerminateGpuProcess(buffer_manager_->error_message());
+diff --git a/ui/ozone/platform/wayland/wayland_connection.h b/ui/ozone/platform/wayland/wayland_connection.h
+index cfa0c92832a4..c5ded050c6fe 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.h
++++ b/ui/ozone/platform/wayland/wayland_connection.h
+@@ -112,6 +112,8 @@ class WaylandConnection : public PlatformEventSource,
+     return wayland_cursor_position_.get();
+   }
+ 
++  WaylandBufferManager* buffer_manager() const { return buffer_manager_.get(); }
++
+   // Clipboard implementation.
+   PlatformClipboard* GetPlatformClipboard();
+   void DataSourceCancelled();
+diff --git a/ui/ozone/platform/wayland/wayland_connection_connector.cc b/ui/ozone/platform/wayland/wayland_connection_connector.cc
+index cee7bb448896..91cf7445d5ab 100644
+--- a/ui/ozone/platform/wayland/wayland_connection_connector.cc
++++ b/ui/ozone/platform/wayland/wayland_connection_connector.cc
+@@ -82,6 +82,13 @@ void WaylandConnectionConnector::OnWaylandConnectionPtrBinded(
+   auto request = mojo::MakeRequest(&wcp_ptr);
+   BindInterfaceInGpuProcess(std::move(request), binder_);
+   wcp_ptr->SetWaylandConnection(std::move(wc_ptr));
++
++#if defined(WAYLAND_GBM)
++  if (!connection_->buffer_manager()) {
++    LOG(WARNING) << "zwp_linux_dmabuf is not available.";
++    wcp_ptr->ResetGbmDevice();
++  }
++#endif
+ }
+ 
+ void WaylandConnectionConnector::OnTerminateGpuProcess(std::string message) {
+diff --git a/ui/ozone/public/interfaces/wayland/wayland_connection.mojom b/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
+index a3993ccb15c0..b13007339e9f 100644
+--- a/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
++++ b/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
+@@ -35,8 +35,14 @@ interface WaylandConnection {
+           gfx.mojom.PresentationFeedback feedback);
+ };
+ 
+-// Used by the browser process to provide the GPU process with a mojo ptr to a
+-// WaylandConnection, which lives on the browser process.
++
+ interface WaylandConnectionClient {
++  // Used by the browser process to provide the GPU process with a mojo ptr to a
++  // WaylandConnection, which lives on the browser process.
+   SetWaylandConnection(WaylandConnection wc_ptr);
++
++  // The browser process may request the client to reset gbm device instance to
++  // avoid using zwp_linux_dmabuf protocol, which means using wl_egl_surface in
++  // a single process mode, and software rendering in a multiple process mode.
++  ResetGbmDevice();
+ };
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0031-Remove-dependency-cycle-between-ui-base-ime-and-ui-o.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0031-Remove-dependency-cycle-between-ui-base-ime-and-ui-o.patch
@@ -1,0 +1,106 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1448471
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From feed50da1ed0c2793f62e931bdd02d0143192493 Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nickdiego@igalia.com>
+Date: Fri, 1 Feb 2019 02:11:19 +0000
+Subject: [PATCH 31/35] Remove dependency cycle between ui/base/ime and
+ ui/ozone
+
+Fix cyclic dependency error when trying to use CharacterComposer
+in ozone/platform (e.g: ozone/wayland). The issue shows up on chromeos
+builds due to the following dependency chain:
+
+  //ui/ozone:ozone ->
+  //ui/ozone:platform ->
+  //ui/ozone/platform/wayland:wayland ->
+  //ui/base/ime:ime ->
+  //services/ws/public/cpp/input_devices:input_devices ->
+  //ui/ozone:ozone
+
+This CL fixes it by moving character_composer.* files into
+//ui/base/ime:ime_types component, which is already in
+//ui/base/ime deps when is_chromeos=true and can automatically
+used in ozone/platform/wayland becaused ime_types is included
+in //ui/base/ime/linux's public_deps, which is in
+//ui/ozone/platform/wayland's deps.
+
+BUG=921947
+
+Change-Id: I9d01445325066f9c5a89d7d44729ec07f21c20c7
+Reviewed-on: https://chromium-review.googlesource.com/c/1448471
+Auto-Submit: Nick Yamane <nickdiego@igalia.com>
+Reviewed-by: Shu Chen <shuchen@chromium.org>
+Commit-Queue: Nick Yamane <nickdiego@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#628202}
+---
+ ui/base/ime/BUILD.gn             | 20 ++++++++++++--------
+ ui/base/ime/character_composer.h |  4 ++--
+ 2 files changed, 14 insertions(+), 10 deletions(-)
+
+diff --git a/ui/base/ime/BUILD.gn b/ui/base/ime/BUILD.gn
+index 204fd89cfbd0..8106220f5b81 100644
+--- a/ui/base/ime/BUILD.gn
++++ b/ui/base/ime/BUILD.gn
+@@ -41,6 +41,18 @@ jumbo_component("ime_types") {
+     ":text_input_types",
+     "//skia",
+   ]
++
++  if (is_chromeos || use_ozone) {
++    sources += [
++      "character_composer.cc",
++      "character_composer.h",
++    ]
++    deps += [
++      "//ui/events:dom_keycode_converter",
++      "//ui/events:events",
++      "//ui/events:events_base",
++    ]
++  }
+ }
+ 
+ jumbo_component("ime") {
+@@ -174,14 +186,6 @@ jumbo_component("ime") {
+     ]
+   }
+ 
+-  if (is_chromeos || use_ozone) {
+-    sources += [
+-      "character_composer.cc",
+-      "character_composer.h",
+-    ]
+-    deps += [ "//ui/events:dom_keycode_converter" ]
+-  }
+-
+   if (!toolkit_views && !use_aura) {
+     sources -= [
+       "input_method_factory.cc",
+diff --git a/ui/base/ime/character_composer.h b/ui/base/ime/character_composer.h
+index b3845c3d669c..9f7967e4250b 100644
+--- a/ui/base/ime/character_composer.h
++++ b/ui/base/ime/character_composer.h
+@@ -12,7 +12,7 @@
+ 
+ #include "base/macros.h"
+ #include "base/strings/string_util.h"
+-#include "ui/base/ime/ui_base_ime_export.h"
++#include "ui/base/ime/ui_base_ime_types_export.h"
+ #include "ui/events/keycodes/dom/dom_key.h"
+ 
+ namespace ui {
+@@ -20,7 +20,7 @@ class KeyEvent;
+ 
+ // A class to recognize compose and dead key sequence.
+ // Outputs composed character.
+-class UI_BASE_IME_EXPORT CharacterComposer {
++class UI_BASE_IME_TYPES_EXPORT CharacterComposer {
+  public:
+   using ComposeBuffer = std::vector<DomKey>;
+ 
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0032-Roll-third_party-minigbm-ff1ecaf.4fe3038.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0032-Roll-third_party-minigbm-ff1ecaf.4fe3038.patch
@@ -1,0 +1,66 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1477075
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 09069be5a1988e9bc775a523b8e7d8be15af4666 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Wed, 20 Feb 2019 15:43:33 +0000
+Subject: [PATCH 32/35] Roll third_party/minigbm ff1ecaf...4fe3038
+
+$ git log --oneline ff1ecaf...4fe3038
+4fe3038 Reland "minigbm: define GBM_BO_IMPORT_FD_MODIFIER"
+eea88fa minigbm:amdgpu: align stride to 256
+067594b minigbm: msm: Add modifier for tiled buffer allocation
+90f8bb0 minigbm: Fix some clang-format issues
+c65bd8c minigbm: msm: Add platform specific alignment for NV12 linear format
+400e928 Revert "minigbm: define GBM_BO_IMPORT_FD_MODIFIER"
+bc667c3 minigbm: define GBM_BO_IMPORT_FD_MODIFIER
+ff66c80 amdgpu: use amdgpu_gem_wait_idle_ioctl to wait for GPU to finish.
+74e4893 amdgpu: Don't use AMDGPU_GEM_CREATE_EXPLICIT_SYNC flag.
+d7630cd amdgpu: fix misplaced code block
+39eb951 minigbm: i915: Do not use I915_MMAP_WC for camera buffers
+11161ac minigbm: add MINIGBM define.
+ee98f4e minigbm: align width so that stride aligns to 256
+617ee71 minigbm: minimal buffer allocation support using msm gem ioctls
+71bc665 minigbm: don't advertise BGR24 as a render/texture target
+86ddfdc minigbm: use drv_add_combination when adding a single combination
+2fdb721 minigbm: delete unused functions and definitions
+2b1d689 minigbm: run clang-format
+a72f442 minigbm: mediatek: always provide munmap() with a valid address
+500928f minigbm: mediatek: wait for outstanding operations when invalidating
+b131c9d minigbm: msm: add supported formats
+571a687 minigbm/i915.c: Android's HAL_PIXEL_FORMAT_BLOB is not tilable if BO_USE_PROTECTED
+d706a8c minigbm: move height adjustments to helper function
+79155d7 minigbm: run clang-format
+a13dda7 minigbm: support NV12 in virtio_gpu
+af94db9 minigbm: adjust height of NV12 buffer in helper
+
+Bug: 933123
+Change-Id: I174363f379407697ae0d571175ecc43d4cc51d3e
+Reviewed-on: https://chromium-review.googlesource.com/c/1477075
+Auto-Submit: Maksim Sisov <msisov@igalia.com>
+Commit-Queue: Michael Spang <spang@chromium.org>
+Reviewed-by: Michael Spang <spang@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#633716}
+---
+ DEPS | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/DEPS b/DEPS
+index efb83282bd9b..960612d2af5c 100644
+--- a/DEPS
++++ b/DEPS
+@@ -935,7 +935,7 @@ deps = {
+ 
+   # Graphics buffer allocator for Chrome OS.
+   'src/third_party/minigbm/src': {
+-      'url': Var('chromium_git') + '/chromiumos/platform/minigbm.git' + '@' + 'ff1ecaf1014df4cb9ca36c5a270647a9934aaa99',
++      'url': Var('chromium_git') + '/chromiumos/platform/minigbm.git' + '@' + '4fe3038be586d5db8e44e452f5ed6a93c8ccf50a',
+       'condition': 'checkout_linux',
+   },
+ 
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0033-ozone-wayland-Fix-software-rendering.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0033-ozone-wayland-Fix-software-rendering.patch
@@ -1,0 +1,910 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1454623
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 7a5d84120f2df7f30decb47b9fb2aee0e23257b9 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Mon, 25 Feb 2019 14:55:51 +0200
+Subject: [PATCH 33/35] [ozone/wayland] Fix software rendering.
+
+This patch fixes software rendering path by adding mojo APIs
+to call newly created WaylandShmBufferManager, which
+uses Wayland APIs to create shm buffer and commit it.
+
+Also, some code is rearrenged and moved to WaylandShmBufferManager
+instead. WaylandSurfaceCanvas is also moved to a separate file.
+
+gn args:
+use_ozone=true
+ozone_platform_wayland=true
+use_xkbcommon=true
+
+Test: ./chrome --ozone-platform=wayland --use-gl=swiftshader
+./chrome --ozone-platform=wayland --use-gl=swiftshader --in-process-gpu
+Bug: 910998
+Change-Id: I18d867d66a8b1b5b11900c4bd4a9de614b0a20e7
+---
+ ui/ozone/platform/wayland/BUILD.gn            |   4 +
+ .../wayland/gpu/wayland_canvas_surface.cc     |  93 +++++++++++++
+ .../wayland/gpu/wayland_canvas_surface.h      |  47 +++++++
+ .../wayland/gpu/wayland_connection_proxy.cc   |  34 ++++-
+ .../wayland/gpu/wayland_connection_proxy.h    |  21 ++-
+ .../platform/wayland/wayland_connection.cc    |  26 ++++
+ .../platform/wayland/wayland_connection.h     |  15 ++-
+ .../wayland_shared_memory_buffer_manager.cc   |  95 +++++++++++++
+ .../wayland_shared_memory_buffer_manager.h    |  76 +++++++++++
+ .../wayland/wayland_surface_factory.cc        | 127 ++----------------
+ .../wayland/wayland_surface_factory.h         |   1 -
+ .../wayland_surface_factory_unittest.cc       |  22 +++
+ ui/ozone/platform/wayland/wayland_util.h      |   2 +
+ .../wayland/wayland_connection.mojom          |  20 +++
+ 14 files changed, 455 insertions(+), 128 deletions(-)
+ create mode 100644 ui/ozone/platform/wayland/gpu/wayland_canvas_surface.cc
+ create mode 100644 ui/ozone/platform/wayland/gpu/wayland_canvas_surface.h
+ create mode 100644 ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.cc
+ create mode 100644 ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.h
+
+diff --git a/ui/ozone/platform/wayland/BUILD.gn b/ui/ozone/platform/wayland/BUILD.gn
+index d98c4474a877..e93a0017b3bd 100644
+--- a/ui/ozone/platform/wayland/BUILD.gn
++++ b/ui/ozone/platform/wayland/BUILD.gn
+@@ -20,6 +20,8 @@ source_set("wayland") {
+     "gl_surface_wayland.h",
+     "gpu/drm_render_node_path_finder.cc",
+     "gpu/drm_render_node_path_finder.h",
++    "gpu/wayland_canvas_surface.cc",
++    "gpu/wayland_canvas_surface.h",
+     "gpu/wayland_connection_proxy.cc",
+     "gpu/wayland_connection_proxy.h",
+     "ozone_platform_wayland.cc",
+@@ -58,6 +60,8 @@ source_set("wayland") {
+     "wayland_pointer.h",
+     "wayland_screen.cc",
+     "wayland_screen.h",
++    "wayland_shared_memory_buffer_manager.cc",
++    "wayland_shared_memory_buffer_manager.h",
+     "wayland_surface_factory.cc",
+     "wayland_surface_factory.h",
+     "wayland_touch.cc",
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_canvas_surface.cc b/ui/ozone/platform/wayland/gpu/wayland_canvas_surface.cc
+new file mode 100644
+index 000000000000..a281d5bd578a
+--- /dev/null
++++ b/ui/ozone/platform/wayland/gpu/wayland_canvas_surface.cc
+@@ -0,0 +1,93 @@
++// Copyright 2019 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "ui/ozone/platform/wayland/gpu/wayland_canvas_surface.h"
++
++#include <utility>
++
++#include "base/files/scoped_file.h"
++#include "base/macros.h"
++#include "base/memory/shared_memory.h"
++#include "base/posix/eintr_wrapper.h"
++#include "ui/gfx/vsync_provider.h"
++#include "ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h"
++
++namespace ui {
++
++namespace {
++
++void DeleteSharedMemory(void* pixels, void* context) {
++  delete static_cast<base::SharedMemory*>(context);
++}
++
++}  // namespace
++
++WaylandCanvasSurface::WaylandCanvasSurface(WaylandConnectionProxy* connection,
++                                           gfx::AcceleratedWidget widget)
++    : connection_(connection), widget_(widget) {}
++
++WaylandCanvasSurface::~WaylandCanvasSurface() {
++  if (sk_surface_)
++    connection_->DestroyShmBuffer(widget_);
++}
++
++sk_sp<SkSurface> WaylandCanvasSurface::GetSurface() {
++  if (sk_surface_)
++    return sk_surface_;
++  DCHECK(!size_.IsEmpty());
++
++  size_t length = size_.width() * size_.height() * 4;
++  auto shared_memory = std::make_unique<base::SharedMemory>();
++  if (!shared_memory->CreateAndMapAnonymous(length)) {
++    return nullptr;
++  }
++
++  base::ScopedFD fd(HANDLE_EINTR(dup(shared_memory->handle().GetHandle())));
++  if (!fd.is_valid()) {
++    PLOG(FATAL) << "dup";
++    return nullptr;
++  }
++
++  base::File file(fd.release());
++  connection_->CreateShmBufferForWidget(widget_, std::move(file), length,
++                                        size_);
++
++  sk_surface_ = SkSurface::MakeRasterDirectReleaseProc(
++      SkImageInfo::MakeN32Premul(size_.width(), size_.height()),
++      shared_memory->memory(), size_.width() * 4, &DeleteSharedMemory,
++      shared_memory.get(), nullptr);
++  if (!sk_surface_)
++    return nullptr;
++
++  ignore_result(shared_memory.release());
++  return sk_surface_;
++}
++
++void WaylandCanvasSurface::ResizeCanvas(const gfx::Size& viewport_size) {
++  if (size_ == viewport_size)
++    return;
++  // TODO(https://crbug.com/930667): We could implement more efficient resizes
++  // by allocating buffers rounded up to larger sizes, and then reusing them if
++  // the new size still fits (but still reallocate if the new size is much
++  // smaller than the old size).
++  if (sk_surface_) {
++    sk_surface_.reset();
++    connection_->DestroyShmBuffer(widget_);
++  }
++  size_ = viewport_size;
++}
++
++void WaylandCanvasSurface::PresentCanvas(const gfx::Rect& damage) {
++  connection_->PresentShmBufferForWidget(widget_, damage);
++}
++
++std::unique_ptr<gfx::VSyncProvider>
++WaylandCanvasSurface::CreateVSyncProvider() {
++  // TODO(https://crbug.com/930662): This can be implemented with information
++  // from frame callbacks, and possibly output refresh rate.
++  NOTIMPLEMENTED_LOG_ONCE();
++  return nullptr;
++}
++
++}  // namespace ui
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_canvas_surface.h b/ui/ozone/platform/wayland/gpu/wayland_canvas_surface.h
+new file mode 100644
+index 000000000000..0511bb3b4b53
+--- /dev/null
++++ b/ui/ozone/platform/wayland/gpu/wayland_canvas_surface.h
+@@ -0,0 +1,47 @@
++// Copyright 2019 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef UI_OZONE_PLATFORM_WAYLAND_GPU_WAYLAND_CANVAS_SURFACE_H_
++#define UI_OZONE_PLATFORM_WAYLAND_GPU_WAYLAND_CANVAS_SURFACE_H_
++
++#include <memory>
++
++#include "base/macros.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
++#include "third_party/skia/include/core/SkSurface.h"
++#include "ui/gfx/geometry/size.h"
++#include "ui/gfx/native_widget_types.h"
++#include "ui/ozone/public/surface_ozone_canvas.h"
++
++namespace ui {
++
++class WaylandConnectionProxy;
++
++class WaylandCanvasSurface : public SurfaceOzoneCanvas {
++ public:
++  WaylandCanvasSurface(WaylandConnectionProxy* connection,
++                       gfx::AcceleratedWidget widget);
++  ~WaylandCanvasSurface() override;
++
++  // SurfaceOzoneCanvas
++  sk_sp<SkSurface> GetSurface() override;
++  void ResizeCanvas(const gfx::Size& viewport_size) override;
++  void PresentCanvas(const gfx::Rect& damage) override;
++  std::unique_ptr<gfx::VSyncProvider> CreateVSyncProvider() override;
++
++ private:
++  void OnGetSizeForWidget(const gfx::Size& widget_size) { size_ = widget_size; }
++
++  WaylandConnectionProxy* const connection_;
++  const gfx::AcceleratedWidget widget_;
++
++  gfx::Size size_;
++  sk_sp<SkSurface> sk_surface_;
++
++  DISALLOW_COPY_AND_ASSIGN(WaylandCanvasSurface);
++};
++
++}  // namespace ui
++
++#endif  // UI_OZONE_PLATFORM_WAYLAND_GPU_WAYLAND_CANVAS_SURFACE_H_
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+index 63372824985a..2d19898b0aa0 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+@@ -4,6 +4,8 @@
+ 
+ #include "ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h"
+ 
++#include <utility>
++
+ #include "base/process/process.h"
+ #include "third_party/khronos/EGL/egl.h"
+ #include "ui/ozone/common/linux/drm_util_linux.h"
+@@ -104,6 +106,31 @@ void WaylandConnectionProxy::ScheduleBufferSwap(
+                               std::move(callback));
+ }
+ 
++void WaylandConnectionProxy::CreateShmBufferForWidget(
++    gfx::AcceleratedWidget widget,
++    base::File file,
++    size_t length,
++    const gfx::Size size) {
++  if (!bound_) {
++    wc_ptr_.Bind(std::move(wc_ptr_info_));
++    bound_ = true;
++  }
++  DCHECK(wc_ptr_);
++  wc_ptr_->CreateShmBufferForWidget(widget, std::move(file), length, size);
++}
++
++void WaylandConnectionProxy::PresentShmBufferForWidget(
++    gfx::AcceleratedWidget widget,
++    const gfx::Rect& damage) {
++  DCHECK(wc_ptr_);
++  wc_ptr_->PresentShmBufferForWidget(widget, damage);
++}
++
++void WaylandConnectionProxy::DestroyShmBuffer(gfx::AcceleratedWidget widget) {
++  DCHECK(wc_ptr_);
++  wc_ptr_->DestroyShmBuffer(widget);
++}
++
+ WaylandWindow* WaylandConnectionProxy::GetWindow(
+     gfx::AcceleratedWidget widget) {
+   if (connection_)
+@@ -119,13 +146,6 @@ void WaylandConnectionProxy::ScheduleFlush() {
+                 "when multi-process moe is used";
+ }
+ 
+-wl_shm* WaylandConnectionProxy::shm() {
+-  wl_shm* shm = nullptr;
+-  if (connection_)
+-    shm = connection_->shm();
+-  return shm;
+-}
+-
+ intptr_t WaylandConnectionProxy::Display() {
+   if (connection_)
+     return reinterpret_cast<intptr_t>(connection_->display());
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+index 2f3072cbdca9..8da7a183aefc 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+@@ -18,8 +18,6 @@
+ #include "ui/ozone/common/linux/gbm_device.h"  // nogncheck
+ #endif
+ 
+-struct wl_shm;
+-
+ namespace gfx {
+ enum class SwapResult;
+ class Rect;
+@@ -80,6 +78,23 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
+   }
+ #endif
+ 
++  // Methods that are used to manage shared buffers when software rendering is
++  // used:
++  //
++  // Asks Wayland to create a buffer based on shared memory |file| handle for
++  // specific |widget|. There can be only one buffer per widget.
++  void CreateShmBufferForWidget(gfx::AcceleratedWidget widget,
++                                base::File file,
++                                size_t length,
++                                const gfx::Size size);
++
++  // Asks to damage and commit previously created buffer for the |widget|.
++  void PresentShmBufferForWidget(gfx::AcceleratedWidget widget,
++                                 const gfx::Rect& damage);
++
++  // Asks to destroy shared memory based buffer for the |widget|.
++  void DestroyShmBuffer(gfx::AcceleratedWidget widget);
++
+   // Methods, which must be used when a single process mode is used (GPU is
+   // hosted in the browser process).
+   //
+@@ -87,8 +102,6 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
+   WaylandWindow* GetWindow(gfx::AcceleratedWidget widget);
+   // Schedule flush in the Wayland message loop.
+   void ScheduleFlush();
+-  // Returns an object for a shared memory support. Used for software fallback.
+-  wl_shm* shm();
+ 
+   // Methods, which can be used with both single- and multi-process modes.
+   //
+diff --git a/ui/ozone/platform/wayland/wayland_connection.cc b/ui/ozone/platform/wayland/wayland_connection.cc
+index f09b061436ff..622809650576 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/wayland_connection.cc
+@@ -20,6 +20,7 @@
+ #include "ui/ozone/platform/wayland/wayland_input_method_context.h"
+ #include "ui/ozone/platform/wayland/wayland_object.h"
+ #include "ui/ozone/platform/wayland/wayland_output_manager.h"
++#include "ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.h"
+ #include "ui/ozone/platform/wayland/wayland_window.h"
+ 
+ static_assert(XDG_SHELL_VERSION_CURRENT == 5, "Unsupported xdg-shell version");
+@@ -227,6 +228,29 @@ void WaylandConnection::ScheduleBufferSwap(
+   }
+ }
+ 
++void WaylandConnection::CreateShmBufferForWidget(gfx::AcceleratedWidget widget,
++                                                 base::File file,
++                                                 uint64_t length,
++                                                 const gfx::Size& size) {
++  DCHECK(shm_buffer_manager_);
++  if (!shm_buffer_manager_->CreateBufferForWidget(widget, std::move(file),
++                                                  length, size))
++    TerminateGpuProcess("Failed to create SHM buffer.");
++}
++
++void WaylandConnection::PresentShmBufferForWidget(gfx::AcceleratedWidget widget,
++                                                  const gfx::Rect& damage) {
++  DCHECK(shm_buffer_manager_);
++  if (!shm_buffer_manager_->PresentBufferForWidget(widget, damage))
++    TerminateGpuProcess("Failed to present SHM buffer.");
++}
++
++void WaylandConnection::DestroyShmBuffer(gfx::AcceleratedWidget widget) {
++  DCHECK(shm_buffer_manager_);
++  if (!shm_buffer_manager_->DestroyBuffer(widget))
++    TerminateGpuProcess("Failed to destroy SHM buffer.");
++}
++
+ PlatformClipboard* WaylandConnection::GetPlatformClipboard() {
+   return this;
+ }
+@@ -414,6 +438,8 @@ void WaylandConnection::Global(void* data,
+         wl::Bind<wl_shm>(registry, name, std::min(version, kMaxShmVersion));
+     if (!connection->shm_)
+       LOG(ERROR) << "Failed to bind to wl_shm global";
++    connection->shm_buffer_manager_ =
++        std::make_unique<WaylandShmBufferManager>(connection);
+   } else if (!connection->seat_ && strcmp(interface, "wl_seat") == 0) {
+     connection->seat_ =
+         wl::Bind<wl_seat>(registry, name, std::min(version, kMaxSeatVersion));
+diff --git a/ui/ozone/platform/wayland/wayland_connection.h b/ui/ozone/platform/wayland/wayland_connection.h
+index c5ded050c6fe..230e22cef36e 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.h
++++ b/ui/ozone/platform/wayland/wayland_connection.h
+@@ -28,6 +28,7 @@
+ namespace ui {
+ 
+ class WaylandBufferManager;
++class WaylandShmBufferManager;
+ class WaylandOutputManager;
+ class WaylandWindow;
+ 
+@@ -45,7 +46,8 @@ class WaylandConnection : public PlatformEventSource,
+ 
+   // ozone::mojom::WaylandConnection overrides:
+   //
+-  // These overridden methods below are invoked by the GPU.
++  // These overridden methods below are invoked by the GPU when hardware
++  // accelerated rendering is used.
+   //
+   // Called by the GPU and asks to import a wl_buffer based on a gbm file
+   // descriptor.
+@@ -66,6 +68,16 @@ class WaylandConnection : public PlatformEventSource,
+                           uint32_t buffer_id,
+                           const gfx::Rect& damage_region,
+                           ScheduleBufferSwapCallback callback) override;
++  // These overridden methods below are invoked by the GPU when hardware
++  // accelerated rendering is not used. Check comments in the
++  // ui/ozone/public/interfaces/wayland/wayland_connection.mojom.
++  void CreateShmBufferForWidget(gfx::AcceleratedWidget widget,
++                                base::File file,
++                                uint64_t length,
++                                const gfx::Size& size) override;
++  void PresentShmBufferForWidget(gfx::AcceleratedWidget widget,
++                                 const gfx::Rect& damage) override;
++  void DestroyShmBuffer(gfx::AcceleratedWidget widget) override;
+ 
+   // Schedules a flush of the Wayland connection.
+   void ScheduleFlush();
+@@ -227,6 +239,7 @@ class WaylandConnection : public PlatformEventSource,
+   std::unique_ptr<WaylandPointer> pointer_;
+   std::unique_ptr<WaylandTouch> touch_;
+   std::unique_ptr<WaylandCursorPosition> wayland_cursor_position_;
++  std::unique_ptr<WaylandShmBufferManager> shm_buffer_manager_;
+ 
+   // Objects that are using when GPU runs in own process.
+   std::unique_ptr<WaylandBufferManager> buffer_manager_;
+diff --git a/ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.cc b/ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.cc
+new file mode 100644
+index 000000000000..9c649d5b9bec
+--- /dev/null
++++ b/ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.cc
+@@ -0,0 +1,95 @@
++// Copyright 2019 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.h"
++
++#include <utility>
++
++#include "base/trace_event/trace_event.h"
++#include "ui/ozone/platform/wayland/wayland_connection.h"
++#include "ui/ozone/platform/wayland/wayland_window.h"
++
++namespace ui {
++
++WaylandShmBufferManager::ShmBuffer::ShmBuffer() = default;
++
++WaylandShmBufferManager::ShmBuffer::ShmBuffer(
++    wl::Object<struct wl_buffer> buffer,
++    wl::Object<struct wl_shm_pool> pool)
++    : shm_buffer(std::move(buffer)), shm_pool(std::move(pool)) {}
++
++WaylandShmBufferManager::ShmBuffer::~ShmBuffer() = default;
++
++WaylandShmBufferManager::WaylandShmBufferManager(WaylandConnection* connection)
++    : connection_(connection) {}
++
++WaylandShmBufferManager::~WaylandShmBufferManager() {
++  DCHECK(shm_buffers_.empty());
++}
++
++bool WaylandShmBufferManager::CreateBufferForWidget(
++    gfx::AcceleratedWidget widget,
++    base::File file,
++    size_t length,
++    const gfx::Size& size) {
++  if (!file.IsValid() || length == 0 || size.IsEmpty() ||
++      widget == gfx::kNullAcceleratedWidget)
++    return false;
++
++  auto it = shm_buffers_.find(widget);
++  if (it != shm_buffers_.end())
++    return false;
++
++  base::ScopedFD fd(file.TakePlatformFile());
++  wl::Object<wl_shm_pool> pool(
++      wl_shm_create_pool(connection_->shm(), fd.get(), length));
++  if (!pool)
++    return false;
++
++  wl::Object<wl_buffer> shm_buffer(
++      wl_shm_pool_create_buffer(pool.get(), 0, size.width(), size.height(),
++                                size.width() * 4, WL_SHM_FORMAT_ARGB8888));
++  if (!shm_buffer)
++    return false;
++
++  shm_buffers_.insert(std::make_pair(
++      widget,
++      std::make_unique<ShmBuffer>(std::move(shm_buffer), std::move(pool))));
++
++  connection_->ScheduleFlush();
++  return true;
++}
++
++bool WaylandShmBufferManager::PresentBufferForWidget(
++    gfx::AcceleratedWidget widget,
++    const gfx::Rect& damage) {
++  auto it = shm_buffers_.find(widget);
++  if (it == shm_buffers_.end())
++    return false;
++
++  // TODO(https://crbug.com/930662): This is just a naive implementation that
++  // allows chromium to draw to the buffer at any time, even if it is being used
++  // by the Wayland compositor. Instead, we should track buffer releases and
++  // frame callbacks from Wayland to ensure perfect frames (while minimizing
++  // copies).
++  wl_surface* surface = connection_->GetWindow(widget)->surface();
++  wl_surface_damage(surface, damage.x(), damage.y(), damage.width(),
++                    damage.height());
++  wl_surface_attach(surface, it->second->shm_buffer.get(), 0, 0);
++  wl_surface_commit(surface);
++  connection_->ScheduleFlush();
++  return true;
++}
++
++bool WaylandShmBufferManager::DestroyBuffer(gfx::AcceleratedWidget widget) {
++  auto it = shm_buffers_.find(widget);
++  if (it == shm_buffers_.end())
++    return false;
++
++  shm_buffers_.erase(it);
++  connection_->ScheduleFlush();
++  return true;
++}
++
++}  // namespace ui
+diff --git a/ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.h b/ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.h
+new file mode 100644
+index 000000000000..8626ff007f4e
+--- /dev/null
++++ b/ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.h
+@@ -0,0 +1,76 @@
++// Copyright 2019 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SHARED_MEMORY_BUFFER_MANAGER_H_
++#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SHARED_MEMORY_BUFFER_MANAGER_H_
++
++#include <map>
++#include <memory>
++#include <vector>
++
++#include "base/containers/flat_map.h"
++#include "base/files/file.h"
++#include "base/macros.h"
++#include "ui/gfx/geometry/rect.h"
++#include "ui/gfx/native_widget_types.h"
++#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/wayland_util.h"
++
++namespace ui {
++
++class WaylandConnection;
++
++// Manages shared memory buffers, which are created by the GPU on the GPU
++// process/thread side, when software rendering is used.
++class WaylandShmBufferManager {
++ public:
++  explicit WaylandShmBufferManager(WaylandConnection* connection);
++  ~WaylandShmBufferManager();
++
++  // Creates a wl_buffer based on shared memory handle for the specified
++  // |widget|.
++  bool CreateBufferForWidget(gfx::AcceleratedWidget widget,
++                             base::File file,
++                             size_t length,
++                             const gfx::Size& size);
++
++  // Attaches and commits a |wl_buffer| created for the |widget| in the Create
++  // method.
++  bool PresentBufferForWidget(gfx::AcceleratedWidget widget,
++                              const gfx::Rect& damage);
++
++  // Destroyes a |wl_buffer|, which was created for the |widget| in the Create
++  // method.
++  bool DestroyBuffer(gfx::AcceleratedWidget widget);
++
++ private:
++  // Internal representation of a shared memory buffer.
++  struct ShmBuffer {
++    ShmBuffer();
++    ShmBuffer(wl::Object<struct wl_buffer> buffer,
++              wl::Object<struct wl_shm_pool> pool);
++    ~ShmBuffer();
++
++    // A wl_buffer backed by a shared memory handle passed from the gpu process.
++    wl::Object<struct wl_buffer> shm_buffer;
++
++    // Is used to create shared memory based buffer objects.
++    wl::Object<struct wl_shm_pool> shm_pool;
++
++    DISALLOW_COPY_AND_ASSIGN(ShmBuffer);
++  };
++
++  // A container of created buffers.
++  base::flat_map<gfx::AcceleratedWidget, std::unique_ptr<ShmBuffer>>
++      shm_buffers_;
++
++  // Non-owned pointer to the main connection.
++  WaylandConnection* connection_ = nullptr;
++
++  DISALLOW_COPY_AND_ASSIGN(WaylandShmBufferManager);
++};
++
++}  // namespace ui
++
++#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SHARED_MEMORY_BUFFER_MANAGER_H_
+diff --git a/ui/ozone/platform/wayland/wayland_surface_factory.cc b/ui/ozone/platform/wayland/wayland_surface_factory.cc
+index 83fb59de100e..dc4d7195d8f2 100644
+--- a/ui/ozone/platform/wayland/wayland_surface_factory.cc
++++ b/ui/ozone/platform/wayland/wayland_surface_factory.cc
+@@ -4,22 +4,17 @@
+ 
+ #include "ui/ozone/platform/wayland/wayland_surface_factory.h"
+ 
+-#include <fcntl.h>
+-#include <sys/mman.h>
+-#include <wayland-client.h>
++#include <memory>
+ 
+ #include "base/memory/ptr_util.h"
+-#include "base/memory/shared_memory.h"
+-#include "third_party/skia/include/core/SkSurface.h"
+ #include "ui/gfx/linux/client_native_pixmap_dmabuf.h"
+-#include "ui/gfx/vsync_provider.h"
+ #include "ui/ozone/common/egl_util.h"
+ #include "ui/ozone/common/gl_ozone_egl.h"
+ #include "ui/ozone/platform/wayland/gl_surface_wayland.h"
++#include "ui/ozone/platform/wayland/gpu/wayland_canvas_surface.h"
+ #include "ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h"
+ #include "ui/ozone/platform/wayland/wayland_object.h"
+ #include "ui/ozone/platform/wayland/wayland_window.h"
+-#include "ui/ozone/public/surface_ozone_canvas.h"
+ 
+ #if defined(WAYLAND_GBM)
+ #include "ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.h"
+@@ -29,109 +24,6 @@
+ 
+ namespace ui {
+ 
+-static void DeleteSharedMemory(void* pixels, void* context) {
+-  delete static_cast<base::SharedMemory*>(context);
+-}
+-
+-class WaylandCanvasSurface : public SurfaceOzoneCanvas {
+- public:
+-  WaylandCanvasSurface(WaylandConnectionProxy* connection,
+-                       WaylandWindow* window_);
+-  ~WaylandCanvasSurface() override;
+-
+-  // SurfaceOzoneCanvas
+-  sk_sp<SkSurface> GetSurface() override;
+-  void ResizeCanvas(const gfx::Size& viewport_size) override;
+-  void PresentCanvas(const gfx::Rect& damage) override;
+-  std::unique_ptr<gfx::VSyncProvider> CreateVSyncProvider() override;
+-
+- private:
+-  WaylandConnectionProxy* connection_;
+-  WaylandWindow* window_;
+-
+-  gfx::Size size_;
+-  sk_sp<SkSurface> sk_surface_;
+-  wl::Object<wl_shm_pool> pool_;
+-  wl::Object<wl_buffer> buffer_;
+-
+-  DISALLOW_COPY_AND_ASSIGN(WaylandCanvasSurface);
+-};
+-
+-WaylandCanvasSurface::WaylandCanvasSurface(WaylandConnectionProxy* connection,
+-                                           WaylandWindow* window)
+-    : connection_(connection),
+-      window_(window),
+-      size_(window->GetBounds().size()) {}
+-
+-WaylandCanvasSurface::~WaylandCanvasSurface() {}
+-
+-sk_sp<SkSurface> WaylandCanvasSurface::GetSurface() {
+-  if (sk_surface_)
+-    return sk_surface_;
+-
+-  size_t length = size_.width() * size_.height() * 4;
+-  auto shared_memory = base::WrapUnique(new base::SharedMemory);
+-  if (!shared_memory->CreateAndMapAnonymous(length))
+-    return nullptr;
+-
+-  wl::Object<wl_shm_pool> pool(wl_shm_create_pool(
+-      connection_->shm(), shared_memory->handle().GetHandle(), length));
+-  if (!pool)
+-    return nullptr;
+-  wl::Object<wl_buffer> buffer(
+-      wl_shm_pool_create_buffer(pool.get(), 0, size_.width(), size_.height(),
+-                                size_.width() * 4, WL_SHM_FORMAT_ARGB8888));
+-  if (!buffer)
+-    return nullptr;
+-
+-  sk_surface_ = SkSurface::MakeRasterDirectReleaseProc(
+-      SkImageInfo::MakeN32Premul(size_.width(), size_.height()),
+-      shared_memory->memory(), size_.width() * 4, &DeleteSharedMemory,
+-      shared_memory.get(), nullptr);
+-  if (!sk_surface_)
+-    return nullptr;
+-  pool_ = std::move(pool);
+-  buffer_ = std::move(buffer);
+-  (void)shared_memory.release();
+-  return sk_surface_;
+-}
+-
+-void WaylandCanvasSurface::ResizeCanvas(const gfx::Size& viewport_size) {
+-  if (size_ == viewport_size)
+-    return;
+-  // TODO(forney): We could implement more efficient resizes by allocating
+-  // buffers rounded up to larger sizes, and then reusing them if the new size
+-  // still fits (but still reallocate if the new size is much smaller than the
+-  // old size).
+-  if (sk_surface_) {
+-    sk_surface_.reset();
+-    buffer_.reset();
+-    pool_.reset();
+-  }
+-  size_ = viewport_size;
+-}
+-
+-void WaylandCanvasSurface::PresentCanvas(const gfx::Rect& damage) {
+-  // TODO(forney): This is just a naive implementation that allows chromium to
+-  // draw to the buffer at any time, even if it is being used by the Wayland
+-  // compositor. Instead, we should track buffer releases and frame callbacks
+-  // from Wayland to ensure perfect frames (while minimizing copies).
+-  wl_surface* surface = window_->surface();
+-  wl_surface_damage(surface, damage.x(), damage.y(), damage.width(),
+-                    damage.height());
+-  wl_surface_attach(surface, buffer_.get(), 0, 0);
+-  wl_surface_commit(surface);
+-  connection_->ScheduleFlush();
+-}
+-
+-std::unique_ptr<gfx::VSyncProvider>
+-WaylandCanvasSurface::CreateVSyncProvider() {
+-  // TODO(forney): This can be implemented with information from frame
+-  // callbacks, and possibly output refresh rate.
+-  NOTIMPLEMENTED();
+-  return nullptr;
+-}
+-
+ namespace {
+ 
+ class GLOzoneEGLWayland : public GLOzoneEGL {
+@@ -145,6 +37,10 @@ class GLOzoneEGLWayland : public GLOzoneEGL {
+ 
+   scoped_refptr<gl::GLSurface> CreateSurfacelessViewGLSurface(
+       gfx::AcceleratedWidget window) override {
++    // Only EGLGLES2 is supported with surfaceless view gl.
++    if (gl::GetGLImplementation() != gl::kGLImplementationEGLGLES2)
++      return nullptr;
++
+ #if defined(WAYLAND_GBM)
+     // If there is a gbm device available, use surfaceless gl surface.
+     if (!connection_->gbm_device())
+@@ -173,10 +69,15 @@ class GLOzoneEGLWayland : public GLOzoneEGL {
+ 
+ scoped_refptr<gl::GLSurface> GLOzoneEGLWayland::CreateViewGLSurface(
+     gfx::AcceleratedWidget widget) {
++  // Only EGLGLES2 is supported with surfaceless view gl.
++  if (gl::GetGLImplementation() != gl::kGLImplementationEGLGLES2)
++    return nullptr;
++
+   DCHECK(connection_);
+   WaylandWindow* window = connection_->GetWindow(widget);
+   if (!window)
+     return nullptr;
++
+   // The wl_egl_window needs to be created before the GLSurface so it can be
+   // used in the GLSurface constructor.
+   auto egl_window = CreateWaylandEglWindow(window);
+@@ -243,11 +144,7 @@ void WaylandSurfaceFactory::ScheduleBufferSwap(
+ 
+ std::unique_ptr<SurfaceOzoneCanvas>
+ WaylandSurfaceFactory::CreateCanvasForWidget(gfx::AcceleratedWidget widget) {
+-  if (!connection_)
+-    return nullptr;
+-  WaylandWindow* window = connection_->GetWindow(widget);
+-  DCHECK(window);
+-  return std::make_unique<WaylandCanvasSurface>(connection_, window);
++  return std::make_unique<WaylandCanvasSurface>(connection_, widget);
+ }
+ 
+ std::vector<gl::GLImplementation>
+diff --git a/ui/ozone/platform/wayland/wayland_surface_factory.h b/ui/ozone/platform/wayland/wayland_surface_factory.h
+index d20c3f903b8f..2f5ab3a92f17 100644
+--- a/ui/ozone/platform/wayland/wayland_surface_factory.h
++++ b/ui/ozone/platform/wayland/wayland_surface_factory.h
+@@ -7,7 +7,6 @@
+ 
+ #include "base/macros.h"
+ #include "base/memory/ref_counted.h"
+-#include "base/posix/eintr_wrapper.h"
+ #include "base/single_thread_task_runner.h"
+ #include "base/threading/sequenced_task_runner_handle.h"
+ #include "ui/gl/gl_surface.h"
+diff --git a/ui/ozone/platform/wayland/wayland_surface_factory_unittest.cc b/ui/ozone/platform/wayland/wayland_surface_factory_unittest.cc
+index e1365e7dd83a..d13b14faf3ec 100644
+--- a/ui/ozone/platform/wayland/wayland_surface_factory_unittest.cc
++++ b/ui/ozone/platform/wayland/wayland_surface_factory_unittest.cc
+@@ -25,8 +25,23 @@ class WaylandSurfaceFactoryTest : public WaylandTest {
+ 
+   void SetUp() override {
+     WaylandTest::SetUp();
++
++    auto connection_ptr = connection_->BindInterface();
++    connection_proxy_->SetWaylandConnection(std::move(connection_ptr));
++
+     canvas = surface_factory.CreateCanvasForWidget(widget_);
+     ASSERT_TRUE(canvas);
++
++    // Wait until initialization and mojo calls go through.
++    base::RunLoop().RunUntilIdle();
++  }
++
++  void TearDown() override {
++    canvas.reset();
++
++    // The mojo call to destroy shared buffer goes after canvas is destroyed.
++    // Wait until it's done.
++    base::RunLoop().RunUntilIdle();
+   }
+ 
+  protected:
+@@ -38,9 +53,13 @@ class WaylandSurfaceFactoryTest : public WaylandTest {
+ };
+ 
+ TEST_P(WaylandSurfaceFactoryTest, Canvas) {
++  canvas->ResizeCanvas(window_->GetBounds().size());
+   canvas->GetSurface();
+   canvas->PresentCanvas(gfx::Rect(5, 10, 20, 15));
+ 
++  // Wait until the mojo calls are done.
++  base::RunLoop().RunUntilIdle();
++
+   Expectation damage = EXPECT_CALL(*surface_, Damage(5, 10, 20, 15));
+   wl_resource* buffer_resource = nullptr;
+   Expectation attach = EXPECT_CALL(*surface_, Attach(_, 0, 0))
+@@ -60,11 +79,14 @@ TEST_P(WaylandSurfaceFactoryTest, Canvas) {
+ }
+ 
+ TEST_P(WaylandSurfaceFactoryTest, CanvasResize) {
++  canvas->ResizeCanvas(window_->GetBounds().size());
+   canvas->GetSurface();
+   canvas->ResizeCanvas(gfx::Size(100, 50));
+   canvas->GetSurface();
+   canvas->PresentCanvas(gfx::Rect(0, 0, 100, 50));
+ 
++  base::RunLoop().RunUntilIdle();
++
+   Expectation damage = EXPECT_CALL(*surface_, Damage(0, 0, 100, 50));
+   wl_resource* buffer_resource = nullptr;
+   Expectation attach = EXPECT_CALL(*surface_, Attach(_, 0, 0))
+diff --git a/ui/ozone/platform/wayland/wayland_util.h b/ui/ozone/platform/wayland/wayland_util.h
+index 2a2db3aba1db..5a5fbdb632b4 100644
+--- a/ui/ozone/platform/wayland/wayland_util.h
++++ b/ui/ozone/platform/wayland/wayland_util.h
+@@ -35,6 +35,8 @@ namespace wl {
+ using BufferSwapCallback =
+     base::OnceCallback<void(gfx::SwapResult, const gfx::PresentationFeedback&)>;
+ 
++using RequestSizeCallback = base::OnceCallback<void(const gfx::Size&)>;
++
+ wl_buffer* CreateSHMBuffer(const gfx::Size& size,
+                            base::SharedMemory* shared_memory,
+                            wl_shm* shm);
+diff --git a/ui/ozone/public/interfaces/wayland/wayland_connection.mojom b/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
+index b13007339e9f..f7fc67762911 100644
+--- a/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
++++ b/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
+@@ -14,6 +14,8 @@ import "ui/gfx/mojo/swap_result.mojom";
+ // Used by the GPU for communication with a WaylandConnection on the browser
+ // process.
+ interface WaylandConnection {
++  // Methods used for hardware accelerated rendering:
++  //
+   // Asks Wayland to create a wl_buffer based on the dmabuf |file| descriptor.
+   CreateZwpLinuxDmabuf(mojo_base.mojom.File file,
+                             uint32 width,
+@@ -33,6 +35,24 @@ interface WaylandConnection {
+                      gfx.mojom.Rect damage_region)
+       => (gfx.mojom.SwapResult swap_result,
+           gfx.mojom.PresentationFeedback feedback);
++
++  // Methods used for software rendering:
++  //
++  // Asks Wayland to create a wl_buffer based on the shared memory |file|
++  // descriptor. There can be only one buffer per |widget|.
++  CreateShmBufferForWidget(gfx.mojom.AcceleratedWidget widget,
++                           mojo_base.mojom.File file,
++                           uint64 length,
++                           gfx.mojom.Size size);
++
++  // Asks Wayland to damage and commit previously created buffer for the
++  // |widget|.
++  PresentShmBufferForWidget(gfx.mojom.AcceleratedWidget widget,
++                            gfx.mojom.Rect damage);
++
++  // Destroys the previously created shared memory based buffer for the
++  // |widget|.
++  DestroyShmBuffer(gfx.mojom.AcceleratedWidget widget);
+ };
+ 
+ 
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0034-ozone-wayland-Return-primary-display-on-null-window.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0034-ozone-wayland-Return-primary-display-on-null-window.patch
@@ -1,0 +1,40 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1485933
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 52a60a99cbb93e35e99d3314b1dabe9ecadfe79e Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Mon, 25 Feb 2019 15:00:26 +0200
+Subject: [PATCH 34/35] [ozone/wayland] Return primary display on null window.
+
+WaylandScreen::GetDisplayForAcceleratedWidget might be
+called right after the browser closed the WaylandWindow (on
+shutting down, for example), which may result in segfault or DCHECK.
+
+R=rjkroege@chromium.org
+Bug:578890
+Change-Id: Ic2b6fc5b9853a1aec7e5e70a0e979dc6c9e87aea
+---
+ ui/ozone/platform/wayland/wayland_screen.cc | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/ui/ozone/platform/wayland/wayland_screen.cc b/ui/ozone/platform/wayland/wayland_screen.cc
+index a7a0b8b1172e..19fb4050b2c0 100644
+--- a/ui/ozone/platform/wayland/wayland_screen.cc
++++ b/ui/ozone/platform/wayland/wayland_screen.cc
+@@ -100,7 +100,9 @@ display::Display WaylandScreen::GetPrimaryDisplay() const {
+ display::Display WaylandScreen::GetDisplayForAcceleratedWidget(
+     gfx::AcceleratedWidget widget) const {
+   auto* wayland_window = connection_->GetWindow(widget);
+-  DCHECK(wayland_window);
++  // A window might be destroyed by this time on shutting down the browser.
++  if (!wayland_window)
++    return GetPrimaryDisplay();
+ 
+   const std::set<uint32_t> entered_outputs_ids =
+       wayland_window->GetEnteredOutputsIds();
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0035-ozone-Implement-single-window-tab-dragging.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0035-ozone-Implement-single-window-tab-dragging.patch
@@ -1,0 +1,81 @@
+Upstream-Status: Backport
+
+* Backported from the ToT: https://crrev.com/c/1433272
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From ceadbfcbc9178b88485b8fff82da4d4fe5673af8 Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nickdiego@igalia.com>
+Date: Thu, 21 Feb 2019 17:55:18 +0000
+Subject: [PATCH 35/35] ozone: Implement single window tab dragging
+
+This change adds initial support for tab dragging for non-ChromeOS
+Ozone builds. This first patch makes it possible to drag tabs in inside
+a browser window. Dragging to external window will be addressed in a
+follow up CL.
+
+To make it possible, this patch adds an implementation of
+WindowFinder::GetLocalProcessWindowAtPoint(), which is used by
+TabDragController to determine which window to use when checking
+cursor is dragging over a tab strip.
+
+Bug: 896640
+Co-author: Julie Jeongeun Kim <jkim@igalia.com>
+Change-Id: I2ff3202333445aafa16f06623c9dbef0c77759e2
+Reviewed-on: https://chromium-review.googlesource.com/c/1433272
+Reviewed-by: Scott Violet <sky@chromium.org>
+Reviewed-by: Peter Kasting <pkasting@chromium.org>
+Commit-Queue: Nick Diego Yamane <nickdiego@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#634251}
+---
+ .../browser/ui/views/tabs/tab_drag_controller.cc  |  5 +++++
+ .../browser/ui/views/tabs/window_finder_ozone.cc  | 15 ++++++++++++---
+ 2 files changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/chrome/browser/ui/views/tabs/tab_drag_controller.cc b/chrome/browser/ui/views/tabs/tab_drag_controller.cc
+index 7ebba65ec624..c15aa3ff5390 100644
+--- a/chrome/browser/ui/views/tabs/tab_drag_controller.cc
++++ b/chrome/browser/ui/views/tabs/tab_drag_controller.cc
+@@ -333,7 +333,12 @@ TabDragController::TabDragController()
+       last_move_screen_loc_(0),
+       source_tab_index_(std::numeric_limits<size_t>::max()),
+       initial_move_(true),
++#if defined(USE_OZONE) && !defined(OS_CHROMEOS)
++      // TODO(crbug.com/896640): Support detachable tabs
++      detach_behavior_(NOT_DETACHABLE),
++#else
+       detach_behavior_(DETACHABLE),
++#endif
+       move_behavior_(REORDER),
+       mouse_has_ever_moved_left_(false),
+       mouse_has_ever_moved_right_(false),
+diff --git a/chrome/browser/ui/views/tabs/window_finder_ozone.cc b/chrome/browser/ui/views/tabs/window_finder_ozone.cc
+index bb904744b6bd..f290223e703c 100644
+--- a/chrome/browser/ui/views/tabs/window_finder_ozone.cc
++++ b/chrome/browser/ui/views/tabs/window_finder_ozone.cc
+@@ -4,10 +4,19 @@
+ 
+ #include "chrome/browser/ui/views/tabs/window_finder.h"
+ 
++#include "base/stl_util.h"
++#include "ui/aura/window.h"
++#include "ui/display/screen.h"
++#include "ui/views/widget/widget.h"
++
+ gfx::NativeWindow WindowFinder::GetLocalProcessWindowAtPoint(
+     const gfx::Point& screen_point,
+     const std::set<gfx::NativeWindow>& ignore) {
+-  NOTIMPLEMENTED()
+-      << "For Ozone builds, window finder is not supported for now.";
+-  return nullptr;
++  gfx::NativeWindow window =
++      display::Screen::GetScreen()->GetWindowAtScreenPoint(screen_point);
++  for (; window; window = window->parent()) {
++    if (views::Widget::GetWidgetForNativeWindow(window))
++      break;
++  }
++  return (window && !base::ContainsKey(ignore, window)) ? window : nullptr;
+ }
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland_72.0.3626.119.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_72.0.3626.119.bb
@@ -19,6 +19,25 @@ SRC_URI += " \
         file://0014-Reland-ozone-common-Make-gbm_wrapper-to-be-compiled-.patch \
         file://0015-Add-support-for-V4L2VDA-on-Linux.patch \
         file://0016-Add-mmap-via-libv4l-to-generic_v4l2_device.patch \
+        file://0017-Move-CharacterComposer-into-ui-base-ime.patch \
+        file://0018-ozone-wayland-Support-dead-keys.patch \
+        file://0019-ozone-wayland-Pass-0-modifier-on-DRM_FORMAT_MOD_INVA.patch \
+        file://0020-ozone-wayland-The-fuzzer-for-wayland-buffers-is-intr.patch \
+        file://0021-ozone-wayland-Remove-WaylandXkbKeyboardLayoutEngine.patch \
+        file://0022-ozone-wayland-Fix-wl_pointer-enter-event-handling.patch \
+        file://0023-ozone-wayland-Handle-preedit-string-in-WaylandInputM.patch \
+        file://0024-ozone-wayland-Use-gbm-with-in-process-gpu-mode.patch \
+        file://0025-ozone-wayland-Make-buffer-manager-resistant-to-event.patch \
+        file://0026-ozone-wayland-Reuse-tooltip-subsurfaces.patch \
+        file://0027-ozone-Implement-receiving-dragging.patch \
+        file://0028-ozone-wayland-Fix-includes-and-deps.patch \
+        file://0029-ozone-wayland-xkbcommon-Fix-layout-switching.patch \
+        file://0030-ozone-wayland-Fix-crash-when-there-is-no-zwp_linux_d.patch \
+        file://0031-Remove-dependency-cycle-between-ui-base-ime-and-ui-o.patch \
+        file://0032-Roll-third_party-minigbm-ff1ecaf.4fe3038.patch \
+        file://0033-ozone-wayland-Fix-software-rendering.patch \
+        file://0034-ozone-wayland-Return-primary-display-on-null-window.patch \
+        file://0035-ozone-Implement-single-window-tab-dragging.patch \
 "
 
 # Chromium can use v4l2 device for hardware accelerated video decoding. Make sure that


### PR DESCRIPTION
This just backports more upstream patches to improve
user experience.

The builds compile as usual.

* Added non-us keyboard layouts.
* Improved compatibility with different Wayland compositors.
* Stability fixes.

Signed-off-by: Maksim Sisov <msisov@igalia.com>