### PR TITLE
chromium: Fix do_configure() after 7c6d7bb

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -149,7 +149,7 @@ GN_ARGS += "use_custom_libcxx=false"
 
 # When using meta-clang, one can switch to using the lld linker
 # by using the ld-is-lld distro feature.
-GN_ARGS += "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', 'true', 'false', d)}"
+GN_ARGS += "use_lld=${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', 'true', 'false', d)}"
 
 # By default, passing is_official_build=true to GN causes its symbol_level
 # variable to be set to "2". This means the compiler will be passed "-g2" and


### PR DESCRIPTION
Commit 7c6d7bb ("chromium: enable lld when set in distro features") broke
do_configure() as instead of passing a key=value pair to GN it was just
passing the value half.

Spotted by @diego-santacruz.