### PR TITLE
firefox: Remove "installdir"

### DIFF
--- a/recipes-browser/firefox/firefox_60.4.0esr.bb
+++ b/recipes-browser/firefox/firefox_60.4.0esr.bb
@@ -76,7 +76,6 @@ S = "${WORKDIR}/firefox-${MOZ_APP_BASE_VERSION}"
 inherit mozilla rust-common
 
 DISABLE_STATIC=""
-EXTRA_OEMAKE += "installdir=${libdir}/${PN}"
 
 ARM_INSTRUCTION_SET_armv5 = "arm"
 


### PR DESCRIPTION
Because it doesn't take effect.
"--libdir" is already added to EXTRA_OECONF instead.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>