### PR TITLE
firefox: Support multilib environment

### DIFF
--- a/classes/mozilla.bbclass
+++ b/classes/mozilla.bbclass
@@ -7,7 +7,8 @@ inherit pkgconfig
 
 EXTRA_OECONF = "--target=${TARGET_SYS} --host=${BUILD_SYS} \
                 --with-toolchain-prefix=${TARGET_SYS}- \
-                --prefix=${prefix}"
+                --prefix=${prefix} \
+                --libdir=${libdir}"
 EXTRA_OECONF_append_arm = " --disable-elf-hack"
 EXTRA_OECONF_append_x86 = " --disable-elf-hack"
 EXTRA_OECONF_append_x86-64 = " --disable-elf-hack"


### PR DESCRIPTION
We should specify `--libdir` in mozilla.bbclass
because multilib environment requests to put libraries into
not default location.
(e.g. `/usr/lib64` in x86_64 firefox build on multilib environment case.)

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>