### PR TITLE
chromium-ozone-wayland: Fix regression with VizDisplayCompositor

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland/0001-ozone-wayland-Add-const-keyword-to-getters.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0001-ozone-wayland-Add-const-keyword-to-getters.patch
@@ -1,0 +1,202 @@
+Upstream-Status: Backport
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 4f19d8c539c63594d8fae98dad9b741f938d1482 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Fri, 15 Mar 2019 14:46:19 +0000
+Subject: [PATCH 01/11] [ozone/wayland] Add const keyword to getters.
+
+This patch just adds const keyword to getter methods.
+
+Bug: 578890
+Change-Id: Id1e37a2d498f309734447c18e5dbeae6535e87fb
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1508523
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Reviewed-by: Robert Kroeger <rjkroege@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#641194}
+---
+ .../wayland/gpu/wayland_connection_proxy.cc   |  4 +--
+ .../wayland/gpu/wayland_connection_proxy.h    |  8 ++---
+ .../platform/wayland/wayland_connection.cc    | 11 +++---
+ .../platform/wayland/wayland_connection.h     | 34 ++++++++++---------
+ 4 files changed, 30 insertions(+), 27 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+index 2d19898b0aa0..e2d82f83191f 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+@@ -132,7 +132,7 @@ void WaylandConnectionProxy::DestroyShmBuffer(gfx::AcceleratedWidget widget) {
+ }
+ 
+ WaylandWindow* WaylandConnectionProxy::GetWindow(
+-    gfx::AcceleratedWidget widget) {
++    gfx::AcceleratedWidget widget) const {
+   if (connection_)
+     return connection_->GetWindow(widget);
+   return nullptr;
+@@ -146,7 +146,7 @@ void WaylandConnectionProxy::ScheduleFlush() {
+                 "when multi-process moe is used";
+ }
+ 
+-intptr_t WaylandConnectionProxy::Display() {
++intptr_t WaylandConnectionProxy::Display() const {
+   if (connection_)
+     return reinterpret_cast<intptr_t>(connection_->display());
+ 
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+index 8da7a183aefc..27909874410d 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+@@ -99,7 +99,7 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
+   // hosted in the browser process).
+   //
+   // Return a WaylandWindow based on the |widget|.
+-  WaylandWindow* GetWindow(gfx::AcceleratedWidget widget);
++  WaylandWindow* GetWindow(gfx::AcceleratedWidget widget) const;
+   // Schedule flush in the Wayland message loop.
+   void ScheduleFlush();
+ 
+@@ -108,13 +108,13 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
+   // Returns a pointer to native display. When used in single process mode,
+   // a wl_display pointer is returned. For the the mode, when there are GPU
+   // and browser processes, EGL_DEFAULT_DISPLAY is returned.
+-  intptr_t Display();
++  intptr_t Display() const;
+ 
+   // Adds a WaylandConnectionClient binding.
+   void AddBindingWaylandConnectionClient(
+       ozone::mojom::WaylandConnectionClientRequest request);
+ 
+-  WaylandConnection* connection() { return connection_; }
++  WaylandConnection* connection() const { return connection_; }
+ 
+  private:
+   void CreateZwpLinuxDmabufInternal(base::File file,
+@@ -129,7 +129,7 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
+ 
+   // Non-owned pointer to a WaylandConnection. It is only used in a single
+   // process mode, when a shared dmabuf approach is not used.
+-  WaylandConnection* connection_ = nullptr;
++  WaylandConnection* const connection_;
+ 
+ #if defined(WAYLAND_GBM)
+   // A DRM render node based gbm device.
+diff --git a/ui/ozone/platform/wayland/wayland_connection.cc b/ui/ozone/platform/wayland/wayland_connection.cc
+index e7095507a83d..05e23b51a446 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/wayland_connection.cc
+@@ -123,12 +123,13 @@ void WaylandConnection::ScheduleFlush() {
+   scheduled_flush_ = true;
+ }
+ 
+-WaylandWindow* WaylandConnection::GetWindow(gfx::AcceleratedWidget widget) {
++WaylandWindow* WaylandConnection::GetWindow(
++    gfx::AcceleratedWidget widget) const {
+   auto it = window_map_.find(widget);
+   return it == window_map_.end() ? nullptr : it->second;
+ }
+ 
+-WaylandWindow* WaylandConnection::GetWindowWithLargestBounds() {
++WaylandWindow* WaylandConnection::GetWindowWithLargestBounds() const {
+   WaylandWindow* window_with_largest_bounds = nullptr;
+   for (auto entry : window_map_) {
+     if (!window_with_largest_bounds) {
+@@ -142,7 +143,7 @@ WaylandWindow* WaylandConnection::GetWindowWithLargestBounds() {
+   return window_with_largest_bounds;
+ }
+ 
+-WaylandWindow* WaylandConnection::GetCurrentFocusedWindow() {
++WaylandWindow* WaylandConnection::GetCurrentFocusedWindow() const {
+   for (auto entry : window_map_) {
+     WaylandWindow* window = entry.second;
+     if (window->has_pointer_focus())
+@@ -151,7 +152,7 @@ WaylandWindow* WaylandConnection::GetCurrentFocusedWindow() {
+   return nullptr;
+ }
+ 
+-WaylandWindow* WaylandConnection::GetCurrentKeyboardFocusedWindow() {
++WaylandWindow* WaylandConnection::GetCurrentKeyboardFocusedWindow() const {
+   for (auto entry : window_map_) {
+     WaylandWindow* window = entry.second;
+     if (window->has_keyboard_focus())
+@@ -178,7 +179,7 @@ void WaylandConnection::SetCursorBitmap(const std::vector<SkBitmap>& bitmaps,
+   pointer_->cursor()->UpdateBitmap(bitmaps, location, serial_);
+ }
+ 
+-int WaylandConnection::GetKeyboardModifiers() {
++int WaylandConnection::GetKeyboardModifiers() const {
+   int modifiers = 0;
+   if (keyboard_)
+     modifiers = keyboard_->modifiers();
+diff --git a/ui/ozone/platform/wayland/wayland_connection.h b/ui/ozone/platform/wayland/wayland_connection.h
+index c7da42b930dd..86228edc6bfe 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.h
++++ b/ui/ozone/platform/wayland/wayland_connection.h
+@@ -82,45 +82,47 @@ class WaylandConnection : public PlatformEventSource,
+   // Schedules a flush of the Wayland connection.
+   void ScheduleFlush();
+ 
+-  wl_display* display() { return display_.get(); }
+-  wl_compositor* compositor() { return compositor_.get(); }
+-  wl_subcompositor* subcompositor() { return subcompositor_.get(); }
+-  wl_shm* shm() { return shm_.get(); }
++  wl_display* display() const { return display_.get(); }
++  wl_compositor* compositor() const { return compositor_.get(); }
++  wl_subcompositor* subcompositor() const { return subcompositor_.get(); }
++  wl_shm* shm() const { return shm_.get(); }
+   xdg_shell* shell() const { return shell_.get(); }
+   zxdg_shell_v6* shell_v6() const { return shell_v6_.get(); }
+-  wl_seat* seat() { return seat_.get(); }
+-  wl_data_device* data_device() { return data_device_->data_device(); }
++  wl_seat* seat() const { return seat_.get(); }
++  wl_data_device* data_device() const { return data_device_->data_device(); }
+   wp_presentation* presentation() const { return presentation_.get(); }
+-  zwp_text_input_manager_v1* text_input_manager_v1() {
++  zwp_text_input_manager_v1* text_input_manager_v1() const {
+     return text_input_manager_v1_.get();
+   }
+ 
+-  WaylandWindow* GetWindow(gfx::AcceleratedWidget widget);
+-  WaylandWindow* GetWindowWithLargestBounds();
+-  WaylandWindow* GetCurrentFocusedWindow();
+-  WaylandWindow* GetCurrentKeyboardFocusedWindow();
++  WaylandWindow* GetWindow(gfx::AcceleratedWidget widget) const;
++  WaylandWindow* GetWindowWithLargestBounds() const;
++  WaylandWindow* GetCurrentFocusedWindow() const;
++  WaylandWindow* GetCurrentKeyboardFocusedWindow() const;
+   void AddWindow(gfx::AcceleratedWidget widget, WaylandWindow* window);
+   void RemoveWindow(gfx::AcceleratedWidget widget);
+ 
+   void set_serial(uint32_t serial) { serial_ = serial; }
+-  uint32_t serial() { return serial_; }
++  uint32_t serial() const { return serial_; }
+ 
+   void SetCursorBitmap(const std::vector<SkBitmap>& bitmaps,
+                        const gfx::Point& location);
+ 
+-  int GetKeyboardModifiers();
++  int GetKeyboardModifiers() const;
+ 
+   // Returns the current pointer, which may be null.
+-  WaylandPointer* pointer() { return pointer_.get(); }
++  WaylandPointer* pointer() const { return pointer_.get(); }
+ 
+-  WaylandDataSource* drag_data_source() { return drag_data_source_.get(); }
++  WaylandDataSource* drag_data_source() const {
++    return drag_data_source_.get();
++  }
+ 
+   WaylandOutputManager* wayland_output_manager() const {
+     return wayland_output_manager_.get();
+   }
+ 
+   // Returns the cursor position, which may be null.
+-  WaylandCursorPosition* wayland_cursor_position() {
++  WaylandCursorPosition* wayland_cursor_position() const {
+     return wayland_cursor_position_.get();
+   }
+ 
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0002-ozone-wayland-Clean-up-data-device-related-code.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0002-ozone-wayland-Clean-up-data-device-related-code.patch
@@ -1,0 +1,392 @@
+Upstream-Status: Backport
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 2b102c86c7add0c9d9fe032d00d016b3c55b2438 Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nickdiego@igalia.com>
+Date: Fri, 15 Mar 2019 23:42:03 +0000
+Subject: [PATCH 02/11] ozone/wayland: Clean up data device related code
+
+This CL cleans up, improve readability and fixes
+some styling/convention inconsistencies in wayland
+data device related code in ozone/wayland, such as:
+
+ - Use more meaningful names for DataDevice's sync
+ callback and related variables, in this case used
+ to defer data reading from data device's pipe file
+ descriptor. Also, use local variables to store wayland
+ callback structs, making it more consistent with other
+ ozone wayland classes;
+ - Move data source factory method into data device
+ manager, which is its actual factory in wayland
+ API/protocol;
+ - Improve and expand WaylandDataSource class variable
+ names making it easier to distinguish between clipboard
+ and drag&drop instances;
+ - Fix lint errors in files touched by this change;
+
+Bug: 875164
+Change-Id: I9af0e09908d94ada285f60592bba70ff0cc3904f
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1521887
+Commit-Queue: Nick Yamane <nickdiego@igalia.com>
+Reviewed-by: Maksim Sisov <msisov@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#641350}
+---
+ .../platform/wayland/wayland_connection.cc    | 40 ++++++--------
+ .../platform/wayland/wayland_connection.h     | 11 ++--
+ .../platform/wayland/wayland_data_device.cc   | 52 ++++++++++---------
+ .../platform/wayland/wayland_data_device.h    | 20 ++++---
+ .../wayland/wayland_data_device_manager.cc    |  7 ++-
+ .../wayland/wayland_data_device_manager.h     |  5 +-
+ 6 files changed, 73 insertions(+), 62 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/wayland_connection.cc b/ui/ozone/platform/wayland/wayland_connection.cc
+index 05e23b51a446..2044e47791f0 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/wayland_connection.cc
+@@ -7,6 +7,9 @@
+ #include <xdg-shell-unstable-v5-client-protocol.h>
+ #include <xdg-shell-unstable-v6-client-protocol.h>
+ 
++#include <algorithm>
++#include <utility>
++
+ #include "base/bind.h"
+ #include "base/logging.h"
+ #include "base/memory/ptr_util.h"
+@@ -36,15 +39,7 @@ constexpr uint32_t kMaxXdgShellVersion = 1;
+ constexpr uint32_t kMaxDeviceManagerVersion = 3;
+ constexpr uint32_t kMaxWpPresentationVersion = 1;
+ constexpr uint32_t kMaxTextInputManagerVersion = 1;
+-
+ constexpr uint32_t kMinWlOutputVersion = 2;
+-
+-std::unique_ptr<WaylandDataSource> CreateWaylandDataSource(
+-    WaylandDataDeviceManager* data_device_manager,
+-    WaylandConnection* connection) {
+-  wl_data_source* data_source = data_device_manager->CreateSource();
+-  return std::make_unique<WaylandDataSource>(data_source, connection);
+-}
+ }  // namespace
+ 
+ WaylandConnection::WaylandConnection()
+@@ -259,11 +254,11 @@ PlatformClipboard* WaylandConnection::GetPlatformClipboard() {
+ void WaylandConnection::OfferClipboardData(
+     const PlatformClipboard::DataMap& data_map,
+     PlatformClipboard::OfferDataClosure callback) {
+-  if (!data_source_) {
+-    data_source_ = CreateWaylandDataSource(data_device_manager_.get(), this);
+-    data_source_->WriteToClipboard(data_map);
++  if (!clipboard_data_source_) {
++    clipboard_data_source_ = data_device_manager_->CreateSource();
++    clipboard_data_source_->WriteToClipboard(data_map);
+   }
+-  data_source_->UpdateDataMap(data_map);
++  clipboard_data_source_->UpdateDataMap(data_map);
+   std::move(callback).Run();
+ }
+ 
+@@ -279,7 +274,7 @@ void WaylandConnection::RequestClipboardData(
+ }
+ 
+ bool WaylandConnection::IsSelectionOwner() {
+-  return !!data_source_;
++  return !!clipboard_data_source_;
+ }
+ 
+ void WaylandConnection::SetSequenceNumberUpdateCb(
+@@ -311,13 +306,11 @@ void WaylandConnection::SetTerminateGpuCallback(
+ 
+ void WaylandConnection::StartDrag(const ui::OSExchangeData& data,
+                                   int operation) {
+-  if (!drag_data_source_) {
+-    drag_data_source_ =
+-        CreateWaylandDataSource(data_device_manager_.get(), this);
+-  }
+-  drag_data_source_->Offer(data);
+-  drag_data_source_->SetAction(operation);
+-  data_device_->StartDrag(*(drag_data_source_->data_source()), data);
++  if (!dragdrop_data_source_)
++    dragdrop_data_source_ = data_device_manager_->CreateSource();
++  dragdrop_data_source_->Offer(data);
++  dragdrop_data_source_->SetAction(operation);
++  data_device_->StartDrag(*(dragdrop_data_source_->data_source()), data);
+ }
+ 
+ void WaylandConnection::FinishDragSession(uint32_t dnd_action,
+@@ -325,7 +318,7 @@ void WaylandConnection::FinishDragSession(uint32_t dnd_action,
+   if (source_window)
+     source_window->OnDragSessionClose(dnd_action);
+   data_device_->ResetSourceData();
+-  drag_data_source_.reset();
++  dragdrop_data_source_.reset();
+ }
+ 
+ void WaylandConnection::DeliverDragData(const std::string& mime_type,
+@@ -354,8 +347,9 @@ void WaylandConnection::GetAvailableMimeTypes(
+ }
+ 
+ void WaylandConnection::DataSourceCancelled() {
+-  SetClipboardData(std::string(), std::string());
+-  data_source_.reset();
++  DCHECK(clipboard_data_source_);
++  SetClipboardData({}, {});
++  clipboard_data_source_.reset();
+ }
+ 
+ void WaylandConnection::SetClipboardData(const std::string& contents,
+diff --git a/ui/ozone/platform/wayland/wayland_connection.h b/ui/ozone/platform/wayland/wayland_connection.h
+index 86228edc6bfe..a6bc2b4c65a0 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.h
++++ b/ui/ozone/platform/wayland/wayland_connection.h
+@@ -6,6 +6,9 @@
+ #define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CONNECTION_H_
+ 
+ #include <map>
++#include <memory>
++#include <string>
++#include <vector>
+ 
+ #include "base/files/file.h"
+ #include "base/message_loop/message_pump_libevent.h"
+@@ -32,7 +35,7 @@ class WaylandShmBufferManager;
+ class WaylandOutputManager;
+ class WaylandWindow;
+ 
+-// TODO: factor out PlatformClipboard to a separate class.
++// TODO(crbug.com/942203): factor out PlatformClipboard to a separate class.
+ class WaylandConnection : public PlatformEventSource,
+                           public PlatformClipboard,
+                           public ozone::mojom::WaylandConnection,
+@@ -114,7 +117,7 @@ class WaylandConnection : public PlatformEventSource,
+   WaylandPointer* pointer() const { return pointer_.get(); }
+ 
+   WaylandDataSource* drag_data_source() const {
+-    return drag_data_source_.get();
++    return dragdrop_data_source_.get();
+   }
+ 
+   WaylandOutputManager* wayland_output_manager() const {
+@@ -237,8 +240,8 @@ class WaylandConnection : public PlatformEventSource,
+ 
+   std::unique_ptr<WaylandDataDeviceManager> data_device_manager_;
+   std::unique_ptr<WaylandDataDevice> data_device_;
+-  std::unique_ptr<WaylandDataSource> data_source_;
+-  std::unique_ptr<WaylandDataSource> drag_data_source_;
++  std::unique_ptr<WaylandDataSource> clipboard_data_source_;
++  std::unique_ptr<WaylandDataSource> dragdrop_data_source_;
+   std::unique_ptr<WaylandKeyboard> keyboard_;
+   std::unique_ptr<WaylandOutputManager> wayland_output_manager_;
+   std::unique_ptr<WaylandPointer> pointer_;
+diff --git a/ui/ozone/platform/wayland/wayland_data_device.cc b/ui/ozone/platform/wayland/wayland_data_device.cc
+index 92e96de09489..225cf5370e6d 100644
+--- a/ui/ozone/platform/wayland/wayland_data_device.cc
++++ b/ui/ozone/platform/wayland/wayland_data_device.cc
+@@ -4,6 +4,9 @@
+ 
+ #include "ui/ozone/platform/wayland/wayland_data_device.h"
+ 
++#include <algorithm>
++#include <utility>
++
+ #include "base/bind.h"
+ #include "base/memory/shared_memory.h"
+ #include "base/strings/string16.h"
+@@ -67,10 +70,6 @@ void AddToOSExchangeData(const std::string& data,
+ }  // namespace
+ 
+ // static
+-const wl_callback_listener WaylandDataDevice::callback_listener_ = {
+-    WaylandDataDevice::SyncCallback,
+-};
+-
+ WaylandDataDevice::WaylandDataDevice(WaylandConnection* connection,
+                                      wl_data_device* data_device)
+     : data_device_(data_device),
+@@ -99,10 +98,10 @@ void WaylandDataDevice::RequestSelectionData(const std::string& mime_type) {
+ 
+   // Ensure there is not pending operation to be performed by the compositor,
+   // otherwise read(..) can block awaiting data to be sent to pipe.
+-  read_from_fd_closure_ =
++  deferred_read_closure_ =
+       base::BindOnce(&WaylandDataDevice::ReadClipboardDataFromFD,
+                      base::Unretained(this), std::move(fd), mime_type);
+-  RegisterSyncCallback();
++  RegisterDeferredReadCallback();
+ }
+ 
+ void WaylandDataDevice::RequestDragData(
+@@ -116,10 +115,10 @@ void WaylandDataDevice::RequestDragData(
+ 
+   // Ensure there is not pending operation to be performed by the compositor,
+   // otherwise read(..) can block awaiting data to be sent to pipe.
+-  read_from_fd_closure_ = base::BindOnce(&WaylandDataDevice::ReadDragDataFromFD,
+-                                         base::Unretained(this), std::move(fd),
+-                                         std::move(callback));
+-  RegisterSyncCallback();
++  deferred_read_closure_ = base::BindOnce(
++      &WaylandDataDevice::ReadDragDataFromFD, base::Unretained(this),
++      std::move(fd), std::move(callback));
++  RegisterDeferredReadCallback();
+ }
+ 
+ void WaylandDataDevice::DeliverDragData(const std::string& mime_type,
+@@ -195,13 +194,6 @@ void WaylandDataDevice::ReadDragDataFromFD(
+   std::move(callback).Run(contents);
+ }
+ 
+-void WaylandDataDevice::RegisterSyncCallback() {
+-  DCHECK(!sync_callback_);
+-  sync_callback_.reset(wl_display_sync(connection_->display()));
+-  wl_callback_add_listener(sync_callback_.get(), &callback_listener_, this);
+-  wl_display_flush(connection_->display());
+-}
+-
+ void WaylandDataDevice::ReadDataFromFD(base::ScopedFD fd,
+                                        std::string* contents) {
+   DCHECK(contents);
+@@ -363,15 +355,25 @@ void WaylandDataDevice::OnSelection(void* data,
+   self->selection_offer_->EnsureTextMimeTypeIfNeeded();
+ }
+ 
+-void WaylandDataDevice::SyncCallback(void* data,
+-                                     struct wl_callback* cb,
+-                                     uint32_t time) {
+-  WaylandDataDevice* data_device = static_cast<WaylandDataDevice*>(data);
+-  DCHECK(data_device);
++void WaylandDataDevice::RegisterDeferredReadCallback() {
++  static const wl_callback_listener kDeferredReadListener = {
++      WaylandDataDevice::DeferredReadCallback};
+ 
+-  std::move(data_device->read_from_fd_closure_).Run();
+-  DCHECK(data_device->read_from_fd_closure_.is_null());
+-  data_device->sync_callback_.reset();
++  DCHECK(!deferred_read_callback_);
++  deferred_read_callback_.reset(wl_display_sync(connection_->display()));
++  wl_callback_add_listener(deferred_read_callback_.get(),
++                           &kDeferredReadListener, this);
++  wl_display_flush(connection_->display());
++}
++
++void WaylandDataDevice::DeferredReadCallback(void* data,
++                                             struct wl_callback* cb,
++                                             uint32_t time) {
++  auto* data_device = static_cast<WaylandDataDevice*>(data);
++  DCHECK(data_device);
++  DCHECK(!data_device->deferred_read_closure_.is_null());
++  std::move(data_device->deferred_read_closure_).Run();
++  data_device->deferred_read_callback_.reset();
+ }
+ 
+ void WaylandDataDevice::CreateDragImage(const SkBitmap* bitmap) {
+diff --git a/ui/ozone/platform/wayland/wayland_data_device.h b/ui/ozone/platform/wayland/wayland_data_device.h
+index c3953993e08b..6efad52af789 100644
+--- a/ui/ozone/platform/wayland/wayland_data_device.h
++++ b/ui/ozone/platform/wayland/wayland_data_device.h
+@@ -6,8 +6,11 @@
+ #define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_DEVICE_H_
+ 
+ #include <wayland-client.h>
++
+ #include <list>
++#include <memory>
+ #include <string>
++#include <vector>
+ 
+ #include "base/callback.h"
+ #include "base/files/scoped_file.h"
+@@ -67,9 +70,6 @@ class WaylandDataDevice {
+       base::ScopedFD fd,
+       base::OnceCallback<void(const std::string&)> callback);
+ 
+-  // Registers display sync callback. Once it's called, it's reset.
+-  void RegisterSyncCallback();
+-
+   // Helper function to read data from fd.
+   void ReadDataFromFD(base::ScopedFD fd, std::string* contents);
+ 
+@@ -108,7 +108,14 @@ class WaylandDataDevice {
+                           wl_data_device* data_device,
+                           wl_data_offer* id);
+ 
+-  static void SyncCallback(void* data, struct wl_callback* cb, uint32_t time);
++  // Registers DeferredReadCallback as display sync callback listener, to
++  // ensure there is no pending operation to be performed by the compositor,
++  // otherwise read(..) could block awaiting data to be sent to pipe. It is
++  // reset once it's called.
++  void RegisterDeferredReadCallback();
++  static void DeferredReadCallback(void* data,
++                                   struct wl_callback* cb,
++                                   uint32_t time);
+ 
+   bool CreateSHMBuffer(const gfx::Size& size);
+   void CreateDragImage(const SkBitmap* bitmap);
+@@ -151,9 +158,8 @@ class WaylandDataDevice {
+   WaylandWindow* window_ = nullptr;
+ 
+   // Make sure server has written data on the pipe, before block on read().
+-  static const wl_callback_listener callback_listener_;
+-  base::OnceClosure read_from_fd_closure_;
+-  wl::Object<wl_callback> sync_callback_;
++  base::OnceClosure deferred_read_closure_;
++  wl::Object<wl_callback> deferred_read_callback_;
+ 
+   bool is_handling_dropped_data_ = false;
+   bool is_leaving_ = false;
+diff --git a/ui/ozone/platform/wayland/wayland_data_device_manager.cc b/ui/ozone/platform/wayland/wayland_data_device_manager.cc
+index 4c20f3fb4a31..25737b78ee81 100644
+--- a/ui/ozone/platform/wayland/wayland_data_device_manager.cc
++++ b/ui/ozone/platform/wayland/wayland_data_device_manager.cc
+@@ -5,6 +5,7 @@
+ #include "ui/ozone/platform/wayland/wayland_data_device_manager.h"
+ 
+ #include "ui/ozone/platform/wayland/wayland_connection.h"
++#include "ui/ozone/platform/wayland/wayland_data_source.h"
+ 
+ namespace ui {
+ 
+@@ -24,8 +25,10 @@ wl_data_device* WaylandDataDeviceManager::GetDevice() {
+                                                 connection_->seat());
+ }
+ 
+-wl_data_source* WaylandDataDeviceManager::CreateSource() {
+-  return wl_data_device_manager_create_data_source(device_manager_.get());
++std::unique_ptr<WaylandDataSource> WaylandDataDeviceManager::CreateSource() {
++  wl_data_source* data_source =
++      wl_data_device_manager_create_data_source(device_manager_.get());
++  return std::make_unique<WaylandDataSource>(data_source, connection_);
+ }
+ 
+ }  // namespace ui
+diff --git a/ui/ozone/platform/wayland/wayland_data_device_manager.h b/ui/ozone/platform/wayland/wayland_data_device_manager.h
+index f444d7d38575..18f5b077638b 100644
+--- a/ui/ozone/platform/wayland/wayland_data_device_manager.h
++++ b/ui/ozone/platform/wayland/wayland_data_device_manager.h
+@@ -7,12 +7,15 @@
+ 
+ #include <wayland-client.h>
+ 
++#include <memory>
++
+ #include "base/macros.h"
+ #include "ui/ozone/platform/wayland/wayland_object.h"
+ 
+ namespace ui {
+ 
+ class WaylandConnection;
++class WaylandDataSource;
+ 
+ class WaylandDataDeviceManager {
+  public:
+@@ -21,7 +24,7 @@ class WaylandDataDeviceManager {
+   ~WaylandDataDeviceManager();
+ 
+   wl_data_device* GetDevice();
+-  wl_data_source* CreateSource();
++  std::unique_ptr<WaylandDataSource> CreateSource();
+ 
+  private:
+   wl::Object<wl_data_device_manager> device_manager_;
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0003-ozone-Allow-running-presentation-feedback-any-time-a.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0003-ozone-Allow-running-presentation-feedback-any-time-a.patch
@@ -1,0 +1,223 @@
+Upstream-Status: Backport
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 8f2f37c56384a420a9d4baa68f5e3533d794bc18 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Tue, 26 Mar 2019 10:03:33 +0200
+Subject: [PATCH 03/11] ozone: Allow running presentation feedback any time
+ after swap ack.
+
+The previous limitation is artificial and blocks Wayland
+from correct behaviour.
+
+The presentation and swap completion callbacks come completely
+independently in case of Wayland, and blocking swap completion callback
+until presentation callback come adds an artificial delay to
+the display compositor as long as it's not known when the pixel
+will be turned to light.
+
+Thus, use local swap ids to allow the following order
+Swap[0]
+Swap-Ack[0]
+Swap[1]
+PresentationCallback[0]
+Swap-Ack[1]
+PresentationCallback[1]
+
+Right now, it crashes because Swap[1] sets
+allow_running_presentation_callback_ to false and the feedback
+for the Swap[0] cannot go through.
+
+To ensure that the presentation callback does not come earlier
+than the swap-ack callback, implement a queue with local swap ids
+to ensure 1) correct order of swap and swap-ack and ensure the
+presentation callbacks do not run earlier than their preceeding
+swap requests.
+
+Bug: 943096
+Change-Id: I0c399c6031991fd317484a8448228fe27ec69ded
+---
+ .../pass_through_image_transport_surface.cc   | 56 +++++++++++++++----
+ .../pass_through_image_transport_surface.h    | 11 +++-
+ 2 files changed, 54 insertions(+), 13 deletions(-)
+
+diff --git a/gpu/ipc/service/pass_through_image_transport_surface.cc b/gpu/ipc/service/pass_through_image_transport_surface.cc
+index 8827552d3206..477352d4d73d 100644
+--- a/gpu/ipc/service/pass_through_image_transport_surface.cc
++++ b/gpu/ipc/service/pass_through_image_transport_surface.cc
+@@ -56,7 +56,8 @@ gfx::SwapResult PassThroughImageTransportSurface::SwapBuffers(
+   StartSwapBuffers(&response);
+   gfx::SwapResult result = gl::GLSurfaceAdapter::SwapBuffers(
+       base::Bind(&PassThroughImageTransportSurface::BufferPresented,
+-                 weak_ptr_factory_.GetWeakPtr(), callback));
++                 weak_ptr_factory_.GetWeakPtr(), callback,
++                 GetCurrentLocalSwapId()));
+   response.result = result;
+   FinishSwapBuffers(std::move(response));
+   return result;
+@@ -77,7 +78,8 @@ void PassThroughImageTransportSurface::SwapBuffersAsync(
+                  weak_ptr_factory_.GetWeakPtr(), completion_callback,
+                  base::Passed(&response)),
+       base::Bind(&PassThroughImageTransportSurface::BufferPresented,
+-                 weak_ptr_factory_.GetWeakPtr(), presentation_callback));
++                 weak_ptr_factory_.GetWeakPtr(), presentation_callback,
++                 GetCurrentLocalSwapId()));
+ }
+ 
+ gfx::SwapResult PassThroughImageTransportSurface::SwapBuffersWithBounds(
+@@ -87,7 +89,8 @@ gfx::SwapResult PassThroughImageTransportSurface::SwapBuffersWithBounds(
+   StartSwapBuffers(&response);
+   gfx::SwapResult result = gl::GLSurfaceAdapter::SwapBuffersWithBounds(
+       rects, base::Bind(&PassThroughImageTransportSurface::BufferPresented,
+-                        weak_ptr_factory_.GetWeakPtr(), callback));
++                        weak_ptr_factory_.GetWeakPtr(), callback,
++                        GetCurrentLocalSwapId()));
+   response.result = result;
+   FinishSwapBuffers(std::move(response));
+   return result;
+@@ -104,7 +107,8 @@ gfx::SwapResult PassThroughImageTransportSurface::PostSubBuffer(
+   gfx::SwapResult result = gl::GLSurfaceAdapter::PostSubBuffer(
+       x, y, width, height,
+       base::Bind(&PassThroughImageTransportSurface::BufferPresented,
+-                 weak_ptr_factory_.GetWeakPtr(), callback));
++                 weak_ptr_factory_.GetWeakPtr(), callback,
++                 GetCurrentLocalSwapId()));
+   response.result = result;
+   FinishSwapBuffers(std::move(response));
+ 
+@@ -126,7 +130,8 @@ void PassThroughImageTransportSurface::PostSubBufferAsync(
+                  weak_ptr_factory_.GetWeakPtr(), completion_callback,
+                  base::Passed(&response)),
+       base::Bind(&PassThroughImageTransportSurface::BufferPresented,
+-                 weak_ptr_factory_.GetWeakPtr(), presentation_callback));
++                 weak_ptr_factory_.GetWeakPtr(), presentation_callback,
++                 GetCurrentLocalSwapId()));
+ }
+ 
+ gfx::SwapResult PassThroughImageTransportSurface::CommitOverlayPlanes(
+@@ -135,7 +140,8 @@ gfx::SwapResult PassThroughImageTransportSurface::CommitOverlayPlanes(
+   StartSwapBuffers(&response);
+   gfx::SwapResult result = gl::GLSurfaceAdapter::CommitOverlayPlanes(
+       base::Bind(&PassThroughImageTransportSurface::BufferPresented,
+-                 weak_ptr_factory_.GetWeakPtr(), callback));
++                 weak_ptr_factory_.GetWeakPtr(), callback,
++                 GetCurrentLocalSwapId()));
+   response.result = result;
+   FinishSwapBuffers(std::move(response));
+   return result;
+@@ -151,7 +157,8 @@ void PassThroughImageTransportSurface::CommitOverlayPlanesAsync(
+                  weak_ptr_factory_.GetWeakPtr(), callback,
+                  base::Passed(&response)),
+       base::Bind(&PassThroughImageTransportSurface::BufferPresented,
+-                 weak_ptr_factory_.GetWeakPtr(), presentation_callback));
++                 weak_ptr_factory_.GetWeakPtr(), presentation_callback,
++                 GetCurrentLocalSwapId()));
+ }
+ 
+ void PassThroughImageTransportSurface::SetVSyncEnabled(bool enabled) {
+@@ -197,10 +204,13 @@ void PassThroughImageTransportSurface::UpdateVSyncEnabled() {
+ void PassThroughImageTransportSurface::StartSwapBuffers(
+     gfx::SwapResponse* response) {
+   UpdateVSyncEnabled();
+-  allow_running_presentation_callback_ = false;
++  // Store the local swap id to ensure the presentation callback is not called
++  // before this swap is completed.
++  pending_local_swap_ids_.push(++local_swap_id_);
+ 
+-  // Populated later in the DecoderClient, before passing to client.
+-  response->swap_id = 0;
++  // Temporary store the local swap id to ensure swap acks come in the correct
++  // order.
++  response->swap_id = pending_local_swap_ids_.back();
+ 
+   response->swap_start = base::TimeTicks::Now();
+ }
+@@ -209,12 +219,20 @@ void PassThroughImageTransportSurface::FinishSwapBuffers(
+     gfx::SwapResponse response) {
+   response.swap_end = base::TimeTicks::Now();
+ 
++  // After the swap is completed, the local swap id is removed from the queue,
++  // and the presentation callback for this swap can be run at any time later.
++  DCHECK_EQ(pending_local_swap_ids_.front(), response.swap_id);
++  pending_local_swap_ids_.pop();
++
++  // Reset the local swap id. Correct id will be opulated later in the
++  // DecoderClient, before passing to client.
++  response.swap_id = 0;
++
+   if (delegate_) {
+     SwapBuffersCompleteParams params;
+     params.swap_response = std::move(response);
+     delegate_->DidSwapBuffersComplete(std::move(params));
+   }
+-  allow_running_presentation_callback_ = true;
+ }
+ 
+ void PassThroughImageTransportSurface::FinishSwapBuffersAsync(
+@@ -235,11 +253,25 @@ void PassThroughImageTransportSurface::FinishSwapBuffersAsync(
+ 
+ void PassThroughImageTransportSurface::BufferPresented(
+     const GLSurface::PresentationCallback& callback,
++    uint64_t swap_id,
+     const gfx::PresentationFeedback& feedback) {
+-  DCHECK(allow_running_presentation_callback_);
++  // The swaps are handled in queue. Thus, to allow the presentation feedback to
++  // be called after the first swap ack later, disregarding any of the following
++  // swap requests with own presentation feedbacks, and disallow calling the
++  // presentation callback before the same swap request, make sure the queue is
++  // either empty or the pending swap id is greater than the current. This means
++  // that the requested swap is completed and it's safe to call the presentation
++  // callback.
++  DCHECK(pending_local_swap_ids_.empty() ||
++         pending_local_swap_ids_.front() > swap_id);
++
+   callback.Run(feedback);
+   if (delegate_)
+     delegate_->BufferPresented(feedback);
+ }
+ 
++uint32_t PassThroughImageTransportSurface::GetCurrentLocalSwapId() const {
++  return pending_local_swap_ids_.front();
++}
++
+ }  // namespace gpu
+diff --git a/gpu/ipc/service/pass_through_image_transport_surface.h b/gpu/ipc/service/pass_through_image_transport_surface.h
+index 279bfa39e8d3..7b1a3ed4e8c4 100644
+--- a/gpu/ipc/service/pass_through_image_transport_surface.h
++++ b/gpu/ipc/service/pass_through_image_transport_surface.h
+@@ -10,6 +10,7 @@
+ #include <memory>
+ #include <vector>
+ 
++#include "base/containers/queue.h"
+ #include "base/macros.h"
+ #include "base/memory/weak_ptr.h"
+ #include "gpu/ipc/service/image_transport_surface.h"
+@@ -68,14 +69,22 @@ class PassThroughImageTransportSurface : public gl::GLSurfaceAdapter {
+                               std::unique_ptr<gfx::GpuFence> gpu_fence);
+ 
+   void BufferPresented(const GLSurface::PresentationCallback& callback,
++                       uint64_t swap_id,
+                        const gfx::PresentationFeedback& feedback);
+ 
++  uint32_t GetCurrentLocalSwapId() const;
++
+   const bool is_gpu_vsync_disabled_;
+   const bool is_multi_window_swap_vsync_override_enabled_;
+   base::WeakPtr<ImageTransportSurfaceDelegate> delegate_;
+   int swap_generation_ = 0;
+   bool vsync_enabled_ = true;
+-  bool allow_running_presentation_callback_ = true;
++
++  // Local swap ids, which are used to make sure the swap order is correct and
++  // the presentation callbacks are not called earlier than the swap ack of the
++  // same swap request.
++  uint64_t local_swap_id_ = 0;
++  base::queue<uint64_t> pending_local_swap_ids_;
+ 
+   base::WeakPtrFactory<PassThroughImageTransportSurface> weak_ptr_factory_;
+ 
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0004-ozone-wayland-Factor-out-zwp-linux-dmabuf-from-the-m.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0004-ozone-wayland-Factor-out-zwp-linux-dmabuf-from-the-m.patch
@@ -1,0 +1,777 @@
+Upstream-Status: Backport
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From a40cf1fb09ffceedbc0e381e4c90bb511e4a2898 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Wed, 27 Mar 2019 10:15:16 +0000
+Subject: [PATCH 04/11] [ozone/wayland] Factor out zwp linux dmabuf from the
+ manager.
+
+This change is a prerequisite for having buffer manager
+to handle frame callbacks.
+
+Also, each window will be backed with own buffer manager,
+which is needed to ease handling of the frame callbacks.
+
+Now, zwp_linux_dmabuf Wayland factory is wrapped around
+WaylandZwpLinuxDmabuf and receives requests to create
+buffers backed by dmabuf file descriptor. Returns
+a wl_buffer on success via a provided callback. If
+failed, nullptr is returned.
+
+Bug: 943096
+Change-Id: I85cff3ad7a12e26a4380b87d2933af377c436e4d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1539700
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Reviewed-by: Robert Kroeger <rjkroege@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#644728}
+---
+ ui/ozone/platform/wayland/BUILD.gn            |   2 +
+ .../wayland/wayland_buffer_manager.cc         | 149 +++---------------
+ .../platform/wayland/wayland_buffer_manager.h |  60 ++-----
+ .../platform/wayland/wayland_connection.cc    |  17 +-
+ .../platform/wayland/wayland_connection.h     |   4 +
+ .../wayland/wayland_connection_connector.cc   |   2 +-
+ ui/ozone/platform/wayland/wayland_util.h      |   3 +
+ .../wayland/wayland_zwp_linux_dmabuf.cc       | 144 +++++++++++++++++
+ .../wayland/wayland_zwp_linux_dmabuf.h        | 102 ++++++++++++
+ 9 files changed, 298 insertions(+), 185 deletions(-)
+ create mode 100644 ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.cc
+ create mode 100644 ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h
+
+diff --git a/ui/ozone/platform/wayland/BUILD.gn b/ui/ozone/platform/wayland/BUILD.gn
+index 0dbb7c94a779..d6138998dc03 100644
+--- a/ui/ozone/platform/wayland/BUILD.gn
++++ b/ui/ozone/platform/wayland/BUILD.gn
+@@ -70,6 +70,8 @@ source_set("wayland") {
+     "wayland_util.h",
+     "wayland_window.cc",
+     "wayland_window.h",
++    "wayland_zwp_linux_dmabuf.cc",
++    "wayland_zwp_linux_dmabuf.h",
+     "xdg_popup_wrapper.h",
+     "xdg_popup_wrapper_v5.cc",
+     "xdg_popup_wrapper_v5.h",
+diff --git a/ui/ozone/platform/wayland/wayland_buffer_manager.cc b/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+index 862989e10cfa..f42940c94de3 100644
+--- a/ui/ozone/platform/wayland/wayland_buffer_manager.cc
++++ b/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+@@ -4,14 +4,13 @@
+ 
+ #include "ui/ozone/platform/wayland/wayland_buffer_manager.h"
+ 
+-#include <drm_fourcc.h>
+-#include <linux-dmabuf-unstable-v1-client-protocol.h>
+ #include <presentation-time-client-protocol.h>
+ 
+ #include "base/trace_event/trace_event.h"
+ #include "ui/ozone/common/linux/drm_util_linux.h"
+ #include "ui/ozone/platform/wayland/wayland_connection.h"
+ #include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h"
+ 
+ namespace ui {
+ 
+@@ -43,27 +42,12 @@ base::TimeTicks GetPresentationFeedbackTimeStamp(uint32_t tv_sec_hi,
+ }  // namespace
+ 
+ WaylandBufferManager::Buffer::Buffer() = default;
+-WaylandBufferManager::Buffer::Buffer(uint32_t id,
+-                                     zwp_linux_buffer_params_v1* zwp_params,
+-                                     const gfx::Size& buffer_size)
+-    : buffer_id(id), size(buffer_size), params(zwp_params) {}
++WaylandBufferManager::Buffer::Buffer(const gfx::Size& buffer_size)
++    : size(buffer_size) {}
+ WaylandBufferManager::Buffer::~Buffer() = default;
+ 
+-WaylandBufferManager::WaylandBufferManager(
+-    zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
+-    WaylandConnection* connection)
+-    : zwp_linux_dmabuf_(zwp_linux_dmabuf), connection_(connection) {
+-  static const zwp_linux_dmabuf_v1_listener dmabuf_listener = {
+-      &WaylandBufferManager::Format,
+-      &WaylandBufferManager::Modifiers,
+-  };
+-  zwp_linux_dmabuf_v1_add_listener(zwp_linux_dmabuf_.get(), &dmabuf_listener,
+-                                   this);
+-
+-  // A roundtrip after binding guarantees that the client has received all
+-  // supported formats.
+-  wl_display_roundtrip(connection->display());
+-}
++WaylandBufferManager::WaylandBufferManager(WaylandConnection* connection)
++    : connection_(connection), weak_factory_(this) {}
+ 
+ WaylandBufferManager::~WaylandBufferManager() {
+   DCHECK(buffers_.empty());
+@@ -81,9 +65,6 @@ bool WaylandBufferManager::CreateBuffer(base::File file,
+   TRACE_EVENT2("wayland", "WaylandBufferManager::CreateZwpLinuxDmabuf",
+                "Format", format, "Buffer id", buffer_id);
+ 
+-  static const struct zwp_linux_buffer_params_v1_listener params_listener = {
+-      WaylandBufferManager::CreateSucceeded,
+-      WaylandBufferManager::CreateFailed};
+   if (!ValidateDataFromGpu(file, width, height, strides, offsets, format,
+                            modifiers, planes_count, buffer_id)) {
+     // base::File::Close() has an assertion that checks if blocking operations
+@@ -92,36 +73,15 @@ bool WaylandBufferManager::CreateBuffer(base::File file,
+     return false;
+   }
+ 
+-  base::ScopedFD fd(file.TakePlatformFile());
+-
+-  // Store |params| connected to |buffer_id| to track buffer creation and
+-  // identify, which buffer a client wants to use.
+-  DCHECK(zwp_linux_dmabuf_);
+-  struct zwp_linux_buffer_params_v1* params =
+-      zwp_linux_dmabuf_v1_create_params(zwp_linux_dmabuf_.get());
+-
+-  buffers_.insert(std::pair<uint32_t, std::unique_ptr<Buffer>>(
+-      buffer_id,
+-      std::make_unique<Buffer>(buffer_id, params, gfx::Size(width, height))));
+-
+-  for (size_t i = 0; i < planes_count; i++) {
+-    uint32_t modifier_lo = 0;
+-    uint32_t modifier_hi = 0;
+-    if (modifiers[i] != DRM_FORMAT_MOD_INVALID) {
+-      modifier_lo = modifiers[i] & UINT32_MAX;
+-      modifier_hi = modifiers[i] >> 32;
+-    } else {
+-      DCHECK_EQ(planes_count, 1u) << "Invalid modifier may be passed only in "
+-                                     "case of single plane format being used";
+-    }
+-    zwp_linux_buffer_params_v1_add(params, fd.get(), i /* plane id */,
+-                                   offsets[i], strides[i], modifier_hi,
+-                                   modifier_lo);
+-  }
+-  zwp_linux_buffer_params_v1_add_listener(params, &params_listener, this);
+-  zwp_linux_buffer_params_v1_create(params, width, height, format, 0);
++  std::unique_ptr<Buffer> buffer =
++      std::make_unique<Buffer>(gfx::Size(width, height));
++  buffers_.insert(std::make_pair(buffer_id, std::move(buffer)));
+ 
+-  connection_->ScheduleFlush();
++  auto callback = base::BindOnce(&WaylandBufferManager::OnCreateBufferComplete,
++                                 weak_factory_.GetWeakPtr(), buffer_id);
++  connection_->zwp_dmabuf()->CreateBuffer(
++      std::move(file), gfx::Size(width, height), strides, offsets, modifiers,
++      format, planes_count, std::move(callback));
+   return true;
+ }
+ 
+@@ -130,7 +90,7 @@ bool WaylandBufferManager::ScheduleBufferSwap(gfx::AcceleratedWidget widget,
+                                               uint32_t buffer_id,
+                                               const gfx::Rect& damage_region,
+                                               wl::BufferSwapCallback callback) {
+-  TRACE_EVENT1("wayland", "WaylandBufferManager::ScheduleSwapBuffer",
++  TRACE_EVENT1("wayland", "WaylandBufferManager::ScheduleBufferSwap",
+                "Buffer id", buffer_id);
+ 
+   if (!ValidateDataFromGpu(widget, buffer_id))
+@@ -190,9 +150,6 @@ void WaylandBufferManager::ClearState() {
+ 
+ // TODO(msisov): handle buffer swap failure or success.
+ bool WaylandBufferManager::SwapBuffer(Buffer* buffer) {
+-  TRACE_EVENT1("wayland", "WaylandBufferManager::SwapBuffer", "Buffer id",
+-               buffer->buffer_id);
+-
+   WaylandWindow* window = connection_->GetWindow(buffer->widget);
+   if (!window) {
+     error_message_ = "A WaylandWindow with current widget does not exist";
+@@ -309,27 +266,17 @@ bool WaylandBufferManager::ValidateDataFromGpu(
+   return true;
+ }
+ 
+-void WaylandBufferManager::CreateSucceededInternal(
+-    struct zwp_linux_buffer_params_v1* params,
+-    struct wl_buffer* new_buffer) {
+-  // Find which buffer id |params| belong to and store wl_buffer
+-  // with that id.
+-  Buffer* buffer = nullptr;
+-  for (auto& item : buffers_) {
+-    if (item.second.get()->params == params) {
+-      buffer = item.second.get();
+-      break;
+-    }
+-  }
+-
++void WaylandBufferManager::OnCreateBufferComplete(
++    uint32_t buffer_id,
++    wl::Object<struct wl_buffer> new_buffer) {
++  auto it = buffers_.find(buffer_id);
+   // It can happen that buffer was destroyed by a client while the Wayland
+   // compositor was processing a request to create a wl_buffer.
+-  if (!buffer)
++  if (it == buffers_.end())
+     return;
+ 
+-  buffer->wl_buffer.reset(new_buffer);
+-  buffer->params = nullptr;
+-  zwp_linux_buffer_params_v1_destroy(params);
++  Buffer* buffer = it->second.get();
++  buffer->wl_buffer = std::move(new_buffer);
+ 
+   if (buffer->widget != gfx::kNullAcceleratedWidget)
+     SwapBuffer(buffer);
+@@ -341,60 +288,6 @@ void WaylandBufferManager::OnBufferSwapped(Buffer* buffer) {
+       .Run(buffer->swap_result, std::move(buffer->feedback));
+ }
+ 
+-void WaylandBufferManager::AddSupportedFourCCFormat(uint32_t fourcc_format) {
+-  // Return on not the supported fourcc format.
+-  if (!IsValidBufferFormat(fourcc_format))
+-    return;
+-
+-  // It can happen that ::Format or ::Modifiers call can have already added such
+-  // a format. Thus, we can ignore that format.
+-  gfx::BufferFormat format = GetBufferFormatFromFourCCFormat(fourcc_format);
+-  auto it = std::find(supported_buffer_formats_.begin(),
+-                      supported_buffer_formats_.end(), format);
+-  if (it != supported_buffer_formats_.end())
+-    return;
+-  supported_buffer_formats_.push_back(format);
+-}
+-
+-// static
+-void WaylandBufferManager::Modifiers(
+-    void* data,
+-    struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
+-    uint32_t format,
+-    uint32_t modifier_hi,
+-    uint32_t modifier_lo) {
+-  WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+-  if (self)
+-    self->AddSupportedFourCCFormat(format);
+-}
+-
+-// static
+-void WaylandBufferManager::Format(void* data,
+-                                  struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
+-                                  uint32_t format) {
+-  WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+-  if (self)
+-    self->AddSupportedFourCCFormat(format);
+-}
+-
+-// static
+-void WaylandBufferManager::CreateSucceeded(
+-    void* data,
+-    struct zwp_linux_buffer_params_v1* params,
+-    struct wl_buffer* new_buffer) {
+-  WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+-  DCHECK(self);
+-  self->CreateSucceededInternal(params, new_buffer);
+-}
+-
+-// static
+-void WaylandBufferManager::CreateFailed(
+-    void* data,
+-    struct zwp_linux_buffer_params_v1* params) {
+-  zwp_linux_buffer_params_v1_destroy(params);
+-  LOG(FATAL) << "zwp_linux_buffer_params.create failed";
+-}
+-
+ // static
+ void WaylandBufferManager::FrameCallbackDone(void* data,
+                                              wl_callback* callback,
+diff --git a/ui/ozone/platform/wayland/wayland_buffer_manager.h b/ui/ozone/platform/wayland/wayland_buffer_manager.h
+index 482b98a7333c..ae7257e5b53c 100644
+--- a/ui/ozone/platform/wayland/wayland_buffer_manager.h
++++ b/ui/ozone/platform/wayland/wayland_buffer_manager.h
+@@ -11,6 +11,7 @@
+ #include "base/containers/flat_map.h"
+ #include "base/files/file.h"
+ #include "base/macros.h"
++#include "base/memory/weak_ptr.h"
+ #include "ui/gfx/geometry/rect.h"
+ #include "ui/gfx/native_widget_types.h"
+ #include "ui/gfx/presentation_feedback.h"
+@@ -18,14 +19,8 @@
+ #include "ui/ozone/platform/wayland/wayland_object.h"
+ #include "ui/ozone/platform/wayland/wayland_util.h"
+ 
+-struct zwp_linux_dmabuf_v1;
+-struct zwp_linux_buffer_params_v1;
+ struct wp_presentation_feedback;
+ 
+-namespace gfx {
+-enum class BufferFormat;
+-}  // namespace gfx
+-
+ namespace ui {
+ 
+ class WaylandConnection;
+@@ -34,16 +29,11 @@ class WaylandConnection;
+ // dmabuf buffers. Only used when GPU runs in own process.
+ class WaylandBufferManager {
+  public:
+-  WaylandBufferManager(zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
+-                       WaylandConnection* connection);
++  explicit WaylandBufferManager(WaylandConnection* connection);
+   ~WaylandBufferManager();
+ 
+   std::string error_message() { return std::move(error_message_); }
+ 
+-  std::vector<gfx::BufferFormat> supported_buffer_formats() {
+-    return supported_buffer_formats_;
+-  }
+-
+   // Creates a wl_buffer based on the dmabuf |file| descriptor. On error, false
+   // is returned and |error_message_| is set.
+   bool CreateBuffer(base::File file,
+@@ -82,14 +72,9 @@ class WaylandBufferManager {
+   // to this Buffer object on run-time.
+   struct Buffer {
+     Buffer();
+-    Buffer(uint32_t id,
+-           zwp_linux_buffer_params_v1* zwp_params,
+-           const gfx::Size& buffer_size);
++    explicit Buffer(const gfx::Size& buffer_size);
+     ~Buffer();
+ 
+-    // GPU GbmPixmapWayland corresponding buffer id.
+-    uint32_t buffer_id = 0;
+-
+     // Actual buffer size.
+     const gfx::Size size;
+ 
+@@ -108,9 +93,6 @@ class WaylandBufferManager {
+     // supported.
+     gfx::PresentationFeedback feedback;
+ 
+-    // Params that are used to create a wl_buffer.
+-    zwp_linux_buffer_params_v1* params = nullptr;
+-
+     // A wl_buffer backed by a dmabuf created on the GPU side.
+     wl::Object<struct wl_buffer> wl_buffer;
+ 
+@@ -146,30 +128,13 @@ class WaylandBufferManager {
+   bool ValidateDataFromGpu(const gfx::AcceleratedWidget& widget,
+                            uint32_t buffer_id);
+ 
+-  void CreateSucceededInternal(struct zwp_linux_buffer_params_v1* params,
+-                               struct wl_buffer* new_buffer);
++  // Callback method. Receives a result for the request to create a wl_buffer
++  // backend by dmabuf file descriptor from ::CreateBuffer call.
++  void OnCreateBufferComplete(uint32_t buffer_id,
++                              wl::Object<struct wl_buffer> new_buffer);
+ 
+   void OnBufferSwapped(Buffer* buffer);
+ 
+-  void AddSupportedFourCCFormat(uint32_t fourcc_format);
+-
+-  // zwp_linux_dmabuf_v1_listener
+-  static void Modifiers(void* data,
+-                        struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
+-                        uint32_t format,
+-                        uint32_t modifier_hi,
+-                        uint32_t modifier_lo);
+-  static void Format(void* data,
+-                     struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
+-                     uint32_t format);
+-
+-  // zwp_linux_buffer_params_v1_listener
+-  static void CreateSucceeded(void* data,
+-                              struct zwp_linux_buffer_params_v1* params,
+-                              struct wl_buffer* new_buffer);
+-  static void CreateFailed(void* data,
+-                           struct zwp_linux_buffer_params_v1* params);
+-
+   // wl_callback_listener
+   static void FrameCallbackDone(void* data,
+                                 wl_callback* callback,
+@@ -194,19 +159,18 @@ class WaylandBufferManager {
+       void* data,
+       struct wp_presentation_feedback* wp_presentation_feedback);
+ 
+-  // Stores announced buffer formats supported by the compositor.
+-  std::vector<gfx::BufferFormat> supported_buffer_formats_;
+-
+   // A container of created buffers.
+   base::flat_map<uint32_t, std::unique_ptr<Buffer>> buffers_;
+ 
+   // Set when invalid data is received from the GPU process.
+   std::string error_message_;
+ 
+-  wl::Object<zwp_linux_dmabuf_v1> zwp_linux_dmabuf_;
+-
+   // Non-owned pointer to the main connection.
+-  WaylandConnection* connection_ = nullptr;
++  WaylandConnection* const connection_;
++
++  base::WeakPtrFactory<WaylandBufferManager> weak_factory_;
++
++  DISALLOW_COPY_AND_ASSIGN(WaylandBufferManager);
+ };
+ 
+ }  // namespace ui
+diff --git a/ui/ozone/platform/wayland/wayland_connection.cc b/ui/ozone/platform/wayland/wayland_connection.cc
+index 2044e47791f0..142e9dece09f 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/wayland_connection.cc
+@@ -25,6 +25,7 @@
+ #include "ui/ozone/platform/wayland/wayland_output_manager.h"
+ #include "ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.h"
+ #include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h"
+ 
+ static_assert(XDG_SHELL_VERSION_CURRENT == 5, "Unsupported xdg-shell version");
+ 
+@@ -285,17 +286,15 @@ void WaylandConnection::SetSequenceNumberUpdateCb(
+ }
+ 
+ ozone::mojom::WaylandConnectionPtr WaylandConnection::BindInterface() {
+-  // This mustn't be called twice or when the zwp_linux_dmabuf interface is not
+-  // available.
+-  DCHECK(!binding_.is_bound() || buffer_manager_);
++  DCHECK(!binding_.is_bound());
+   ozone::mojom::WaylandConnectionPtr ptr;
+   binding_.Bind(MakeRequest(&ptr));
+   return ptr;
+ }
+ 
+ std::vector<gfx::BufferFormat> WaylandConnection::GetSupportedBufferFormats() {
+-  if (buffer_manager_)
+-    return buffer_manager_->supported_buffer_formats();
++  if (zwp_dmabuf_)
++    return zwp_dmabuf_->supported_buffer_formats();
+   return std::vector<gfx::BufferFormat>();
+ }
+ 
+@@ -508,13 +507,15 @@ void WaylandConnection::Global(void* data,
+     connection->data_device_manager_.reset(new WaylandDataDeviceManager(
+         data_device_manager.release(), connection));
+     connection->EnsureDataDevice();
+-  } else if (!connection->buffer_manager_ &&
++  } else if (!connection->zwp_dmabuf_ &&
+              (strcmp(interface, "zwp_linux_dmabuf_v1") == 0)) {
+     wl::Object<zwp_linux_dmabuf_v1> zwp_linux_dmabuf =
+         wl::Bind<zwp_linux_dmabuf_v1>(
+             registry, name, std::min(version, kMaxLinuxDmabufVersion));
+-    connection->buffer_manager_.reset(
+-        new WaylandBufferManager(zwp_linux_dmabuf.release(), connection));
++    connection->zwp_dmabuf_ = std::make_unique<WaylandZwpLinuxDmabuf>(
++        zwp_linux_dmabuf.release(), connection);
++    connection->buffer_manager_ =
++        std::make_unique<WaylandBufferManager>(connection);
+   } else if (!connection->presentation_ &&
+              (strcmp(interface, "wp_presentation") == 0)) {
+     connection->presentation_ =
+diff --git a/ui/ozone/platform/wayland/wayland_connection.h b/ui/ozone/platform/wayland/wayland_connection.h
+index a6bc2b4c65a0..624f1cdf1eee 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.h
++++ b/ui/ozone/platform/wayland/wayland_connection.h
+@@ -34,6 +34,7 @@ class WaylandBufferManager;
+ class WaylandShmBufferManager;
+ class WaylandOutputManager;
+ class WaylandWindow;
++class WaylandZwpLinuxDmabuf;
+ 
+ // TODO(crbug.com/942203): factor out PlatformClipboard to a separate class.
+ class WaylandConnection : public PlatformEventSource,
+@@ -131,6 +132,8 @@ class WaylandConnection : public PlatformEventSource,
+ 
+   WaylandBufferManager* buffer_manager() const { return buffer_manager_.get(); }
+ 
++  WaylandZwpLinuxDmabuf* zwp_dmabuf() const { return zwp_dmabuf_.get(); }
++
+   // Clipboard implementation.
+   PlatformClipboard* GetPlatformClipboard();
+   void DataSourceCancelled();
+@@ -248,6 +251,7 @@ class WaylandConnection : public PlatformEventSource,
+   std::unique_ptr<WaylandTouch> touch_;
+   std::unique_ptr<WaylandCursorPosition> wayland_cursor_position_;
+   std::unique_ptr<WaylandShmBufferManager> shm_buffer_manager_;
++  std::unique_ptr<WaylandZwpLinuxDmabuf> zwp_dmabuf_;
+ 
+   // Objects that are using when GPU runs in own process.
+   std::unique_ptr<WaylandBufferManager> buffer_manager_;
+diff --git a/ui/ozone/platform/wayland/wayland_connection_connector.cc b/ui/ozone/platform/wayland/wayland_connection_connector.cc
+index 91cf7445d5ab..ca323862d9b8 100644
+--- a/ui/ozone/platform/wayland/wayland_connection_connector.cc
++++ b/ui/ozone/platform/wayland/wayland_connection_connector.cc
+@@ -84,7 +84,7 @@ void WaylandConnectionConnector::OnWaylandConnectionPtrBinded(
+   wcp_ptr->SetWaylandConnection(std::move(wc_ptr));
+ 
+ #if defined(WAYLAND_GBM)
+-  if (!connection_->buffer_manager()) {
++  if (!connection_->zwp_dmabuf()) {
+     LOG(WARNING) << "zwp_linux_dmabuf is not available.";
+     wcp_ptr->ResetGbmDevice();
+   }
+diff --git a/ui/ozone/platform/wayland/wayland_util.h b/ui/ozone/platform/wayland/wayland_util.h
+index 5a5fbdb632b4..6d4ae174db3f 100644
+--- a/ui/ozone/platform/wayland/wayland_util.h
++++ b/ui/ozone/platform/wayland/wayland_util.h
+@@ -37,6 +37,9 @@ using BufferSwapCallback =
+ 
+ using RequestSizeCallback = base::OnceCallback<void(const gfx::Size&)>;
+ 
++using OnRequestBufferCallback =
++    base::OnceCallback<void(wl::Object<struct wl_buffer>)>;
++
+ wl_buffer* CreateSHMBuffer(const gfx::Size& size,
+                            base::SharedMemory* shared_memory,
+                            wl_shm* shm);
+diff --git a/ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.cc b/ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.cc
+new file mode 100644
+index 000000000000..fccb6073f8a0
+--- /dev/null
++++ b/ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.cc
+@@ -0,0 +1,144 @@
++// Copyright 2019 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h"
++
++#include <drm_fourcc.h>
++#include <linux-dmabuf-unstable-v1-client-protocol.h>
++
++#include "ui/ozone/common/linux/drm_util_linux.h"
++#include "ui/ozone/platform/wayland/wayland_connection.h"
++
++namespace ui {
++
++WaylandZwpLinuxDmabuf::WaylandZwpLinuxDmabuf(
++    zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
++    WaylandConnection* connection)
++    : zwp_linux_dmabuf_(zwp_linux_dmabuf), connection_(connection) {
++  static const zwp_linux_dmabuf_v1_listener dmabuf_listener = {
++      &WaylandZwpLinuxDmabuf::Format,
++      &WaylandZwpLinuxDmabuf::Modifiers,
++  };
++  zwp_linux_dmabuf_v1_add_listener(zwp_linux_dmabuf_.get(), &dmabuf_listener,
++                                   this);
++
++  // A roundtrip after binding guarantees that the client has received all
++  // supported formats.
++  wl_display_roundtrip(connection_->display());
++}
++
++WaylandZwpLinuxDmabuf::~WaylandZwpLinuxDmabuf() = default;
++
++void WaylandZwpLinuxDmabuf::CreateBuffer(base::File file,
++                                         const gfx::Size& size,
++                                         const std::vector<uint32_t>& strides,
++                                         const std::vector<uint32_t>& offsets,
++                                         const std::vector<uint64_t>& modifiers,
++                                         uint32_t format,
++                                         uint32_t planes_count,
++                                         wl::OnRequestBufferCallback callback) {
++  static const struct zwp_linux_buffer_params_v1_listener params_listener = {
++      &WaylandZwpLinuxDmabuf::CreateSucceeded,
++      &WaylandZwpLinuxDmabuf::CreateFailed};
++
++  struct zwp_linux_buffer_params_v1* params =
++      zwp_linux_dmabuf_v1_create_params(zwp_linux_dmabuf_.get());
++
++  // Store the |params| with the corresponding |callback| to identify newly
++  // created buffer and notify the client about it via the |callback|.
++  pending_params_.insert(std::make_pair(params, std::move(callback)));
++
++  base::ScopedFD fd(file.TakePlatformFile());
++
++  for (size_t i = 0; i < planes_count; i++) {
++    uint32_t modifier_lo = 0;
++    uint32_t modifier_hi = 0;
++    if (modifiers[i] != DRM_FORMAT_MOD_INVALID) {
++      modifier_lo = modifiers[i] & UINT32_MAX;
++      modifier_hi = modifiers[i] >> 32;
++    } else {
++      DCHECK_EQ(planes_count, 1u) << "Invalid modifier may be passed only in "
++                                     "case of single plane format being used";
++    }
++    zwp_linux_buffer_params_v1_add(params, fd.get(), i /* plane id */,
++                                   offsets[i], strides[i], modifier_hi,
++                                   modifier_lo);
++  }
++  zwp_linux_buffer_params_v1_add_listener(params, &params_listener, this);
++  zwp_linux_buffer_params_v1_create(params, size.width(), size.height(), format,
++                                    0);
++
++  connection_->ScheduleFlush();
++}
++
++void WaylandZwpLinuxDmabuf::AddSupportedFourCCFormat(uint32_t fourcc_format) {
++  // Return on not the supported fourcc format.
++  if (!IsValidBufferFormat(fourcc_format))
++    return;
++
++  // It can happen that ::Format or ::Modifiers call can have already added
++  // such a format. Thus, we can ignore that format.
++  gfx::BufferFormat format = GetBufferFormatFromFourCCFormat(fourcc_format);
++  auto it = std::find(supported_buffer_formats_.begin(),
++                      supported_buffer_formats_.end(), format);
++  if (it != supported_buffer_formats_.end())
++    return;
++  supported_buffer_formats_.push_back(format);
++}
++
++void WaylandZwpLinuxDmabuf::NotifyRequestCreateBufferDone(
++    struct zwp_linux_buffer_params_v1* params,
++    struct wl_buffer* new_buffer) {
++  auto it = pending_params_.find(params);
++  DCHECK(it != pending_params_.end());
++
++  std::move(it->second).Run(wl::Object<struct wl_buffer>(new_buffer));
++
++  pending_params_.erase(it);
++  zwp_linux_buffer_params_v1_destroy(params);
++
++  connection_->ScheduleFlush();
++}
++
++// static
++void WaylandZwpLinuxDmabuf::Modifiers(
++    void* data,
++    struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
++    uint32_t format,
++    uint32_t modifier_hi,
++    uint32_t modifier_lo) {
++  WaylandZwpLinuxDmabuf* self = static_cast<WaylandZwpLinuxDmabuf*>(data);
++  if (self)
++    self->AddSupportedFourCCFormat(format);
++}
++
++// static
++void WaylandZwpLinuxDmabuf::Format(void* data,
++                                   struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
++                                   uint32_t format) {
++  WaylandZwpLinuxDmabuf* self = static_cast<WaylandZwpLinuxDmabuf*>(data);
++  if (self)
++    self->AddSupportedFourCCFormat(format);
++}
++
++// static
++void WaylandZwpLinuxDmabuf::CreateSucceeded(
++    void* data,
++    struct zwp_linux_buffer_params_v1* params,
++    struct wl_buffer* new_buffer) {
++  WaylandZwpLinuxDmabuf* self = static_cast<WaylandZwpLinuxDmabuf*>(data);
++  if (self)
++    self->NotifyRequestCreateBufferDone(params, new_buffer);
++}
++
++// static
++void WaylandZwpLinuxDmabuf::CreateFailed(
++    void* data,
++    struct zwp_linux_buffer_params_v1* params) {
++  WaylandZwpLinuxDmabuf* self = static_cast<WaylandZwpLinuxDmabuf*>(data);
++  if (self)
++    self->NotifyRequestCreateBufferDone(params, nullptr);
++}
++
++}  // namespace ui
+diff --git a/ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h b/ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h
+new file mode 100644
+index 000000000000..5c393d5a447d
+--- /dev/null
++++ b/ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h
+@@ -0,0 +1,102 @@
++// Copyright 2019 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_ZWP_LINUX_DMABUF_H_
++#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_ZWP_LINUX_DMABUF_H_
++
++#include <vector>
++
++#include "base/containers/flat_map.h"
++#include "base/files/file.h"
++#include "base/macros.h"
++#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/wayland_util.h"
++
++struct zwp_linux_dmabuf_v1;
++struct zwp_linux_buffer_params_v1;
++
++namespace gfx {
++enum class BufferFormat;
++class Size;
++}  // namespace gfx
++
++namespace ui {
++
++class WaylandConnection;
++
++// Wrapper around |zwp_linux_dmabuf_v1| Wayland factory, which creates
++// |wl_buffer|s backed by dmabuf |file| descriptor.
++class WaylandZwpLinuxDmabuf {
++ public:
++  WaylandZwpLinuxDmabuf(zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
++                        WaylandConnection* connection);
++  ~WaylandZwpLinuxDmabuf();
++
++  // Requests to create a wl_buffer backed by the |file| descriptor. The result
++  // is sent back via the |callback|. If buffer creation failed, nullptr is sent
++  // back via the callback. Otherwise, a pointer to the |wl_buffer| is sent.
++  void CreateBuffer(base::File file,
++                    const gfx::Size& size,
++                    const std::vector<uint32_t>& strides,
++                    const std::vector<uint32_t>& offsets,
++                    const std::vector<uint64_t>& modifiers,
++                    uint32_t format,
++                    uint32_t planes_count,
++                    wl::OnRequestBufferCallback callback);
++
++  // Returns supported buffer formats received from the Wayland compositor.
++  std::vector<gfx::BufferFormat> supported_buffer_formats() const {
++    return supported_buffer_formats_;
++  }
++
++ private:
++  // Receives supported |fourcc_format| from either ::Modifers or ::Format call
++  // (depending on the protocol version), and stores it as gfx::BufferFormat to
++  // the |supported_buffer_formats_| container.
++  void AddSupportedFourCCFormat(uint32_t fourcc_format);
++
++  // Finds the stored callback corresponding to the |params| created in the
++  // RequestBufferAsync call, and passes the wl_buffer to the client. The
++  // |new_buffer| can be null.
++  void NotifyRequestCreateBufferDone(struct zwp_linux_buffer_params_v1* params,
++                                     struct wl_buffer* new_buffer);
++
++  // zwp_linux_dmabuf_v1_listener
++  static void Modifiers(void* data,
++                        struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
++                        uint32_t format,
++                        uint32_t modifier_hi,
++                        uint32_t modifier_lo);
++  static void Format(void* data,
++                     struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf,
++                     uint32_t format);
++
++  // zwp_linux_buffer_params_v1_listener
++  static void CreateSucceeded(void* data,
++                              struct zwp_linux_buffer_params_v1* params,
++                              struct wl_buffer* new_buffer);
++  static void CreateFailed(void* data,
++                           struct zwp_linux_buffer_params_v1* params);
++
++  // Holds pointer to the zwp_linux_dmabuf_v1 Wayland factory.
++  const wl::Object<zwp_linux_dmabuf_v1> zwp_linux_dmabuf_;
++
++  // Non-owned.
++  WaylandConnection* const connection_;
++
++  // Holds supported DRM formats translated to gfx::BufferFormat.
++  std::vector<gfx::BufferFormat> supported_buffer_formats_;
++
++  // Contains callbacks for requests to create |wl_buffer|s using
++  // |zwp_linux_dmabuf_| factory.
++  base::flat_map<struct zwp_linux_buffer_params_v1*,
++                 wl::OnRequestBufferCallback>
++      pending_params_;
++
++  DISALLOW_COPY_AND_ASSIGN(WaylandZwpLinuxDmabuf);
++};
++
++}  // namespace ui
++
++#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_ZWP_LINUX_DMABUF_H_
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0005-ozone-wayland-Handle-viz-process-restart.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0005-ozone-wayland-Handle-viz-process-restart.patch
@@ -1,0 +1,90 @@
+Upstream-Status: Backport
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 462e30f4f215bd9be321f297309673f36b14f211 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Wed, 27 Mar 2019 18:58:35 +0000
+Subject: [PATCH 05/11] [ozone/wayland] Handle viz process restart.
+
+The viz aka gpu process can unexpectedly fail and be restarted.
+This requires clearing the state of the WaylandBufferManager and
+unbinding the WaylandConnection interface.
+
+After this change, restart works as expected.
+
+TEST: about://gpucrash => the viz/gpu process restarts and the
+buffer management flow continues normally.
+
+Bug: 946374
+Change-Id: I3133f242f2ef403cc9a230dfdaa4437be20ad611
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1539737
+Reviewed-by: Robert Kroeger <rjkroege@chromium.org>
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#644917}
+---
+ ui/ozone/platform/wayland/wayland_connection.cc          | 9 +++++++--
+ ui/ozone/platform/wayland/wayland_connection.h           | 5 +++++
+ .../platform/wayland/wayland_connection_connector.cc     | 3 +--
+ 3 files changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/wayland_connection.cc b/ui/ozone/platform/wayland/wayland_connection.cc
+index 142e9dece09f..4bb0b0bcbe8a 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/wayland_connection.cc
+@@ -292,6 +292,12 @@ ozone::mojom::WaylandConnectionPtr WaylandConnection::BindInterface() {
+   return ptr;
+ }
+ 
++void WaylandConnection::OnChannelDestroyed() {
++  binding_.Unbind();
++  if (buffer_manager_)
++    buffer_manager_->ClearState();
++}
++
+ std::vector<gfx::BufferFormat> WaylandConnection::GetSupportedBufferFormats() {
+   if (zwp_dmabuf_)
+     return zwp_dmabuf_->supported_buffer_formats();
+@@ -395,8 +401,7 @@ void WaylandConnection::OnFileCanWriteWithoutBlocking(int fd) {}
+ 
+ void WaylandConnection::TerminateGpuProcess(std::string reason) {
+   std::move(terminate_gpu_cb_).Run(std::move(reason));
+-  binding_.Unbind();
+-  buffer_manager_->ClearState();
++  // The GPU process' failure results in calling ::OnChannelDestroyed.
+ }
+ 
+ void WaylandConnection::EnsureDataDevice() {
+diff --git a/ui/ozone/platform/wayland/wayland_connection.h b/ui/ozone/platform/wayland/wayland_connection.h
+index 624f1cdf1eee..9a4a4a38313c 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.h
++++ b/ui/ozone/platform/wayland/wayland_connection.h
+@@ -158,6 +158,11 @@ class WaylandConnection : public PlatformEventSource,
+   // Returns bound pointer to own mojo interface.
+   ozone::mojom::WaylandConnectionPtr BindInterface();
+ 
++  // Unbinds the interface and clears the state of the |buffer_manager_|. Used
++  // only when the GPU channel, which uses the mojo pipe to this interface, is
++  // destroyed.
++  void OnChannelDestroyed();
++
+   std::vector<gfx::BufferFormat> GetSupportedBufferFormats();
+ 
+   void SetTerminateGpuCallback(
+diff --git a/ui/ozone/platform/wayland/wayland_connection_connector.cc b/ui/ozone/platform/wayland/wayland_connection_connector.cc
+index ca323862d9b8..812fb15e97ba 100644
+--- a/ui/ozone/platform/wayland/wayland_connection_connector.cc
++++ b/ui/ozone/platform/wayland/wayland_connection_connector.cc
+@@ -44,8 +44,7 @@ void WaylandConnectionConnector::OnGpuProcessLaunched(
+     const base::RepeatingCallback<void(IPC::Message*)>& send_callback) {}
+ 
+ void WaylandConnectionConnector::OnChannelDestroyed(int host_id) {
+-  // TODO(msisov): Handle restarting.
+-  NOTIMPLEMENTED();
++  connection_->OnChannelDestroyed();
+ }
+ 
+ void WaylandConnectionConnector::OnMessageReceived(
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0006-ozone-wayland-Move-the-host-gpu-common-and-test-code.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0006-ozone-wayland-Move-the-host-gpu-common-and-test-code.patch
@@ -1,0 +1,2337 @@
+Upstream-Status: Backport
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 149df6f29fa3e33a004693fb9761a769da5e19b3 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Fri, 29 Mar 2019 08:06:23 +0000
+Subject: [PATCH 06/11] [ozone/wayland] Move the host, gpu, common and test
+ code to directories.
+
+This change does not bring any changes to the behaviour of the
+Ozone/Wayland, but rather moves the cc/h files to their corresponding
+folders.
+
+Host: code running in the browser proccess.
+Gpu: code running in the GPU process/thread.
+Common: common code like utils or something that could run on both
+  the gpu and browser processes if they exist.
+Test: test support related code - mocks, helpers etc.
+
+Bug: 578890
+Change-Id: I541c024bebd86f0a26d4bf0646bb2cffb1b7e177
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1541098
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Reviewed-by: Robert Kroeger <rjkroege@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#645691}
+---
+ ui/ozone/platform/wayland/BUILD.gn            | 163 +++++++++---------
+ .../wayland/{ => common}/wayland_object.cc    |   2 +-
+ .../wayland/{ => common}/wayland_object.h     |   6 +-
+ .../wayland/{ => common}/wayland_util.cc      |   4 +-
+ .../wayland/{ => common}/wayland_util.h       |   8 +-
+ .../wayland/gpu/gbm_pixmap_wayland.cc         |   2 +-
+ .../wayland/gpu/gbm_surfaceless_wayland.cc    |   2 +-
+ .../wayland/{ => gpu}/gl_surface_wayland.cc   |   4 +-
+ .../wayland/{ => gpu}/gl_surface_wayland.h    |   6 +-
+ .../wayland/gpu/wayland_connection_proxy.cc   |   2 +-
+ .../wayland/gpu/wayland_connection_proxy.h    |   4 +-
+ .../{ => gpu}/wayland_surface_factory.cc      |   8 +-
+ .../{ => gpu}/wayland_surface_factory.h       |   8 +-
+ .../wayland_surface_factory_unittest.cc       |   0
+ .../{ => host}/wayland_buffer_manager.cc      |   8 +-
+ .../{ => host}/wayland_buffer_manager.h       |  10 +-
+ .../wayland/{ => host}/wayland_connection.cc  |  16 +-
+ .../wayland/{ => host}/wayland_connection.h   |  26 +--
+ .../wayland_connection_connector.cc           |   5 +-
+ .../{ => host}/wayland_connection_connector.h |   6 +-
+ .../{ => host}/wayland_connection_unittest.cc |   0
+ .../wayland/{ => host}/wayland_cursor.cc      |   8 +-
+ .../wayland/{ => host}/wayland_cursor.h       |   8 +-
+ .../{ => host}/wayland_cursor_position.cc     |   4 +-
+ .../{ => host}/wayland_cursor_position.h      |   6 +-
+ .../wayland/{ => host}/wayland_data_device.cc |   8 +-
+ .../wayland/{ => host}/wayland_data_device.h  |  10 +-
+ .../{ => host}/wayland_data_device_manager.cc |   6 +-
+ .../{ => host}/wayland_data_device_manager.h  |   8 +-
+ .../wayland_data_device_unittest.cc           |   0
+ .../wayland/{ => host}/wayland_data_offer.cc  |   2 +-
+ .../wayland/{ => host}/wayland_data_offer.h   |   8 +-
+ .../wayland/{ => host}/wayland_data_source.cc |   6 +-
+ .../wayland/{ => host}/wayland_data_source.h  |   8 +-
+ .../wayland_input_method_context.cc           |   6 +-
+ .../{ => host}/wayland_input_method_context.h |   8 +-
+ .../wayland_input_method_context_factory.cc   |   6 +-
+ .../wayland_input_method_context_factory.h    |   6 +-
+ .../wayland_input_method_context_unittest.cc  |   0
+ .../wayland/{ => host}/wayland_keyboard.cc    |   6 +-
+ .../wayland/{ => host}/wayland_keyboard.h     |   8 +-
+ .../{ => host}/wayland_keyboard_unittest.cc   |   0
+ .../wayland/{ => host}/wayland_output.cc      |  10 +-
+ .../wayland/{ => host}/wayland_output.h       |   8 +-
+ .../{ => host}/wayland_output_manager.cc      |   6 +-
+ .../{ => host}/wayland_output_manager.h       |  12 +-
+ .../wayland/{ => host}/wayland_pointer.cc     |   6 +-
+ .../wayland/{ => host}/wayland_pointer.h      |  10 +-
+ .../{ => host}/wayland_pointer_unittest.cc    |   0
+ .../wayland/{ => host}/wayland_screen.cc      |   8 +-
+ .../wayland/{ => host}/wayland_screen.h       |   8 +-
+ .../{ => host}/wayland_screen_unittest.cc     |   0
+ .../wayland_shared_memory_buffer_manager.cc   |   6 +-
+ .../wayland_shared_memory_buffer_manager.h    |  10 +-
+ .../wayland/{ => host}/wayland_touch.cc       |   6 +-
+ .../wayland/{ => host}/wayland_touch.h        |   8 +-
+ .../{ => host}/wayland_touch_unittest.cc      |   0
+ .../wayland/{ => host}/wayland_window.cc      |  18 +-
+ .../wayland/{ => host}/wayland_window.h       |   8 +-
+ .../{ => host}/wayland_window_unittest.cc     |   0
+ .../{ => host}/wayland_zwp_linux_dmabuf.cc    |   4 +-
+ .../{ => host}/wayland_zwp_linux_dmabuf.h     |  10 +-
+ .../wayland/{ => host}/xdg_popup_wrapper.h    |   8 +-
+ .../{ => host}/xdg_popup_wrapper_v5.cc        |   6 +-
+ .../wayland/{ => host}/xdg_popup_wrapper_v5.h |   8 +-
+ .../{ => host}/xdg_popup_wrapper_v6.cc        |  13 +-
+ .../wayland/{ => host}/xdg_popup_wrapper_v6.h |   8 +-
+ .../wayland/{ => host}/xdg_surface_wrapper.cc |   2 +-
+ .../wayland/{ => host}/xdg_surface_wrapper.h  |   8 +-
+ .../{ => host}/xdg_surface_wrapper_v5.cc      |  11 +-
+ .../{ => host}/xdg_surface_wrapper_v5.h       |   8 +-
+ .../{ => host}/xdg_surface_wrapper_v6.cc      |   8 +-
+ .../{ => host}/xdg_surface_wrapper_v6.h       |   8 +-
+ .../{ => host}/zwp_text_input_wrapper.h       |   8 +-
+ .../{ => host}/zwp_text_input_wrapper_v1.cc   |   6 +-
+ .../{ => host}/zwp_text_input_wrapper_v1.h    |   8 +-
+ .../wayland/ozone_platform_wayland.cc         |  12 +-
+ .../wayland/{ => test}/wayland_test.cc        |   2 +-
+ .../wayland/{ => test}/wayland_test.h         |   0
+ .../platform/wayland/wayland_buffer_fuzzer.cc |   4 +-
+ 80 files changed, 342 insertions(+), 336 deletions(-)
+ rename ui/ozone/platform/wayland/{ => common}/wayland_object.cc (99%)
+ rename ui/ozone/platform/wayland/{ => common}/wayland_object.h (97%)
+ rename ui/ozone/platform/wayland/{ => common}/wayland_util.cc (97%)
+ rename ui/ozone/platform/wayland/{ => common}/wayland_util.h (85%)
+ rename ui/ozone/platform/wayland/{ => gpu}/gl_surface_wayland.cc (94%)
+ rename ui/ozone/platform/wayland/{ => gpu}/gl_surface_wayland.h (86%)
+ rename ui/ozone/platform/wayland/{ => gpu}/wayland_surface_factory.cc (96%)
+ rename ui/ozone/platform/wayland/{ => gpu}/wayland_surface_factory.h (89%)
+ rename ui/ozone/platform/wayland/{ => gpu}/wayland_surface_factory_unittest.cc (100%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_buffer_manager.cc (98%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_buffer_manager.h (95%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_connection.cc (97%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_connection.h (93%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_connection_connector.cc (94%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_connection_connector.h (89%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_connection_unittest.cc (100%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_cursor.cc (91%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_cursor.h (89%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_cursor_position.cc (81%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_cursor_position.h (80%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_data_device.cc (98%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_data_device.h (95%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_data_device_manager.cc (83%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_data_device_manager.h (73%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_data_device_unittest.cc (100%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_data_offer.cc (98%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_data_offer.h (91%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_data_source.cc (96%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_data_source.h (91%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_input_method_context.cc (96%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_input_method_context.h (88%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_input_method_context_factory.cc (84%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_input_method_context_factory.h (81%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_input_method_context_unittest.cc (100%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_keyboard.cc (97%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_keyboard.h (92%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_keyboard_unittest.cc (100%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_output.cc (91%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_output.h (91%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_output_manager.cc (95%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_output_manager.h (79%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_pointer.cc (97%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_pointer.h (90%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_pointer_unittest.cc (100%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_screen.cc (96%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_screen.h (89%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_screen_unittest.cc (100%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_shared_memory_buffer_manager.cc (93%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_shared_memory_buffer_manager.h (85%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_touch.cc (96%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_touch.h (89%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_touch_unittest.cc (100%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_window.cc (98%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_window.h (97%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_window_unittest.cc (100%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_zwp_linux_dmabuf.cc (97%)
+ rename ui/ozone/platform/wayland/{ => host}/wayland_zwp_linux_dmabuf.h (91%)
+ rename ui/ozone/platform/wayland/{ => host}/xdg_popup_wrapper.h (73%)
+ rename ui/ozone/platform/wayland/{ => host}/xdg_popup_wrapper_v5.cc (89%)
+ rename ui/ozone/platform/wayland/{ => host}/xdg_popup_wrapper_v5.h (76%)
+ rename ui/ozone/platform/wayland/{ => host}/xdg_popup_wrapper_v6.cc (96%)
+ rename ui/ozone/platform/wayland/{ => host}/xdg_popup_wrapper_v6.h (85%)
+ rename ui/ozone/platform/wayland/{ => host}/xdg_surface_wrapper.cc (93%)
+ rename ui/ozone/platform/wayland/{ => host}/xdg_surface_wrapper.h (88%)
+ rename ui/ozone/platform/wayland/{ => host}/xdg_surface_wrapper_v5.cc (91%)
+ rename ui/ozone/platform/wayland/{ => host}/xdg_surface_wrapper_v5.h (86%)
+ rename ui/ozone/platform/wayland/{ => host}/xdg_surface_wrapper_v6.cc (95%)
+ rename ui/ozone/platform/wayland/{ => host}/xdg_surface_wrapper_v6.h (88%)
+ rename ui/ozone/platform/wayland/{ => host}/zwp_text_input_wrapper.h (90%)
+ rename ui/ozone/platform/wayland/{ => host}/zwp_text_input_wrapper_v1.cc (97%)
+ rename ui/ozone/platform/wayland/{ => host}/zwp_text_input_wrapper_v1.h (93%)
+ rename ui/ozone/platform/wayland/{ => test}/wayland_test.cc (97%)
+ rename ui/ozone/platform/wayland/{ => test}/wayland_test.h (100%)
+
+diff --git a/ui/ozone/platform/wayland/BUILD.gn b/ui/ozone/platform/wayland/BUILD.gn
+index d6138998dc03..d6843128c8e9 100644
+--- a/ui/ozone/platform/wayland/BUILD.gn
++++ b/ui/ozone/platform/wayland/BUILD.gn
+@@ -16,76 +16,76 @@ source_set("wayland") {
+   sources = [
+     "client_native_pixmap_factory_wayland.cc",
+     "client_native_pixmap_factory_wayland.h",
+-    "gl_surface_wayland.cc",
+-    "gl_surface_wayland.h",
++    "common/wayland_object.cc",
++    "common/wayland_object.h",
++    "common/wayland_util.cc",
++    "common/wayland_util.h",
+     "gpu/drm_render_node_path_finder.cc",
+     "gpu/drm_render_node_path_finder.h",
++    "gpu/gl_surface_wayland.cc",
++    "gpu/gl_surface_wayland.h",
+     "gpu/wayland_canvas_surface.cc",
+     "gpu/wayland_canvas_surface.h",
+     "gpu/wayland_connection_proxy.cc",
+     "gpu/wayland_connection_proxy.h",
++    "gpu/wayland_surface_factory.cc",
++    "gpu/wayland_surface_factory.h",
++    "host/wayland_buffer_manager.cc",
++    "host/wayland_buffer_manager.h",
++    "host/wayland_connection.cc",
++    "host/wayland_connection.h",
++    "host/wayland_connection_connector.cc",
++    "host/wayland_connection_connector.h",
++    "host/wayland_cursor.cc",
++    "host/wayland_cursor.h",
++    "host/wayland_cursor_position.cc",
++    "host/wayland_cursor_position.h",
++    "host/wayland_data_device.cc",
++    "host/wayland_data_device.h",
++    "host/wayland_data_device_manager.cc",
++    "host/wayland_data_device_manager.h",
++    "host/wayland_data_offer.cc",
++    "host/wayland_data_offer.h",
++    "host/wayland_data_source.cc",
++    "host/wayland_data_source.h",
++    "host/wayland_input_method_context.cc",
++    "host/wayland_input_method_context.h",
++    "host/wayland_input_method_context_factory.cc",
++    "host/wayland_input_method_context_factory.h",
++    "host/wayland_keyboard.cc",
++    "host/wayland_keyboard.h",
++    "host/wayland_output.cc",
++    "host/wayland_output.h",
++    "host/wayland_output_manager.cc",
++    "host/wayland_output_manager.h",
++    "host/wayland_pointer.cc",
++    "host/wayland_pointer.h",
++    "host/wayland_screen.cc",
++    "host/wayland_screen.h",
++    "host/wayland_shared_memory_buffer_manager.cc",
++    "host/wayland_shared_memory_buffer_manager.h",
++    "host/wayland_touch.cc",
++    "host/wayland_touch.h",
++    "host/wayland_window.cc",
++    "host/wayland_window.h",
++    "host/wayland_zwp_linux_dmabuf.cc",
++    "host/wayland_zwp_linux_dmabuf.h",
++    "host/xdg_popup_wrapper.h",
++    "host/xdg_popup_wrapper_v5.cc",
++    "host/xdg_popup_wrapper_v5.h",
++    "host/xdg_popup_wrapper_v6.cc",
++    "host/xdg_popup_wrapper_v6.h",
++    "host/xdg_surface_wrapper.cc",
++    "host/xdg_surface_wrapper.h",
++    "host/xdg_surface_wrapper_v5.cc",
++    "host/xdg_surface_wrapper_v5.h",
++    "host/xdg_surface_wrapper_v6.cc",
++    "host/xdg_surface_wrapper_v6.h",
++    "host/zwp_text_input_wrapper.h",
++    "host/zwp_text_input_wrapper_v1.cc",
++    "host/zwp_text_input_wrapper_v1.h",
+     "ozone_platform_wayland.cc",
+     "ozone_platform_wayland.h",
+-    "wayland_buffer_manager.cc",
+-    "wayland_buffer_manager.h",
+-    "wayland_connection.cc",
+-    "wayland_connection.h",
+-    "wayland_connection_connector.cc",
+-    "wayland_connection_connector.h",
+-    "wayland_cursor.cc",
+-    "wayland_cursor.h",
+-    "wayland_cursor_position.cc",
+-    "wayland_cursor_position.h",
+-    "wayland_data_device.cc",
+-    "wayland_data_device.h",
+-    "wayland_data_device_manager.cc",
+-    "wayland_data_device_manager.h",
+-    "wayland_data_offer.cc",
+-    "wayland_data_offer.h",
+-    "wayland_data_source.cc",
+-    "wayland_data_source.h",
+-    "wayland_input_method_context.cc",
+-    "wayland_input_method_context.h",
+-    "wayland_input_method_context_factory.cc",
+-    "wayland_input_method_context_factory.h",
+-    "wayland_keyboard.cc",
+-    "wayland_keyboard.h",
+-    "wayland_object.cc",
+-    "wayland_object.h",
+-    "wayland_output.cc",
+-    "wayland_output.h",
+-    "wayland_output_manager.cc",
+-    "wayland_output_manager.h",
+-    "wayland_pointer.cc",
+-    "wayland_pointer.h",
+-    "wayland_screen.cc",
+-    "wayland_screen.h",
+-    "wayland_shared_memory_buffer_manager.cc",
+-    "wayland_shared_memory_buffer_manager.h",
+-    "wayland_surface_factory.cc",
+-    "wayland_surface_factory.h",
+-    "wayland_touch.cc",
+-    "wayland_touch.h",
+-    "wayland_util.cc",
+-    "wayland_util.h",
+-    "wayland_window.cc",
+-    "wayland_window.h",
+-    "wayland_zwp_linux_dmabuf.cc",
+-    "wayland_zwp_linux_dmabuf.h",
+-    "xdg_popup_wrapper.h",
+-    "xdg_popup_wrapper_v5.cc",
+-    "xdg_popup_wrapper_v5.h",
+-    "xdg_popup_wrapper_v6.cc",
+-    "xdg_popup_wrapper_v6.h",
+-    "xdg_surface_wrapper.cc",
+-    "xdg_surface_wrapper.h",
+-    "xdg_surface_wrapper_v5.cc",
+-    "xdg_surface_wrapper_v5.h",
+-    "xdg_surface_wrapper_v6.cc",
+-    "xdg_surface_wrapper_v6.h",
+-    "zwp_text_input_wrapper.h",
+-    "zwp_text_input_wrapper_v1.cc",
+-    "zwp_text_input_wrapper_v1.h",
+   ]
+ 
+   import("//ui/base/ui_features.gni")
+@@ -154,27 +154,30 @@ source_set("wayland") {
+ source_set("wayland_unittests") {
+   testonly = true
+ 
++  assert(use_wayland_gbm)
++
+   sources = [
+-    "fake_server.cc",
+-    "fake_server.h",
+-    "wayland_connection_unittest.cc",
+-    "wayland_data_device_unittest.cc",
+-    "wayland_input_method_context_unittest.cc",
+-    "wayland_keyboard_unittest.cc",
+-    "wayland_pointer_unittest.cc",
+-    "wayland_screen_unittest.cc",
+-    "wayland_surface_factory_unittest.cc",
+-    "wayland_test.cc",
+-    "wayland_test.h",
+-    "wayland_touch_unittest.cc",
+-    "wayland_window_unittest.cc",
++    "gpu/wayland_surface_factory_unittest.cc",
++    "host/wayland_buffer_manager_unittest.cc",
++    "host/wayland_connection_unittest.cc",
++    "host/wayland_data_device_unittest.cc",
++    "host/wayland_input_method_context_unittest.cc",
++    "host/wayland_keyboard_unittest.cc",
++    "host/wayland_pointer_unittest.cc",
++    "host/wayland_screen_unittest.cc",
++    "host/wayland_touch_unittest.cc",
++    "host/wayland_window_unittest.cc",
++    "test/wayland_test.cc",
++    "test/wayland_test.h",
+   ]
+ 
+   deps = [
+     ":wayland",
++    "//build/config/linux/libdrm",
+     "//testing/gmock",
+     "//testing/gtest",
+     "//third_party/wayland:wayland_server",
++    "//third_party/wayland-protocols:linux_dmabuf_protocol",
+     "//third_party/wayland-protocols:text_input_protocol",
+     "//third_party/wayland-protocols:xdg_shell_protocol",
+     "//ui/base",
+@@ -183,6 +186,7 @@ source_set("wayland_unittests") {
+     "//ui/events/ozone:events_ozone_layout",
+     "//ui/ozone:platform",
+     "//ui/ozone:test_support",
++    "//ui/ozone/common/linux:gbm",
+   ]
+ 
+   import("//ui/base/ui_features.gni")
+@@ -190,10 +194,10 @@ source_set("wayland_unittests") {
+     deps += [ "//ui/events/keycodes:xkb" ]
+   }
+ 
+-  defines = [ "WL_HIDE_DEPRECATED" ]
+-  if (use_wayland_gbm) {
+-    defines += [ "WAYLAND_GBM" ]
+-  }
++  defines = [
++    "WL_HIDE_DEPRECATED",
++    "WAYLAND_GBM",
++  ]
+ }
+ 
+ fuzzer_test("wayland_buffer_fuzzer") {
+@@ -205,7 +209,6 @@ fuzzer_test("wayland_buffer_fuzzer") {
+     ":wayland",
+     "//base/test:test_support",
+     "//build/config/linux/libdrm",
+-    "//testing/gmock:gmock",
+     "//ui/gfx:test_support",
+     "//ui/platform_window:platform_window",
+   ]
+diff --git a/ui/ozone/platform/wayland/wayland_object.cc b/ui/ozone/platform/wayland/common/wayland_object.cc
+similarity index 99%
+rename from ui/ozone/platform/wayland/wayland_object.cc
+rename to ui/ozone/platform/wayland/common/wayland_object.cc
+index 31fae0c2c15a..afb78c837249 100644
+--- a/ui/ozone/platform/wayland/wayland_object.cc
++++ b/ui/ozone/platform/wayland/common/wayland_object.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ #include <linux-dmabuf-unstable-v1-client-protocol.h>
+ #include <presentation-time-client-protocol.h>
+diff --git a/ui/ozone/platform/wayland/wayland_object.h b/ui/ozone/platform/wayland/common/wayland_object.h
+similarity index 97%
+rename from ui/ozone/platform/wayland/wayland_object.h
+rename to ui/ozone/platform/wayland/common/wayland_object.h
+index f7f7fd3264f5..5d56702437d3 100644
+--- a/ui/ozone/platform/wayland/wayland_object.h
++++ b/ui/ozone/platform/wayland/common/wayland_object.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_OBJECT_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_OBJECT_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_COMMON_WAYLAND_OBJECT_H_
++#define UI_OZONE_PLATFORM_WAYLAND_COMMON_WAYLAND_OBJECT_H_
+ 
+ #include <wayland-client-core.h>
+ 
+@@ -272,4 +272,4 @@ wl::Object<T> Bind(wl_registry* registry, uint32_t name, uint32_t version) {
+ 
+ }  // namespace wl
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_OBJECT_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_COMMON_WAYLAND_OBJECT_H_
+diff --git a/ui/ozone/platform/wayland/wayland_util.cc b/ui/ozone/platform/wayland/common/wayland_util.cc
+similarity index 97%
+rename from ui/ozone/platform/wayland/wayland_util.cc
+rename to ui/ozone/platform/wayland/common/wayland_util.cc
+index 0cd05346df82..49dfc163dd3b 100644
+--- a/ui/ozone/platform/wayland/wayland_util.cc
++++ b/ui/ozone/platform/wayland/common/wayland_util.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_util.h"
++#include "ui/ozone/platform/wayland/common/wayland_util.h"
+ 
+ #include <xdg-shell-unstable-v5-client-protocol.h>
+ #include <xdg-shell-unstable-v6-client-protocol.h>
+@@ -12,7 +12,7 @@
+ #include "third_party/skia/include/core/SkSurface.h"
+ #include "ui/base/hit_test.h"
+ #include "ui/gfx/skia_util.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
+ 
+ namespace wl {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_util.h b/ui/ozone/platform/wayland/common/wayland_util.h
+similarity index 85%
+rename from ui/ozone/platform/wayland/wayland_util.h
+rename to ui/ozone/platform/wayland/common/wayland_util.h
+index 6d4ae174db3f..971a00345eb7 100644
+--- a/ui/ozone/platform/wayland/wayland_util.h
++++ b/ui/ozone/platform/wayland/common/wayland_util.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_UTIL_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_UTIL_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_COMMON_WAYLAND_UTIL_H_
++#define UI_OZONE_PLATFORM_WAYLAND_COMMON_WAYLAND_UTIL_H_
+ 
+ #include <wayland-client.h>
+ 
+@@ -11,7 +11,7 @@
+ 
+ #include "base/callback.h"
+ #include "base/macros.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ class SkBitmap;
+ 
+@@ -54,4 +54,4 @@ uint32_t IdentifyDirection(const ui::WaylandConnection& connection,
+ 
+ }  // namespace wl
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_UTIL_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_COMMON_WAYLAND_UTIL_H_
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+index 3dead7f7626e..f2db8e7567f8 100644
+--- a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
++++ b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+@@ -20,7 +20,7 @@
+ #include "ui/ozone/common/linux/gbm_device.h"
+ #include "ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h"
+ #include "ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h"
+-#include "ui/ozone/platform/wayland/wayland_surface_factory.h"
++#include "ui/ozone/platform/wayland/gpu/wayland_surface_factory.h"
+ #include "ui/ozone/public/overlay_plane.h"
+ #include "ui/ozone/public/ozone_platform.h"
+ 
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+index f72331626695..c4bc47e96b5f 100644
+--- a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
++++ b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+@@ -9,7 +9,7 @@
+ #include "base/trace_event/trace_event.h"
+ #include "ui/gfx/gpu_fence.h"
+ #include "ui/ozone/common/egl_util.h"
+-#include "ui/ozone/platform/wayland/wayland_surface_factory.h"
++#include "ui/ozone/platform/wayland/gpu/wayland_surface_factory.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/gl_surface_wayland.cc b/ui/ozone/platform/wayland/gpu/gl_surface_wayland.cc
+similarity index 94%
+rename from ui/ozone/platform/wayland/gl_surface_wayland.cc
+rename to ui/ozone/platform/wayland/gpu/gl_surface_wayland.cc
+index 5827383eefee..dea41416c7ed 100644
+--- a/ui/ozone/platform/wayland/gl_surface_wayland.cc
++++ b/ui/ozone/platform/wayland/gpu/gl_surface_wayland.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/gl_surface_wayland.h"
++#include "ui/ozone/platform/wayland/gpu/gl_surface_wayland.h"
+ 
+ #include <wayland-egl.h>
+ 
+@@ -10,7 +10,7 @@
+ 
+ #include "third_party/khronos/EGL/egl.h"
+ #include "ui/ozone/common/egl_util.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/gl_surface_wayland.h b/ui/ozone/platform/wayland/gpu/gl_surface_wayland.h
+similarity index 86%
+rename from ui/ozone/platform/wayland/gl_surface_wayland.h
+rename to ui/ozone/platform/wayland/gpu/gl_surface_wayland.h
+index 27b81f0e1920..4b9b15ea92d1 100644
+--- a/ui/ozone/platform/wayland/gl_surface_wayland.h
++++ b/ui/ozone/platform/wayland/gpu/gl_surface_wayland.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_GL_SURFACE_WAYLAND_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_GL_SURFACE_WAYLAND_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_GPU_GL_SURFACE_WAYLAND_H_
++#define UI_OZONE_PLATFORM_WAYLAND_GPU_GL_SURFACE_WAYLAND_H_
+ 
+ #include <memory>
+ 
+@@ -47,4 +47,4 @@ class GLSurfaceWayland : public gl::NativeViewGLSurfaceEGL {
+ };
+ 
+ }  // namespace ui
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_GL_SURFACE_WAYLAND_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_GPU_GL_SURFACE_WAYLAND_H_
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+index e2d82f83191f..c8109597f506 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+@@ -9,7 +9,7 @@
+ #include "base/process/process.h"
+ #include "third_party/khronos/EGL/egl.h"
+ #include "ui/ozone/common/linux/drm_util_linux.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+index 27909874410d..f87d0b5ac4de 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+@@ -10,8 +10,8 @@
+ #include "base/threading/thread_checker.h"
+ #include "mojo/public/cpp/bindings/binding_set.h"
+ #include "ui/gfx/native_widget_types.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_util.h"
++#include "ui/ozone/platform/wayland/common/wayland_util.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
+ #include "ui/ozone/public/interfaces/wayland/wayland_connection.mojom.h"
+ 
+ #if defined(WAYLAND_GBM)
+diff --git a/ui/ozone/platform/wayland/wayland_surface_factory.cc b/ui/ozone/platform/wayland/gpu/wayland_surface_factory.cc
+similarity index 96%
+rename from ui/ozone/platform/wayland/wayland_surface_factory.cc
+rename to ui/ozone/platform/wayland/gpu/wayland_surface_factory.cc
+index f3f49a2d5968..f21d27293329 100644
+--- a/ui/ozone/platform/wayland/wayland_surface_factory.cc
++++ b/ui/ozone/platform/wayland/gpu/wayland_surface_factory.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_surface_factory.h"
++#include "ui/ozone/platform/wayland/gpu/wayland_surface_factory.h"
+ 
+ #include <memory>
+ 
+@@ -10,11 +10,11 @@
+ #include "ui/gfx/linux/client_native_pixmap_dmabuf.h"
+ #include "ui/ozone/common/egl_util.h"
+ #include "ui/ozone/common/gl_ozone_egl.h"
+-#include "ui/ozone/platform/wayland/gl_surface_wayland.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
++#include "ui/ozone/platform/wayland/gpu/gl_surface_wayland.h"
+ #include "ui/ozone/platform/wayland/gpu/wayland_canvas_surface.h"
+ #include "ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ #if defined(WAYLAND_GBM)
+ #include "ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.h"
+diff --git a/ui/ozone/platform/wayland/wayland_surface_factory.h b/ui/ozone/platform/wayland/gpu/wayland_surface_factory.h
+similarity index 89%
+rename from ui/ozone/platform/wayland/wayland_surface_factory.h
+rename to ui/ozone/platform/wayland/gpu/wayland_surface_factory.h
+index 2f5ab3a92f17..c18c581e87a0 100644
+--- a/ui/ozone/platform/wayland/wayland_surface_factory.h
++++ b/ui/ozone/platform/wayland/gpu/wayland_surface_factory.h
+@@ -2,15 +2,15 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SURFACE_FACTORY_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SURFACE_FACTORY_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_GPU_WAYLAND_SURFACE_FACTORY_H_
++#define UI_OZONE_PLATFORM_WAYLAND_GPU_WAYLAND_SURFACE_FACTORY_H_
+ 
+ #include "base/macros.h"
+ #include "base/memory/ref_counted.h"
+ #include "base/single_thread_task_runner.h"
+ #include "base/threading/sequenced_task_runner_handle.h"
+ #include "ui/gl/gl_surface.h"
+-#include "ui/ozone/platform/wayland/wayland_util.h"
++#include "ui/ozone/platform/wayland/common/wayland_util.h"
+ #include "ui/ozone/public/surface_factory_ozone.h"
+ 
+ namespace gfx {
+@@ -65,4 +65,4 @@ class WaylandSurfaceFactory : public SurfaceFactoryOzone {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SURFACE_FACTORY_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_GPU_WAYLAND_SURFACE_FACTORY_H_
+diff --git a/ui/ozone/platform/wayland/wayland_surface_factory_unittest.cc b/ui/ozone/platform/wayland/gpu/wayland_surface_factory_unittest.cc
+similarity index 100%
+rename from ui/ozone/platform/wayland/wayland_surface_factory_unittest.cc
+rename to ui/ozone/platform/wayland/gpu/wayland_surface_factory_unittest.cc
+diff --git a/ui/ozone/platform/wayland/wayland_buffer_manager.cc b/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
+similarity index 98%
+rename from ui/ozone/platform/wayland/wayland_buffer_manager.cc
+rename to ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
+index f42940c94de3..98b1d069f26b 100644
+--- a/ui/ozone/platform/wayland/wayland_buffer_manager.cc
++++ b/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
+@@ -2,15 +2,15 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_buffer_manager.h"
++#include "ui/ozone/platform/wayland/host/wayland_buffer_manager.h"
+ 
+ #include <presentation-time-client-protocol.h>
+ 
+ #include "base/trace_event/trace_event.h"
+ #include "ui/ozone/common/linux/drm_util_linux.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
+-#include "ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_zwp_linux_dmabuf.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_buffer_manager.h b/ui/ozone/platform/wayland/host/wayland_buffer_manager.h
+similarity index 95%
+rename from ui/ozone/platform/wayland/wayland_buffer_manager.h
+rename to ui/ozone/platform/wayland/host/wayland_buffer_manager.h
+index ae7257e5b53c..633eba0c9e34 100644
+--- a/ui/ozone/platform/wayland/wayland_buffer_manager.h
++++ b/ui/ozone/platform/wayland/host/wayland_buffer_manager.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_BUFFER_MANAGER_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_BUFFER_MANAGER_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_BUFFER_MANAGER_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_BUFFER_MANAGER_H_
+ 
+ #include <map>
+ #include <vector>
+@@ -16,8 +16,8 @@
+ #include "ui/gfx/native_widget_types.h"
+ #include "ui/gfx/presentation_feedback.h"
+ #include "ui/gfx/swap_result.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
+-#include "ui/ozone/platform/wayland/wayland_util.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_util.h"
+ 
+ struct wp_presentation_feedback;
+ 
+@@ -175,4 +175,4 @@ class WaylandBufferManager {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_BUFFER_MANAGER_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_BUFFER_MANAGER_H_
+diff --git a/ui/ozone/platform/wayland/wayland_connection.cc b/ui/ozone/platform/wayland/host/wayland_connection.cc
+similarity index 97%
+rename from ui/ozone/platform/wayland/wayland_connection.cc
+rename to ui/ozone/platform/wayland/host/wayland_connection.cc
+index 4bb0b0bcbe8a..4eb8db596fdb 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/host/wayland_connection.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
+ 
+ #include <xdg-shell-unstable-v5-client-protocol.h>
+ #include <xdg-shell-unstable-v6-client-protocol.h>
+@@ -19,13 +19,13 @@
+ #include "base/threading/thread_task_runner_handle.h"
+ #include "ui/events/ozone/layout/keyboard_layout_engine_manager.h"
+ #include "ui/gfx/swap_result.h"
+-#include "ui/ozone/platform/wayland/wayland_buffer_manager.h"
+-#include "ui/ozone/platform/wayland/wayland_input_method_context.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
+-#include "ui/ozone/platform/wayland/wayland_output_manager.h"
+-#include "ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
+-#include "ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
++#include "ui/ozone/platform/wayland/host/wayland_buffer_manager.h"
++#include "ui/ozone/platform/wayland/host/wayland_input_method_context.h"
++#include "ui/ozone/platform/wayland/host/wayland_output_manager.h"
++#include "ui/ozone/platform/wayland/host/wayland_shared_memory_buffer_manager.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_zwp_linux_dmabuf.h"
+ 
+ static_assert(XDG_SHELL_VERSION_CURRENT == 5, "Unsupported xdg-shell version");
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_connection.h b/ui/ozone/platform/wayland/host/wayland_connection.h
+similarity index 93%
+rename from ui/ozone/platform/wayland/wayland_connection.h
+rename to ui/ozone/platform/wayland/host/wayland_connection.h
+index 9a4a4a38313c..c1ec0412bee6 100644
+--- a/ui/ozone/platform/wayland/wayland_connection.h
++++ b/ui/ozone/platform/wayland/host/wayland_connection.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CONNECTION_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CONNECTION_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_CONNECTION_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_CONNECTION_H_
+ 
+ #include <map>
+ #include <memory>
+@@ -16,15 +16,15 @@
+ #include "ui/events/platform/platform_event_source.h"
+ #include "ui/gfx/buffer_types.h"
+ #include "ui/gfx/native_widget_types.h"
+-#include "ui/ozone/platform/wayland/wayland_cursor_position.h"
+-#include "ui/ozone/platform/wayland/wayland_data_device.h"
+-#include "ui/ozone/platform/wayland/wayland_data_device_manager.h"
+-#include "ui/ozone/platform/wayland/wayland_data_source.h"
+-#include "ui/ozone/platform/wayland/wayland_keyboard.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
+-#include "ui/ozone/platform/wayland/wayland_output.h"
+-#include "ui/ozone/platform/wayland/wayland_pointer.h"
+-#include "ui/ozone/platform/wayland/wayland_touch.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
++#include "ui/ozone/platform/wayland/host/wayland_cursor_position.h"
++#include "ui/ozone/platform/wayland/host/wayland_data_device.h"
++#include "ui/ozone/platform/wayland/host/wayland_data_device_manager.h"
++#include "ui/ozone/platform/wayland/host/wayland_data_source.h"
++#include "ui/ozone/platform/wayland/host/wayland_keyboard.h"
++#include "ui/ozone/platform/wayland/host/wayland_output.h"
++#include "ui/ozone/platform/wayland/host/wayland_pointer.h"
++#include "ui/ozone/platform/wayland/host/wayland_touch.h"
+ #include "ui/ozone/public/interfaces/wayland/wayland_connection.mojom.h"
+ #include "ui/ozone/public/platform_clipboard.h"
+ 
+@@ -74,7 +74,7 @@ class WaylandConnection : public PlatformEventSource,
+                           ScheduleBufferSwapCallback callback) override;
+   // These overridden methods below are invoked by the GPU when hardware
+   // accelerated rendering is not used. Check comments in the
+-  // ui/ozone/public/interfaces/wayland/wayland_connection.mojom.
++  // ui/ozone/public/interfaces/wayland/host/wayland_connection.mojom.
+   void CreateShmBufferForWidget(gfx::AcceleratedWidget widget,
+                                 base::File file,
+                                 uint64_t length,
+@@ -289,4 +289,4 @@ class WaylandConnection : public PlatformEventSource,
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CONNECTION_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_CONNECTION_H_
+diff --git a/ui/ozone/platform/wayland/wayland_connection_connector.cc b/ui/ozone/platform/wayland/host/wayland_connection_connector.cc
+similarity index 94%
+rename from ui/ozone/platform/wayland/wayland_connection_connector.cc
+rename to ui/ozone/platform/wayland/host/wayland_connection_connector.cc
+index 812fb15e97ba..5c10326747e3 100644
+--- a/ui/ozone/platform/wayland/wayland_connection_connector.cc
++++ b/ui/ozone/platform/wayland/host/wayland_connection_connector.cc
+@@ -2,11 +2,10 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_connection_connector.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection_connector.h"
+ 
+ #include "base/task_runner_util.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/public/interfaces/wayland/wayland_connection.mojom.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_connection_connector.h b/ui/ozone/platform/wayland/host/wayland_connection_connector.h
+similarity index 89%
+rename from ui/ozone/platform/wayland/wayland_connection_connector.h
+rename to ui/ozone/platform/wayland/host/wayland_connection_connector.h
+index c8941edb520a..72c97fe80e62 100644
+--- a/ui/ozone/platform/wayland/wayland_connection_connector.h
++++ b/ui/ozone/platform/wayland/host/wayland_connection_connector.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CONNECTION_CONNECTOR_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CONNECTION_CONNECTOR_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_CONNECTION_CONNECTOR_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_CONNECTION_CONNECTOR_H_
+ 
+ #include "ui/ozone/public/gpu_platform_support_host.h"
+ 
+@@ -56,4 +56,4 @@ class WaylandConnectionConnector : public GpuPlatformSupportHost {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CONNECTION_CONNECTOR_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_CONNECTION_CONNECTOR_H_
+diff --git a/ui/ozone/platform/wayland/wayland_connection_unittest.cc b/ui/ozone/platform/wayland/host/wayland_connection_unittest.cc
+similarity index 100%
+rename from ui/ozone/platform/wayland/wayland_connection_unittest.cc
+rename to ui/ozone/platform/wayland/host/wayland_connection_unittest.cc
+diff --git a/ui/ozone/platform/wayland/wayland_cursor.cc b/ui/ozone/platform/wayland/host/wayland_cursor.cc
+similarity index 91%
+rename from ui/ozone/platform/wayland/wayland_cursor.cc
+rename to ui/ozone/platform/wayland/host/wayland_cursor.cc
+index db2d5913550a..696be7a7ce88 100644
+--- a/ui/ozone/platform/wayland/wayland_cursor.cc
++++ b/ui/ozone/platform/wayland/host/wayland_cursor.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_cursor.h"
++#include "ui/ozone/platform/wayland/host/wayland_cursor.h"
+ 
+ #include <sys/mman.h>
+ #include <vector>
+@@ -10,9 +10,9 @@
+ #include "base/memory/shared_memory.h"
+ #include "third_party/skia/include/core/SkCanvas.h"
+ #include "ui/gfx/skia_util.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_pointer.h"
+-#include "ui/ozone/platform/wayland/wayland_util.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_pointer.h"
++#include "ui/ozone/platform/wayland/common/wayland_util.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_cursor.h b/ui/ozone/platform/wayland/host/wayland_cursor.h
+similarity index 89%
+rename from ui/ozone/platform/wayland/wayland_cursor.h
+rename to ui/ozone/platform/wayland/host/wayland_cursor.h
+index e7e8368d7233..7535d7fa157d 100644
+--- a/ui/ozone/platform/wayland/wayland_cursor.h
++++ b/ui/ozone/platform/wayland/host/wayland_cursor.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CURSOR_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CURSOR_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_CURSOR_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_CURSOR_H_
+ 
+ #include <wayland-client.h>
+ #include <memory>
+@@ -14,7 +14,7 @@
+ #include "base/macros.h"
+ #include "third_party/skia/include/core/SkBitmap.h"
+ #include "third_party/skia/include/core/SkSurface.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ namespace base {
+ class SharedMemory;
+@@ -72,4 +72,4 @@ class WaylandCursor {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CURSOR_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_CURSOR_H_
+diff --git a/ui/ozone/platform/wayland/wayland_cursor_position.cc b/ui/ozone/platform/wayland/host/wayland_cursor_position.cc
+similarity index 81%
+rename from ui/ozone/platform/wayland/wayland_cursor_position.cc
+rename to ui/ozone/platform/wayland/host/wayland_cursor_position.cc
+index 97cb6409a8a4..018c1a3351fe 100644
+--- a/ui/ozone/platform/wayland/wayland_cursor_position.cc
++++ b/ui/ozone/platform/wayland/host/wayland_cursor_position.cc
+@@ -2,9 +2,9 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_cursor_position.h"
++#include "ui/ozone/platform/wayland/host/wayland_cursor_position.h"
+ 
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_cursor_position.h b/ui/ozone/platform/wayland/host/wayland_cursor_position.h
+similarity index 80%
+rename from ui/ozone/platform/wayland/wayland_cursor_position.h
+rename to ui/ozone/platform/wayland/host/wayland_cursor_position.h
+index 123ed9c9a181..57a7ea40155a 100644
+--- a/ui/ozone/platform/wayland/wayland_cursor_position.h
++++ b/ui/ozone/platform/wayland/host/wayland_cursor_position.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CURSOR_POSITION_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CURSOR_POSITION_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_CURSOR_POSITION_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_CURSOR_POSITION_H_
+ 
+ #include "base/macros.h"
+ #include "ui/gfx/geometry/point.h"
+@@ -31,4 +31,4 @@ class WaylandCursorPosition {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CURSOR_POSITION_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_CURSOR_POSITION_H_
+diff --git a/ui/ozone/platform/wayland/wayland_data_device.cc b/ui/ozone/platform/wayland/host/wayland_data_device.cc
+similarity index 98%
+rename from ui/ozone/platform/wayland/wayland_data_device.cc
+rename to ui/ozone/platform/wayland/host/wayland_data_device.cc
+index 225cf5370e6d..81ae59b9f66f 100644
+--- a/ui/ozone/platform/wayland/wayland_data_device.cc
++++ b/ui/ozone/platform/wayland/host/wayland_data_device.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_data_device.h"
++#include "ui/ozone/platform/wayland/host/wayland_data_device.h"
+ 
+ #include <algorithm>
+ #include <utility>
+@@ -16,9 +16,9 @@
+ #include "ui/base/dragdrop/drag_drop_types.h"
+ #include "ui/base/dragdrop/os_exchange_data.h"
+ #include "ui/base/dragdrop/os_exchange_data_provider_aura.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_util.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/common/wayland_util.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_data_device.h b/ui/ozone/platform/wayland/host/wayland_data_device.h
+similarity index 95%
+rename from ui/ozone/platform/wayland/wayland_data_device.h
+rename to ui/ozone/platform/wayland/host/wayland_data_device.h
+index 6efad52af789..75f6f8cf5510 100644
+--- a/ui/ozone/platform/wayland/wayland_data_device.h
++++ b/ui/ozone/platform/wayland/host/wayland_data_device.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_DEVICE_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_DEVICE_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_DATA_DEVICE_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_DATA_DEVICE_H_
+ 
+ #include <wayland-client.h>
+ 
+@@ -16,8 +16,8 @@
+ #include "base/files/scoped_file.h"
+ #include "base/macros.h"
+ #include "ui/gfx/geometry/size.h"
+-#include "ui/ozone/platform/wayland/wayland_data_offer.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/host/wayland_data_offer.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ class SkBitmap;
+ 
+@@ -185,4 +185,4 @@ class WaylandDataDevice {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_DEVICE_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_DATA_DEVICE_H_
+diff --git a/ui/ozone/platform/wayland/wayland_data_device_manager.cc b/ui/ozone/platform/wayland/host/wayland_data_device_manager.cc
+similarity index 83%
+rename from ui/ozone/platform/wayland/wayland_data_device_manager.cc
+rename to ui/ozone/platform/wayland/host/wayland_data_device_manager.cc
+index 25737b78ee81..5b4a79d79796 100644
+--- a/ui/ozone/platform/wayland/wayland_data_device_manager.cc
++++ b/ui/ozone/platform/wayland/host/wayland_data_device_manager.cc
+@@ -2,10 +2,10 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_data_device_manager.h"
++#include "ui/ozone/platform/wayland/host/wayland_data_device_manager.h"
+ 
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_data_source.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_data_source.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_data_device_manager.h b/ui/ozone/platform/wayland/host/wayland_data_device_manager.h
+similarity index 73%
+rename from ui/ozone/platform/wayland/wayland_data_device_manager.h
+rename to ui/ozone/platform/wayland/host/wayland_data_device_manager.h
+index 18f5b077638b..ea37eee0ba3e 100644
+--- a/ui/ozone/platform/wayland/wayland_data_device_manager.h
++++ b/ui/ozone/platform/wayland/host/wayland_data_device_manager.h
+@@ -2,15 +2,15 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_DEVICE_MANAGER_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_DEVICE_MANAGER_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_DATA_DEVICE_MANAGER_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_DATA_DEVICE_MANAGER_H_
+ 
+ #include <wayland-client.h>
+ 
+ #include <memory>
+ 
+ #include "base/macros.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ namespace ui {
+ 
+@@ -36,4 +36,4 @@ class WaylandDataDeviceManager {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_DEVICE_MANAGER_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_DATA_DEVICE_MANAGER_H_
+diff --git a/ui/ozone/platform/wayland/wayland_data_device_unittest.cc b/ui/ozone/platform/wayland/host/wayland_data_device_unittest.cc
+similarity index 100%
+rename from ui/ozone/platform/wayland/wayland_data_device_unittest.cc
+rename to ui/ozone/platform/wayland/host/wayland_data_device_unittest.cc
+diff --git a/ui/ozone/platform/wayland/wayland_data_offer.cc b/ui/ozone/platform/wayland/host/wayland_data_offer.cc
+similarity index 98%
+rename from ui/ozone/platform/wayland/wayland_data_offer.cc
+rename to ui/ozone/platform/wayland/host/wayland_data_offer.cc
+index a3900dd23418..915ea5b47c30 100644
+--- a/ui/ozone/platform/wayland/wayland_data_offer.cc
++++ b/ui/ozone/platform/wayland/host/wayland_data_offer.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_data_offer.h"
++#include "ui/ozone/platform/wayland/host/wayland_data_offer.h"
+ 
+ #include <fcntl.h>
+ #include <algorithm>
+diff --git a/ui/ozone/platform/wayland/wayland_data_offer.h b/ui/ozone/platform/wayland/host/wayland_data_offer.h
+similarity index 91%
+rename from ui/ozone/platform/wayland/wayland_data_offer.h
+rename to ui/ozone/platform/wayland/host/wayland_data_offer.h
+index a2e8170534bf..ec7abc9e5895 100644
+--- a/ui/ozone/platform/wayland/wayland_data_offer.h
++++ b/ui/ozone/platform/wayland/host/wayland_data_offer.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_OFFER_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_OFFER_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_DATA_OFFER_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_DATA_OFFER_H_
+ 
+ #include <wayland-client.h>
+ 
+@@ -12,7 +12,7 @@
+ 
+ #include "base/files/scoped_file.h"
+ #include "base/macros.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ namespace ui {
+ 
+@@ -78,4 +78,4 @@ class WaylandDataOffer {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_OFFER_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_DATA_OFFER_H_
+diff --git a/ui/ozone/platform/wayland/wayland_data_source.cc b/ui/ozone/platform/wayland/host/wayland_data_source.cc
+similarity index 96%
+rename from ui/ozone/platform/wayland/wayland_data_source.cc
+rename to ui/ozone/platform/wayland/host/wayland_data_source.cc
+index 1acf9b9ca140..592b51fdcf02 100644
+--- a/ui/ozone/platform/wayland/wayland_data_source.cc
++++ b/ui/ozone/platform/wayland/host/wayland_data_source.cc
+@@ -2,12 +2,12 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_data_source.h"
++#include "ui/ozone/platform/wayland/host/wayland_data_source.h"
+ 
+ #include "base/files/file_util.h"
+ #include "ui/base/dragdrop/drag_drop_types.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_data_source.h b/ui/ozone/platform/wayland/host/wayland_data_source.h
+similarity index 91%
+rename from ui/ozone/platform/wayland/wayland_data_source.h
+rename to ui/ozone/platform/wayland/host/wayland_data_source.h
+index 1ed57322abbb..09a04dadfec1 100644
+--- a/ui/ozone/platform/wayland/wayland_data_source.h
++++ b/ui/ozone/platform/wayland/host/wayland_data_source.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_SOURCE_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_SOURCE_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_DATA_SOURCE_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_DATA_SOURCE_H_
+ 
+ #include <wayland-client.h>
+ 
+@@ -14,7 +14,7 @@
+ #include "base/logging.h"
+ #include "base/macros.h"
+ #include "base/optional.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ #include "ui/ozone/public/platform_clipboard.h"
+ 
+ namespace ui {
+@@ -81,4 +81,4 @@ class WaylandDataSource {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_DATA_SOURCE_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_DATA_SOURCE_H_
+diff --git a/ui/ozone/platform/wayland/wayland_input_method_context.cc b/ui/ozone/platform/wayland/host/wayland_input_method_context.cc
+similarity index 96%
+rename from ui/ozone/platform/wayland/wayland_input_method_context.cc
+rename to ui/ozone/platform/wayland/host/wayland_input_method_context.cc
+index fadb28c260ca..700232b9b36e 100644
+--- a/ui/ozone/platform/wayland/wayland_input_method_context.cc
++++ b/ui/ozone/platform/wayland/host/wayland_input_method_context.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_input_method_context.h"
++#include "ui/ozone/platform/wayland/host/wayland_input_method_context.h"
+ 
+ #include "base/bind.h"
+ #include "base/command_line.h"
+@@ -20,8 +20,8 @@
+ #include "ui/events/ozone/layout/keyboard_layout_engine.h"
+ #include "ui/events/ozone/layout/keyboard_layout_engine_manager.h"
+ #include "ui/gfx/range/range.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/zwp_text_input_wrapper_v1.h"
+ #include "ui/ozone/public/ozone_switches.h"
+ 
+ namespace ui {
+diff --git a/ui/ozone/platform/wayland/wayland_input_method_context.h b/ui/ozone/platform/wayland/host/wayland_input_method_context.h
+similarity index 88%
+rename from ui/ozone/platform/wayland/wayland_input_method_context.h
+rename to ui/ozone/platform/wayland/host/wayland_input_method_context.h
+index bee874c609be..30268e235b32 100644
+--- a/ui/ozone/platform/wayland/wayland_input_method_context.h
++++ b/ui/ozone/platform/wayland/host/wayland_input_method_context.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_INPUT_METHOD_CONTEXT_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_INPUT_METHOD_CONTEXT_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_INPUT_METHOD_CONTEXT_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_INPUT_METHOD_CONTEXT_H_
+ 
+ #include <memory>
+ #include <string>
+@@ -12,7 +12,7 @@
+ #include "ui/base/ime/character_composer.h"
+ #include "ui/base/ime/linux/linux_input_method_context.h"
+ #include "ui/events/ozone/evdev/event_dispatch_callback.h"
+-#include "ui/ozone/platform/wayland/zwp_text_input_wrapper.h"
++#include "ui/ozone/platform/wayland/host/zwp_text_input_wrapper.h"
+ 
+ namespace ui {
+ 
+@@ -66,4 +66,4 @@ class WaylandInputMethodContext : public LinuxInputMethodContext,
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_INPUT_METHOD_CONTEXT_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_INPUT_METHOD_CONTEXT_H_
+diff --git a/ui/ozone/platform/wayland/wayland_input_method_context_factory.cc b/ui/ozone/platform/wayland/host/wayland_input_method_context_factory.cc
+similarity index 84%
+rename from ui/ozone/platform/wayland/wayland_input_method_context_factory.cc
+rename to ui/ozone/platform/wayland/host/wayland_input_method_context_factory.cc
+index 1eaf6fae245d..2687c358cc1d 100644
+--- a/ui/ozone/platform/wayland/wayland_input_method_context_factory.cc
++++ b/ui/ozone/platform/wayland/host/wayland_input_method_context_factory.cc
+@@ -2,10 +2,10 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_input_method_context_factory.h"
++#include "ui/ozone/platform/wayland/host/wayland_input_method_context_factory.h"
+ 
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_input_method_context.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_input_method_context.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_input_method_context_factory.h b/ui/ozone/platform/wayland/host/wayland_input_method_context_factory.h
+similarity index 81%
+rename from ui/ozone/platform/wayland/wayland_input_method_context_factory.h
+rename to ui/ozone/platform/wayland/host/wayland_input_method_context_factory.h
+index 413f3a4a500e..2c88923ed0bd 100644
+--- a/ui/ozone/platform/wayland/wayland_input_method_context_factory.h
++++ b/ui/ozone/platform/wayland/host/wayland_input_method_context_factory.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_INPUT_METHOD_CONTEXT_FACTORY_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_INPUT_METHOD_CONTEXT_FACTORY_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_INPUT_METHOD_CONTEXT_FACTORY_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_INPUT_METHOD_CONTEXT_FACTORY_H_
+ 
+ #include "base/macros.h"
+ #include "ui/base/ime/linux/linux_input_method_context_factory.h"
+@@ -35,4 +35,4 @@ class WaylandInputMethodContextFactory : public LinuxInputMethodContextFactory {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_INPUT_METHOD_CONTEXT_FACTORY_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_INPUT_METHOD_CONTEXT_FACTORY_H_
+diff --git a/ui/ozone/platform/wayland/wayland_input_method_context_unittest.cc b/ui/ozone/platform/wayland/host/wayland_input_method_context_unittest.cc
+similarity index 100%
+rename from ui/ozone/platform/wayland/wayland_input_method_context_unittest.cc
+rename to ui/ozone/platform/wayland/host/wayland_input_method_context_unittest.cc
+diff --git a/ui/ozone/platform/wayland/wayland_keyboard.cc b/ui/ozone/platform/wayland/host/wayland_keyboard.cc
+similarity index 97%
+rename from ui/ozone/platform/wayland/wayland_keyboard.cc
+rename to ui/ozone/platform/wayland/host/wayland_keyboard.cc
+index 910a5ec2a943..181e6e56b4b6 100644
+--- a/ui/ozone/platform/wayland/wayland_keyboard.cc
++++ b/ui/ozone/platform/wayland/host/wayland_keyboard.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_keyboard.h"
++#include "ui/ozone/platform/wayland/host/wayland_keyboard.h"
+ 
+ #include <sys/mman.h>
+ #include <utility>
+@@ -17,8 +17,8 @@
+ #include "ui/events/ozone/evdev/keyboard_util_evdev.h"
+ #include "ui/events/ozone/layout/keyboard_layout_engine.h"
+ #include "ui/events/ozone/layout/keyboard_layout_engine_manager.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ #if BUILDFLAG(USE_XKBCOMMON)
+ #include "ui/events/ozone/layout/xkb/xkb_keyboard_layout_engine.h"
+diff --git a/ui/ozone/platform/wayland/wayland_keyboard.h b/ui/ozone/platform/wayland/host/wayland_keyboard.h
+similarity index 92%
+rename from ui/ozone/platform/wayland/wayland_keyboard.h
+rename to ui/ozone/platform/wayland/host/wayland_keyboard.h
+index 9c4155c6794c..1e5fd7a40383 100644
+--- a/ui/ozone/platform/wayland/wayland_keyboard.h
++++ b/ui/ozone/platform/wayland/host/wayland_keyboard.h
+@@ -2,15 +2,15 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_KEYBOARD_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_KEYBOARD_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_KEYBOARD_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_KEYBOARD_H_
+ 
+ #include <wayland-client.h>
+ 
+ #include "ui/base/buildflags.h"
+ #include "ui/events/ozone/evdev/event_dispatch_callback.h"
+ #include "ui/events/ozone/keyboard/event_auto_repeat_handler.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ namespace ui {
+ 
+@@ -99,4 +99,4 @@ class WaylandKeyboard : public EventAutoRepeatHandler::Delegate {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_KEYBOARD_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_KEYBOARD_H_
+diff --git a/ui/ozone/platform/wayland/wayland_keyboard_unittest.cc b/ui/ozone/platform/wayland/host/wayland_keyboard_unittest.cc
+similarity index 100%
+rename from ui/ozone/platform/wayland/wayland_keyboard_unittest.cc
+rename to ui/ozone/platform/wayland/host/wayland_keyboard_unittest.cc
+diff --git a/ui/ozone/platform/wayland/wayland_output.cc b/ui/ozone/platform/wayland/host/wayland_output.cc
+similarity index 91%
+rename from ui/ozone/platform/wayland/wayland_output.cc
+rename to ui/ozone/platform/wayland/host/wayland_output.cc
+index 91cdf2c43bf5..0b36d955ed45 100644
+--- a/ui/ozone/platform/wayland/wayland_output.cc
++++ b/ui/ozone/platform/wayland/host/wayland_output.cc
+@@ -2,12 +2,12 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_output.h"
++#include "ui/ozone/platform/wayland/host/wayland_output.h"
+ 
+ #include <wayland-client.h>
+ 
+ #include "ui/gfx/color_space.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
+ 
+ namespace ui {
+ 
+@@ -27,8 +27,10 @@ void WaylandOutput::Initialize(Delegate* delegate) {
+   DCHECK(!delegate_);
+   delegate_ = delegate;
+   static const wl_output_listener output_listener = {
+-      &WaylandOutput::OutputHandleGeometry, &WaylandOutput::OutputHandleMode,
+-      &WaylandOutput::OutputHandleDone, &WaylandOutput::OutputHandleScale,
++      &WaylandOutput::OutputHandleGeometry,
++      &WaylandOutput::OutputHandleMode,
++      &WaylandOutput::OutputHandleDone,
++      &WaylandOutput::OutputHandleScale,
+   };
+   wl_output_add_listener(output_.get(), &output_listener, this);
+ }
+diff --git a/ui/ozone/platform/wayland/wayland_output.h b/ui/ozone/platform/wayland/host/wayland_output.h
+similarity index 91%
+rename from ui/ozone/platform/wayland/wayland_output.h
+rename to ui/ozone/platform/wayland/host/wayland_output.h
+index 41a4d3959bb3..464689eadf7d 100644
+--- a/ui/ozone/platform/wayland/wayland_output.h
++++ b/ui/ozone/platform/wayland/host/wayland_output.h
+@@ -2,15 +2,15 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_OUTPUT_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_OUTPUT_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_OUTPUT_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_OUTPUT_H_
+ 
+ #include <stdint.h>
+ 
+ #include "ui/display/types/display_snapshot.h"
+ #include "ui/display/types/native_display_delegate.h"
+ #include "ui/gfx/geometry/rect.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ namespace ui {
+ 
+@@ -78,4 +78,4 @@ class WaylandOutput {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SCREEN_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_SCREEN_H_
+diff --git a/ui/ozone/platform/wayland/wayland_output_manager.cc b/ui/ozone/platform/wayland/host/wayland_output_manager.cc
+similarity index 95%
+rename from ui/ozone/platform/wayland/wayland_output_manager.cc
+rename to ui/ozone/platform/wayland/host/wayland_output_manager.cc
+index 992d0c309333..a33c494424bb 100644
+--- a/ui/ozone/platform/wayland/wayland_output_manager.cc
++++ b/ui/ozone/platform/wayland/host/wayland_output_manager.cc
+@@ -2,10 +2,10 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_output_manager.h"
++#include "ui/ozone/platform/wayland/host/wayland_output_manager.h"
+ 
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_output.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_output.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_output_manager.h b/ui/ozone/platform/wayland/host/wayland_output_manager.h
+similarity index 79%
+rename from ui/ozone/platform/wayland/wayland_output_manager.h
+rename to ui/ozone/platform/wayland/host/wayland_output_manager.h
+index cae7097d4b12..812323281eaf 100644
+--- a/ui/ozone/platform/wayland/wayland_output_manager.h
++++ b/ui/ozone/platform/wayland/host/wayland_output_manager.h
+@@ -2,18 +2,18 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_OUTPUT_MANAGER_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_OUTPUT_MANAGER_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_OUTPUT_MANAGER_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_OUTPUT_MANAGER_H_
+ 
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ #include <memory>
+ #include <vector>
+ 
+ #include "base/macros.h"
+ #include "base/memory/weak_ptr.h"
+-#include "ui/ozone/platform/wayland/wayland_output.h"
+-#include "ui/ozone/platform/wayland/wayland_screen.h"
++#include "ui/ozone/platform/wayland/host/wayland_output.h"
++#include "ui/ozone/platform/wayland/host/wayland_screen.h"
+ 
+ struct wl_output;
+ 
+@@ -59,4 +59,4 @@ class WaylandOutputManager : public WaylandOutput::Delegate {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_OUTPUT_MANAGER_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_OUTPUT_MANAGER_H_
+diff --git a/ui/ozone/platform/wayland/wayland_pointer.cc b/ui/ozone/platform/wayland/host/wayland_pointer.cc
+similarity index 97%
+rename from ui/ozone/platform/wayland/wayland_pointer.cc
+rename to ui/ozone/platform/wayland/host/wayland_pointer.cc
+index ed2d14646e3a..3171ea07a70c 100644
+--- a/ui/ozone/platform/wayland/wayland_pointer.cc
++++ b/ui/ozone/platform/wayland/host/wayland_pointer.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_pointer.h"
++#include "ui/ozone/platform/wayland/host/wayland_pointer.h"
+ 
+ #include <linux/input.h>
+ #include <wayland-client.h>
+@@ -10,8 +10,8 @@
+ 
+ #include "ui/events/base_event_utils.h"
+ #include "ui/events/event.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ // TODO(forney): Handle version 5 of wl_pointer.
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_pointer.h b/ui/ozone/platform/wayland/host/wayland_pointer.h
+similarity index 90%
+rename from ui/ozone/platform/wayland/wayland_pointer.h
+rename to ui/ozone/platform/wayland/host/wayland_pointer.h
+index 109d08db30a9..969b49a43503 100644
+--- a/ui/ozone/platform/wayland/wayland_pointer.h
++++ b/ui/ozone/platform/wayland/host/wayland_pointer.h
+@@ -2,15 +2,15 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_POINTER_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_POINTER_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_POINTER_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_POINTER_H_
+ 
+ #include "base/macros.h"
+ #include "base/memory/weak_ptr.h"
+ #include "ui/events/ozone/evdev/event_dispatch_callback.h"
+ #include "ui/gfx/geometry/point_f.h"
+-#include "ui/ozone/platform/wayland/wayland_cursor.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
++#include "ui/ozone/platform/wayland/host/wayland_cursor.h"
+ 
+ namespace ui {
+ 
+@@ -95,4 +95,4 @@ class WaylandPointer {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_POINTER_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_POINTER_H_
+diff --git a/ui/ozone/platform/wayland/wayland_pointer_unittest.cc b/ui/ozone/platform/wayland/host/wayland_pointer_unittest.cc
+similarity index 100%
+rename from ui/ozone/platform/wayland/wayland_pointer_unittest.cc
+rename to ui/ozone/platform/wayland/host/wayland_pointer_unittest.cc
+diff --git a/ui/ozone/platform/wayland/wayland_screen.cc b/ui/ozone/platform/wayland/host/wayland_screen.cc
+similarity index 96%
+rename from ui/ozone/platform/wayland/wayland_screen.cc
+rename to ui/ozone/platform/wayland/host/wayland_screen.cc
+index 19fb4050b2c0..e53a95932ef1 100644
+--- a/ui/ozone/platform/wayland/wayland_screen.cc
++++ b/ui/ozone/platform/wayland/host/wayland_screen.cc
+@@ -2,16 +2,16 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_screen.h"
++#include "ui/ozone/platform/wayland/host/wayland_screen.h"
+ 
+ #include "ui/display/display.h"
+ #include "ui/display/display_finder.h"
+ #include "ui/display/display_observer.h"
+ #include "ui/gfx/geometry/point.h"
+ #include "ui/gfx/geometry/size.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_cursor_position.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_cursor_position.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_screen.h b/ui/ozone/platform/wayland/host/wayland_screen.h
+similarity index 89%
+rename from ui/ozone/platform/wayland/wayland_screen.h
+rename to ui/ozone/platform/wayland/host/wayland_screen.h
+index 480957bf024d..f395b9b496fd 100644
+--- a/ui/ozone/platform/wayland/wayland_screen.h
++++ b/ui/ozone/platform/wayland/host/wayland_screen.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SCREEN_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SCREEN_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_SCREEN_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_SCREEN_H_
+ 
+ #include <vector>
+ 
+@@ -11,7 +11,7 @@
+ #include "base/memory/weak_ptr.h"
+ #include "base/observer_list.h"
+ #include "ui/display/display_list.h"
+-#include "ui/ozone/platform/wayland/wayland_output.h"
++#include "ui/ozone/platform/wayland/host/wayland_output.h"
+ #include "ui/ozone/public/ozone_platform.h"
+ #include "ui/ozone/public/platform_screen.h"
+ 
+@@ -62,4 +62,4 @@ class WaylandScreen : public PlatformScreen {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SCREEN_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_SCREEN_H_
+diff --git a/ui/ozone/platform/wayland/wayland_screen_unittest.cc b/ui/ozone/platform/wayland/host/wayland_screen_unittest.cc
+similarity index 100%
+rename from ui/ozone/platform/wayland/wayland_screen_unittest.cc
+rename to ui/ozone/platform/wayland/host/wayland_screen_unittest.cc
+diff --git a/ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.cc b/ui/ozone/platform/wayland/host/wayland_shared_memory_buffer_manager.cc
+similarity index 93%
+rename from ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.cc
+rename to ui/ozone/platform/wayland/host/wayland_shared_memory_buffer_manager.cc
+index 0cfe3cdf204f..af129fe4ece0 100644
+--- a/ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.cc
++++ b/ui/ozone/platform/wayland/host/wayland_shared_memory_buffer_manager.cc
+@@ -2,13 +2,13 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.h"
++#include "ui/ozone/platform/wayland/host/wayland_shared_memory_buffer_manager.h"
+ 
+ #include <utility>
+ 
+ #include "base/trace_event/trace_event.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.h b/ui/ozone/platform/wayland/host/wayland_shared_memory_buffer_manager.h
+similarity index 85%
+rename from ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.h
+rename to ui/ozone/platform/wayland/host/wayland_shared_memory_buffer_manager.h
+index 8626ff007f4e..e10ffe603de5 100644
+--- a/ui/ozone/platform/wayland/wayland_shared_memory_buffer_manager.h
++++ b/ui/ozone/platform/wayland/host/wayland_shared_memory_buffer_manager.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SHARED_MEMORY_BUFFER_MANAGER_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SHARED_MEMORY_BUFFER_MANAGER_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_SHARED_MEMORY_BUFFER_MANAGER_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_SHARED_MEMORY_BUFFER_MANAGER_H_
+ 
+ #include <map>
+ #include <memory>
+@@ -14,8 +14,8 @@
+ #include "base/macros.h"
+ #include "ui/gfx/geometry/rect.h"
+ #include "ui/gfx/native_widget_types.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
+-#include "ui/ozone/platform/wayland/wayland_util.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_util.h"
+ 
+ namespace ui {
+ 
+@@ -73,4 +73,4 @@ class WaylandShmBufferManager {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_SHARED_MEMORY_BUFFER_MANAGER_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_SHARED_MEMORY_BUFFER_MANAGER_H_
+diff --git a/ui/ozone/platform/wayland/wayland_touch.cc b/ui/ozone/platform/wayland/host/wayland_touch.cc
+similarity index 96%
+rename from ui/ozone/platform/wayland/wayland_touch.cc
+rename to ui/ozone/platform/wayland/host/wayland_touch.cc
+index d30bc7342d99..ce18b08b8760 100644
+--- a/ui/ozone/platform/wayland/wayland_touch.cc
++++ b/ui/ozone/platform/wayland/host/wayland_touch.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_touch.h"
++#include "ui/ozone/platform/wayland/host/wayland_touch.h"
+ 
+ #include <sys/mman.h>
+ #include <wayland-client.h>
+@@ -10,8 +10,8 @@
+ #include "base/files/scoped_file.h"
+ #include "ui/base/buildflags.h"
+ #include "ui/events/event.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_touch.h b/ui/ozone/platform/wayland/host/wayland_touch.h
+similarity index 89%
+rename from ui/ozone/platform/wayland/wayland_touch.h
+rename to ui/ozone/platform/wayland/host/wayland_touch.h
+index ae097fd05a5b..52baf9f9a2a5 100644
+--- a/ui/ozone/platform/wayland/wayland_touch.h
++++ b/ui/ozone/platform/wayland/host/wayland_touch.h
+@@ -2,15 +2,15 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_TOUCH_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_TOUCH_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_TOUCH_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_TOUCH_H_
+ 
+ #include <memory>
+ 
+ #include "base/containers/flat_map.h"
+ #include "ui/events/ozone/evdev/event_dispatch_callback.h"
+ #include "ui/gfx/geometry/rect.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ namespace ui {
+ 
+@@ -77,4 +77,4 @@ class WaylandTouch {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_TOUCH_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_TOUCH_H_
+diff --git a/ui/ozone/platform/wayland/wayland_touch_unittest.cc b/ui/ozone/platform/wayland/host/wayland_touch_unittest.cc
+similarity index 100%
+rename from ui/ozone/platform/wayland/wayland_touch_unittest.cc
+rename to ui/ozone/platform/wayland/host/wayland_touch_unittest.cc
+diff --git a/ui/ozone/platform/wayland/wayland_window.cc b/ui/ozone/platform/wayland/host/wayland_window.cc
+similarity index 98%
+rename from ui/ozone/platform/wayland/wayland_window.cc
+rename to ui/ozone/platform/wayland/host/wayland_window.cc
+index 7b658951a403..750da0bf3b2f 100644
+--- a/ui/ozone/platform/wayland/wayland_window.cc
++++ b/ui/ozone/platform/wayland/host/wayland_window.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ #include <memory>
+ 
+@@ -17,14 +17,14 @@
+ #include "ui/events/event_utils.h"
+ #include "ui/events/ozone/events_ozone.h"
+ #include "ui/gfx/geometry/point_f.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_cursor_position.h"
+-#include "ui/ozone/platform/wayland/wayland_output_manager.h"
+-#include "ui/ozone/platform/wayland/wayland_pointer.h"
+-#include "ui/ozone/platform/wayland/xdg_popup_wrapper_v5.h"
+-#include "ui/ozone/platform/wayland/xdg_popup_wrapper_v6.h"
+-#include "ui/ozone/platform/wayland/xdg_surface_wrapper_v5.h"
+-#include "ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_cursor_position.h"
++#include "ui/ozone/platform/wayland/host/wayland_output_manager.h"
++#include "ui/ozone/platform/wayland/host/wayland_pointer.h"
++#include "ui/ozone/platform/wayland/host/xdg_popup_wrapper_v5.h"
++#include "ui/ozone/platform/wayland/host/xdg_popup_wrapper_v6.h"
++#include "ui/ozone/platform/wayland/host/xdg_surface_wrapper_v5.h"
++#include "ui/ozone/platform/wayland/host/xdg_surface_wrapper_v6.h"
+ #include "ui/platform_window/platform_window_handler/wm_drop_handler.h"
+ 
+ namespace ui {
+diff --git a/ui/ozone/platform/wayland/wayland_window.h b/ui/ozone/platform/wayland/host/wayland_window.h
+similarity index 97%
+rename from ui/ozone/platform/wayland/wayland_window.h
+rename to ui/ozone/platform/wayland/host/wayland_window.h
+index 4c7271d19d94..edb3526e3575 100644
+--- a/ui/ozone/platform/wayland/wayland_window.h
++++ b/ui/ozone/platform/wayland/host/wayland_window.h
+@@ -2,8 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_WINDOW_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_WINDOW_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_WINDOW_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_WINDOW_H_
+ 
+ #include <set>
+ #include <vector>
+@@ -13,7 +13,7 @@
+ #include "ui/events/platform/platform_event_dispatcher.h"
+ #include "ui/gfx/geometry/rect.h"
+ #include "ui/gfx/native_widget_types.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ #include "ui/platform_window/platform_window.h"
+ #include "ui/platform_window/platform_window_delegate.h"
+ #include "ui/platform_window/platform_window_handler/wm_drag_handler.h"
+@@ -244,4 +244,4 @@ class WaylandWindow : public PlatformWindow,
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_WINDOW_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_WINDOW_H_
+diff --git a/ui/ozone/platform/wayland/wayland_window_unittest.cc b/ui/ozone/platform/wayland/host/wayland_window_unittest.cc
+similarity index 100%
+rename from ui/ozone/platform/wayland/wayland_window_unittest.cc
+rename to ui/ozone/platform/wayland/host/wayland_window_unittest.cc
+diff --git a/ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.cc b/ui/ozone/platform/wayland/host/wayland_zwp_linux_dmabuf.cc
+similarity index 97%
+rename from ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.cc
+rename to ui/ozone/platform/wayland/host/wayland_zwp_linux_dmabuf.cc
+index fccb6073f8a0..08d5dbf8b565 100644
+--- a/ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.cc
++++ b/ui/ozone/platform/wayland/host/wayland_zwp_linux_dmabuf.cc
+@@ -2,13 +2,13 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h"
++#include "ui/ozone/platform/wayland/host/wayland_zwp_linux_dmabuf.h"
+ 
+ #include <drm_fourcc.h>
+ #include <linux-dmabuf-unstable-v1-client-protocol.h>
+ 
+ #include "ui/ozone/common/linux/drm_util_linux.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h b/ui/ozone/platform/wayland/host/wayland_zwp_linux_dmabuf.h
+similarity index 91%
+rename from ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h
+rename to ui/ozone/platform/wayland/host/wayland_zwp_linux_dmabuf.h
+index 5c393d5a447d..00cc223d9b7b 100644
+--- a/ui/ozone/platform/wayland/wayland_zwp_linux_dmabuf.h
++++ b/ui/ozone/platform/wayland/host/wayland_zwp_linux_dmabuf.h
+@@ -2,16 +2,16 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_ZWP_LINUX_DMABUF_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_ZWP_LINUX_DMABUF_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_ZWP_LINUX_DMABUF_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_ZWP_LINUX_DMABUF_H_
+ 
+ #include <vector>
+ 
+ #include "base/containers/flat_map.h"
+ #include "base/files/file.h"
+ #include "base/macros.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
+-#include "ui/ozone/platform/wayland/wayland_util.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_util.h"
+ 
+ struct zwp_linux_dmabuf_v1;
+ struct zwp_linux_buffer_params_v1;
+@@ -99,4 +99,4 @@ class WaylandZwpLinuxDmabuf {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_ZWP_LINUX_DMABUF_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_ZWP_LINUX_DMABUF_H_
+diff --git a/ui/ozone/platform/wayland/xdg_popup_wrapper.h b/ui/ozone/platform/wayland/host/xdg_popup_wrapper.h
+similarity index 73%
+rename from ui/ozone/platform/wayland/xdg_popup_wrapper.h
+rename to ui/ozone/platform/wayland/host/xdg_popup_wrapper.h
+index 2bd215caa9bf..75cbb04e3ff4 100644
+--- a/ui/ozone/platform/wayland/xdg_popup_wrapper.h
++++ b/ui/ozone/platform/wayland/host/xdg_popup_wrapper.h
+@@ -2,11 +2,11 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_POPUP_WRAPPER_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_POPUP_WRAPPER_H_
+ 
+ #include "ui/gfx/geometry/rect.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ namespace ui {
+ 
+@@ -27,4 +27,4 @@ class XDGPopupWrapper {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_POPUP_WRAPPER_H_
+diff --git a/ui/ozone/platform/wayland/xdg_popup_wrapper_v5.cc b/ui/ozone/platform/wayland/host/xdg_popup_wrapper_v5.cc
+similarity index 89%
+rename from ui/ozone/platform/wayland/xdg_popup_wrapper_v5.cc
+rename to ui/ozone/platform/wayland/host/xdg_popup_wrapper_v5.cc
+index 80cd1ac89cd4..6f011c4f4824 100644
+--- a/ui/ozone/platform/wayland/xdg_popup_wrapper_v5.cc
++++ b/ui/ozone/platform/wayland/host/xdg_popup_wrapper_v5.cc
+@@ -2,13 +2,13 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/xdg_popup_wrapper_v5.h"
++#include "ui/ozone/platform/wayland/host/xdg_popup_wrapper_v5.h"
+ #include <xdg-shell-unstable-v5-client-protocol.h>
+ #include <vector>
+ 
+ #include "ui/gfx/geometry/rect.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/xdg_popup_wrapper_v5.h b/ui/ozone/platform/wayland/host/xdg_popup_wrapper_v5.h
+similarity index 76%
+rename from ui/ozone/platform/wayland/xdg_popup_wrapper_v5.h
+rename to ui/ozone/platform/wayland/host/xdg_popup_wrapper_v5.h
+index 2304e84e5cd7..b6578d1d0e25 100644
+--- a/ui/ozone/platform/wayland/xdg_popup_wrapper_v5.h
++++ b/ui/ozone/platform/wayland/host/xdg_popup_wrapper_v5.h
+@@ -2,10 +2,10 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_V5_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_V5_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_POPUP_WRAPPER_V5_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_POPUP_WRAPPER_V5_H_
+ 
+-#include "ui/ozone/platform/wayland/xdg_popup_wrapper.h"
++#include "ui/ozone/platform/wayland/host/xdg_popup_wrapper.h"
+ 
+ namespace ui {
+ 
+@@ -35,4 +35,4 @@ class XDGPopupWrapperV5 : public XDGPopupWrapper {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_V5_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_POPUP_WRAPPER_V5_H_
+diff --git a/ui/ozone/platform/wayland/xdg_popup_wrapper_v6.cc b/ui/ozone/platform/wayland/host/xdg_popup_wrapper_v6.cc
+similarity index 96%
+rename from ui/ozone/platform/wayland/xdg_popup_wrapper_v6.cc
+rename to ui/ozone/platform/wayland/host/xdg_popup_wrapper_v6.cc
+index 38b274f5d7bd..8a61c3a38fa3 100644
+--- a/ui/ozone/platform/wayland/xdg_popup_wrapper_v6.cc
++++ b/ui/ozone/platform/wayland/host/xdg_popup_wrapper_v6.cc
+@@ -2,16 +2,16 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/xdg_popup_wrapper_v6.h"
++#include "ui/ozone/platform/wayland/host/xdg_popup_wrapper_v6.h"
+ 
+ #include <xdg-shell-unstable-v6-client-protocol.h>
+ 
+ #include "ui/events/event_constants.h"
+ #include "ui/gfx/geometry/rect.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_pointer.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
+-#include "ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_pointer.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/xdg_surface_wrapper_v6.h"
+ 
+ namespace ui {
+ 
+@@ -184,7 +184,8 @@ bool XDGPopupWrapperV6::Initialize(WaylandConnection* connection,
+                                    const gfx::Rect& bounds) {
+   DCHECK(connection && surface && parent_window);
+   static const struct zxdg_popup_v6_listener zxdg_popup_v6_listener = {
+-      &XDGPopupWrapperV6::Configure, &XDGPopupWrapperV6::PopupDone,
++      &XDGPopupWrapperV6::Configure,
++      &XDGPopupWrapperV6::PopupDone,
+   };
+ 
+   XDGSurfaceWrapperV6* xdg_surface =
+diff --git a/ui/ozone/platform/wayland/xdg_popup_wrapper_v6.h b/ui/ozone/platform/wayland/host/xdg_popup_wrapper_v6.h
+similarity index 85%
+rename from ui/ozone/platform/wayland/xdg_popup_wrapper_v6.h
+rename to ui/ozone/platform/wayland/host/xdg_popup_wrapper_v6.h
+index 1d75592cfced..2a086c3b2b72 100644
+--- a/ui/ozone/platform/wayland/xdg_popup_wrapper_v6.h
++++ b/ui/ozone/platform/wayland/host/xdg_popup_wrapper_v6.h
+@@ -2,10 +2,10 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_V6_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_V6_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_POPUP_WRAPPER_V6_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_POPUP_WRAPPER_V6_H_
+ 
+-#include "ui/ozone/platform/wayland/xdg_popup_wrapper.h"
++#include "ui/ozone/platform/wayland/host/xdg_popup_wrapper.h"
+ 
+ namespace ui {
+ 
+@@ -51,4 +51,4 @@ class XDGPopupWrapperV6 : public XDGPopupWrapper {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_V6_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_POPUP_WRAPPER_V6_H_
+diff --git a/ui/ozone/platform/wayland/xdg_surface_wrapper.cc b/ui/ozone/platform/wayland/host/xdg_surface_wrapper.cc
+similarity index 93%
+rename from ui/ozone/platform/wayland/xdg_surface_wrapper.cc
+rename to ui/ozone/platform/wayland/host/xdg_surface_wrapper.cc
+index 6d272e5b79f7..089e3535e5b3 100644
+--- a/ui/ozone/platform/wayland/xdg_surface_wrapper.cc
++++ b/ui/ozone/platform/wayland/host/xdg_surface_wrapper.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/xdg_surface_wrapper.h"
++#include "ui/ozone/platform/wayland/host/xdg_surface_wrapper.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/xdg_surface_wrapper.h b/ui/ozone/platform/wayland/host/xdg_surface_wrapper.h
+similarity index 88%
+rename from ui/ozone/platform/wayland/xdg_surface_wrapper.h
+rename to ui/ozone/platform/wayland/host/xdg_surface_wrapper.h
+index 58bf12938b24..c9736abffa6b 100644
+--- a/ui/ozone/platform/wayland/xdg_surface_wrapper.h
++++ b/ui/ozone/platform/wayland/host/xdg_surface_wrapper.h
+@@ -2,11 +2,11 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_SURFACE_WRAPPER_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_SURFACE_WRAPPER_H_
+ 
+ #include "base/strings/string16.h"
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ namespace gfx {
+ class Rect;
+@@ -65,4 +65,4 @@ bool CheckIfWlArrayHasValue(struct wl_array* wl_array, uint32_t value);
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_SURFACE_WRAPPER_H_
+diff --git a/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc b/ui/ozone/platform/wayland/host/xdg_surface_wrapper_v5.cc
+similarity index 91%
+rename from ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc
+rename to ui/ozone/platform/wayland/host/xdg_surface_wrapper_v5.cc
+index 7f9cdf85ad25..7d4172d2f0cb 100644
+--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc
++++ b/ui/ozone/platform/wayland/host/xdg_surface_wrapper_v5.cc
+@@ -2,15 +2,15 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/xdg_surface_wrapper_v5.h"
++#include "ui/ozone/platform/wayland/host/xdg_surface_wrapper_v5.h"
+ 
+ #include <xdg-shell-unstable-v5-client-protocol.h>
+ 
+ #include "base/strings/utf_string_conversions.h"
+ #include "ui/base/hit_test.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_util.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/common/wayland_util.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ namespace ui {
+ 
+@@ -23,7 +23,8 @@ bool XDGSurfaceWrapperV5::Initialize(WaylandConnection* connection,
+                                      wl_surface* surface,
+                                      bool with_toplevel) {
+   static const xdg_surface_listener xdg_surface_listener = {
+-      &XDGSurfaceWrapperV5::Configure, &XDGSurfaceWrapperV5::Close,
++      &XDGSurfaceWrapperV5::Configure,
++      &XDGSurfaceWrapperV5::Close,
+   };
+   xdg_surface_.reset(xdg_shell_get_xdg_surface(connection->shell(), surface));
+   if (!xdg_surface_) {
+diff --git a/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.h b/ui/ozone/platform/wayland/host/xdg_surface_wrapper_v5.h
+similarity index 86%
+rename from ui/ozone/platform/wayland/xdg_surface_wrapper_v5.h
+rename to ui/ozone/platform/wayland/host/xdg_surface_wrapper_v5.h
+index 5ef0e607a4ed..a8e82fc2b44f 100644
+--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.h
++++ b/ui/ozone/platform/wayland/host/xdg_surface_wrapper_v5.h
+@@ -2,10 +2,10 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_V5_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_V5_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_SURFACE_WRAPPER_V5_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_SURFACE_WRAPPER_V5_H_
+ 
+-#include "ui/ozone/platform/wayland/xdg_surface_wrapper.h"
++#include "ui/ozone/platform/wayland/host/xdg_surface_wrapper.h"
+ 
+ #include "base/macros.h"
+ 
+@@ -55,4 +55,4 @@ class XDGSurfaceWrapperV5 : public XDGSurfaceWrapper {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_V5_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_SURFACE_WRAPPER_V5_H_
+diff --git a/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc b/ui/ozone/platform/wayland/host/xdg_surface_wrapper_v6.cc
+similarity index 95%
+rename from ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc
+rename to ui/ozone/platform/wayland/host/xdg_surface_wrapper_v6.cc
+index f913d208b637..9cac792bf630 100644
+--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc
++++ b/ui/ozone/platform/wayland/host/xdg_surface_wrapper_v6.cc
+@@ -2,15 +2,15 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h"
++#include "ui/ozone/platform/wayland/host/xdg_surface_wrapper_v6.h"
+ 
+ #include <xdg-shell-unstable-v6-client-protocol.h>
+ 
+ #include "base/strings/utf_string_conversions.h"
+ #include "ui/base/hit_test.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_util.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/common/wayland_util.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h b/ui/ozone/platform/wayland/host/xdg_surface_wrapper_v6.h
+similarity index 88%
+rename from ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h
+rename to ui/ozone/platform/wayland/host/xdg_surface_wrapper_v6.h
+index 92443cce94ce..2b49fcfb6bec 100644
+--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h
++++ b/ui/ozone/platform/wayland/host/xdg_surface_wrapper_v6.h
+@@ -2,10 +2,10 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_V6_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_V6_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_SURFACE_WRAPPER_V6_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_SURFACE_WRAPPER_V6_H_
+ 
+-#include "ui/ozone/platform/wayland/xdg_surface_wrapper.h"
++#include "ui/ozone/platform/wayland/host/xdg_surface_wrapper.h"
+ 
+ #include "base/macros.h"
+ 
+@@ -66,4 +66,4 @@ class XDGSurfaceWrapperV6 : public XDGSurfaceWrapper {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_V6_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_XDG_SURFACE_WRAPPER_V6_H_
+diff --git a/ui/ozone/platform/wayland/zwp_text_input_wrapper.h b/ui/ozone/platform/wayland/host/zwp_text_input_wrapper.h
+similarity index 90%
+rename from ui/ozone/platform/wayland/zwp_text_input_wrapper.h
+rename to ui/ozone/platform/wayland/host/zwp_text_input_wrapper.h
+index 8b11a95b779d..83e84c517766 100644
+--- a/ui/ozone/platform/wayland/zwp_text_input_wrapper.h
++++ b/ui/ozone/platform/wayland/host/zwp_text_input_wrapper.h
+@@ -2,10 +2,10 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_ZWP_TEXT_INPUT_WRAPPER_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_ZWP_TEXT_INPUT_WRAPPER_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_ZWP_TEXT_INPUT_WRAPPER_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_ZWP_TEXT_INPUT_WRAPPER_H_
+ 
+-#include "ui/ozone/platform/wayland/wayland_object.h"
++#include "ui/ozone/platform/wayland/common/wayland_object.h"
+ 
+ #include "base/strings/string16.h"
+ 
+@@ -71,4 +71,4 @@ class ZWPTextInputWrapper {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_ZWP_TEXT_INPUT_WRAPPER_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_ZWP_TEXT_INPUT_WRAPPER_H_
+diff --git a/ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.cc b/ui/ozone/platform/wayland/host/zwp_text_input_wrapper_v1.cc
+similarity index 97%
+rename from ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.cc
+rename to ui/ozone/platform/wayland/host/zwp_text_input_wrapper_v1.cc
+index 4a12ace40111..7b72165b4ff0 100644
+--- a/ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.cc
++++ b/ui/ozone/platform/wayland/host/zwp_text_input_wrapper_v1.cc
+@@ -2,14 +2,14 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.h"
++#include "ui/ozone/platform/wayland/host/zwp_text_input_wrapper_v1.h"
+ 
+ #include "base/memory/ptr_util.h"
+ #include "base/strings/string16.h"
+ #include "base/strings/utf_string_conversions.h"
+ #include "ui/gfx/range/range.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ 
+ namespace ui {
+ 
+diff --git a/ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.h b/ui/ozone/platform/wayland/host/zwp_text_input_wrapper_v1.h
+similarity index 93%
+rename from ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.h
+rename to ui/ozone/platform/wayland/host/zwp_text_input_wrapper_v1.h
+index 62cfaa629e9d..59f329fb0ca4 100644
+--- a/ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.h
++++ b/ui/ozone/platform/wayland/host/zwp_text_input_wrapper_v1.h
+@@ -2,13 +2,13 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#ifndef UI_OZONE_PLATFORM_WAYLAND_ZWP_TEXT_INPUT_WRAPPER_V1_H_
+-#define UI_OZONE_PLATFORM_WAYLAND_ZWP_TEXT_INPUT_WRAPPER_V1_H_
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_ZWP_TEXT_INPUT_WRAPPER_V1_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_ZWP_TEXT_INPUT_WRAPPER_V1_H_
+ 
+ #include <text-input-unstable-v1-client-protocol.h>
+ #include <string>
+ 
+-#include "ui/ozone/platform/wayland/zwp_text_input_wrapper.h"
++#include "ui/ozone/platform/wayland/host/zwp_text_input_wrapper.h"
+ 
+ namespace gfx {
+ class Rect;
+@@ -103,4 +103,4 @@ class ZWPTextInputWrapperV1 : public ZWPTextInputWrapper {
+ 
+ }  // namespace ui
+ 
+-#endif  // UI_OZONE_PLATFORM_WAYLAND_ZWP_TEXT_INPUT_WRAPPER_V1_H_
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_ZWP_TEXT_INPUT_WRAPPER_V1_H_
+diff --git a/ui/ozone/platform/wayland/ozone_platform_wayland.cc b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+index c1b023ec169a..2aa399952736 100644
+--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
++++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+@@ -19,12 +19,12 @@
+ #include "ui/ozone/common/stub_overlay_manager.h"
+ #include "ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.h"
+ #include "ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_connection_connector.h"
+-#include "ui/ozone/platform/wayland/wayland_input_method_context_factory.h"
+-#include "ui/ozone/platform/wayland/wayland_output_manager.h"
+-#include "ui/ozone/platform/wayland/wayland_surface_factory.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
++#include "ui/ozone/platform/wayland/gpu/wayland_surface_factory.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection_connector.h"
++#include "ui/ozone/platform/wayland/host/wayland_input_method_context_factory.h"
++#include "ui/ozone/platform/wayland/host/wayland_output_manager.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ #include "ui/ozone/public/gpu_platform_support_host.h"
+ #include "ui/ozone/public/input_controller.h"
+ #include "ui/ozone/public/ozone_platform.h"
+diff --git a/ui/ozone/platform/wayland/wayland_test.cc b/ui/ozone/platform/wayland/test/wayland_test.cc
+similarity index 97%
+rename from ui/ozone/platform/wayland/wayland_test.cc
+rename to ui/ozone/platform/wayland/test/wayland_test.cc
+index c15bc87efa15..e4e97db49539 100644
+--- a/ui/ozone/platform/wayland/wayland_test.cc
++++ b/ui/ozone/platform/wayland/test/wayland_test.cc
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "ui/ozone/platform/wayland/wayland_test.h"
++#include "ui/ozone/platform/wayland/test/wayland_test.h"
+ 
+ #include "base/run_loop.h"
+ #include "ui/events/ozone/layout/keyboard_layout_engine_manager.h"
+diff --git a/ui/ozone/platform/wayland/wayland_test.h b/ui/ozone/platform/wayland/test/wayland_test.h
+similarity index 100%
+rename from ui/ozone/platform/wayland/wayland_test.h
+rename to ui/ozone/platform/wayland/test/wayland_test.h
+diff --git a/ui/ozone/platform/wayland/wayland_buffer_fuzzer.cc b/ui/ozone/platform/wayland/wayland_buffer_fuzzer.cc
+index 84395c43da58..731f6668fdbb 100644
+--- a/ui/ozone/platform/wayland/wayland_buffer_fuzzer.cc
++++ b/ui/ozone/platform/wayland/wayland_buffer_fuzzer.cc
+@@ -18,9 +18,9 @@
+ #include "base/test/fuzzed_data_provider.h"
+ #include "testing/gmock/include/gmock/gmock.h"
+ #include "ui/gfx/geometry/rect.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
+ #include "ui/ozone/platform/wayland/test/test_wayland_server_thread.h"
+-#include "ui/ozone/platform/wayland/wayland_connection.h"
+-#include "ui/ozone/platform/wayland/wayland_window.h"
+ #include "ui/platform_window/platform_window_delegate.h"
+ #include "ui/platform_window/platform_window_init_properties.h"
+ 
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0007-Change-the-order-when-the-opaque-region-is-updated.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0007-Change-the-order-when-the-opaque-region-is-updated.patch
@@ -1,0 +1,75 @@
+Upstream-Status: Backport
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From ba87929562e1aa1aaadc6bc58e26e9f1050cad68 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Mon, 25 Mar 2019 15:27:26 +0000
+Subject: [PATCH 07/11] Change the order when the opaque region is updated.
+
+The Wayland compositor may skip opaque region updates if a client
+has not acked changed size of its surface or has not completed
+the initialization.
+
+This patch changes the order when the opaque region is set:
+1) The region is updated only after SetWindowGeometry() and
+AckConfigure() are sent.
+2) The region is updated after the entire initialization
+step is completed (a window is created first time).
+
+Bug: 942996
+Change-Id: I0ad3f4c7804a3292dedc845c352a89ea35765bea
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1527524
+Reviewed-by: Michael Spang <spang@chromium.org>
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#643847}
+---
+ ui/ozone/platform/wayland/host/wayland_window.cc | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/host/wayland_window.cc b/ui/ozone/platform/wayland/host/wayland_window.cc
+index 750da0bf3b2f..ccabb157d011 100644
+--- a/ui/ozone/platform/wayland/host/wayland_window.cc
++++ b/ui/ozone/platform/wayland/host/wayland_window.cc
+@@ -133,7 +133,6 @@ bool WaylandWindow::Initialize(PlatformWindowInitProperties properties) {
+   }
+   wl_surface_set_user_data(surface_.get(), this);
+   AddSurfaceListener();
+-  MaybeUpdateOpaqueRegion();
+ 
+   ui::PlatformWindowType ui_window_type = properties.type;
+   switch (ui_window_type) {
+@@ -161,6 +160,7 @@ bool WaylandWindow::Initialize(PlatformWindowInitProperties properties) {
+   PlatformEventSource::GetInstance()->AddPlatformEventDispatcher(this);
+   delegate_->OnAcceleratedWidgetAvailable(GetWidget());
+ 
++  MaybeUpdateOpaqueRegion();
+   return true;
+ }
+ 
+@@ -251,6 +251,10 @@ void WaylandWindow::ApplyPendingBounds() {
+   xdg_surface_->AckConfigure();
+   pending_bounds_ = gfx::Rect();
+   connection_->ScheduleFlush();
++
++  // Opaque region is based on the size of the window. Thus, update the region
++  // on each update.
++  MaybeUpdateOpaqueRegion();
+ }
+ 
+ void WaylandWindow::DispatchHostWindowDragMovement(
+@@ -325,11 +329,6 @@ void WaylandWindow::SetBounds(const gfx::Rect& bounds) {
+   if (bounds == bounds_)
+     return;
+   bounds_ = bounds;
+-
+-  // Opaque region is based on the size of the window. Thus, update the region
+-  // on each update.
+-  MaybeUpdateOpaqueRegion();
+-
+   delegate_->OnBoundsChanged(bounds);
+ }
+ 
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0008-Separate-swap-buffer-and-presentation-callbacks.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0008-Separate-swap-buffer-and-presentation-callbacks.patch
@@ -1,0 +1,1178 @@
+Upstream-Status: Backport
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 9a219ef95df2e87acfc580bdc8f590a96756e146 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Thu, 4 Apr 2019 06:10:29 +0000
+Subject: [PATCH 08/11] Separate swap buffer and presentation callbacks
+
+Previously, the WaylandBufferManager did not send swap completion
+callbacks before the presentation feedback was available.
+
+This resulted in delays and blocked the display compositor as long
+as it was waiting for the swap ack => perf regression.
+
+Thus, split the callbacks and handle them separately.
+
+In the follow up CLs, I will also move the submit frame queue
+from the GbmSurfacelessWayland to WaylandBufferManager, which
+receives frame callbacks and able to send the pending buffers as
+soon as possible. Also, it will use buffer release callbacks, which
+may come earlier that frame callbacks.
+
+Bug: 943096
+Change-Id: Ia51389b6cbbe736d19cb22e1f6532faf5e0477f4
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1538195
+Reviewed-by: Michael Spang <spang@chromium.org>
+Reviewed-by: Tom Sepez <tsepez@chromium.org>
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#647629}
+---
+ .../platform/wayland/common/wayland_util.h    |   6 -
+ .../wayland/gpu/gbm_pixmap_wayland.cc         |   9 +-
+ .../platform/wayland/gpu/gbm_pixmap_wayland.h |  10 +-
+ .../wayland/gpu/gbm_surfaceless_wayland.cc    |  64 ++++-----
+ .../wayland/gpu/gbm_surfaceless_wayland.h     |  21 +--
+ .../wayland/gpu/wayland_connection_proxy.cc   |  79 ++++++++---
+ .../wayland/gpu/wayland_connection_proxy.h    |  43 ++++--
+ .../wayland/gpu/wayland_surface_factory.cc    |  44 +++---
+ .../wayland/gpu/wayland_surface_factory.h     |  12 +-
+ .../wayland/host/wayland_buffer_manager.cc    | 126 +++++++++---------
+ .../wayland/host/wayland_buffer_manager.h     |  28 ++--
+ .../wayland/host/wayland_connection.cc        |  35 +++--
+ .../wayland/host/wayland_connection.h         |  24 +++-
+ .../wayland/ozone_platform_wayland.cc         |   6 +-
+ .../platform/wayland/test/wayland_test.cc     |   3 +-
+ .../wayland/wayland_connection.mojom          |  17 ++-
+ 16 files changed, 323 insertions(+), 204 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/common/wayland_util.h b/ui/ozone/platform/wayland/common/wayland_util.h
+index 971a00345eb7..a7bdafbe0d01 100644
+--- a/ui/ozone/platform/wayland/common/wayland_util.h
++++ b/ui/ozone/platform/wayland/common/wayland_util.h
+@@ -25,16 +25,10 @@ class WaylandConnection;
+ 
+ namespace gfx {
+ class Size;
+-enum class SwapResult;
+-struct PresentationFeedback;
+ }
+ 
+ namespace wl {
+ 
+-// Corresponds to mojom::WaylandConnection::ScheduleBufferSwapCallback.
+-using BufferSwapCallback =
+-    base::OnceCallback<void(gfx::SwapResult, const gfx::PresentationFeedback&)>;
+-
+ using RequestSizeCallback = base::OnceCallback<void(const gfx::Size&)>;
+ 
+ using OnRequestBufferCallback =
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+index f2db8e7567f8..585a3d8f31c6 100644
+--- a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
++++ b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+@@ -27,12 +27,15 @@
+ namespace ui {
+ 
+ GbmPixmapWayland::GbmPixmapWayland(WaylandSurfaceFactory* surface_manager,
+-                                   WaylandConnectionProxy* connection)
+-    : surface_manager_(surface_manager), connection_(connection) {}
++                                   WaylandConnectionProxy* connection,
++                                   gfx::AcceleratedWidget widget)
++    : surface_manager_(surface_manager),
++      connection_(connection),
++      widget_(widget) {}
+ 
+ GbmPixmapWayland::~GbmPixmapWayland() {
+   if (gbm_bo_)
+-    connection_->DestroyZwpLinuxDmabuf(GetUniqueId());
++    connection_->DestroyZwpLinuxDmabuf(widget_, GetUniqueId());
+ }
+ 
+ bool GbmPixmapWayland::InitializeBuffer(gfx::Size size,
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.h b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.h
+index 6998041936ba..e456f9e81b6f 100644
+--- a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.h
++++ b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.h
+@@ -22,7 +22,8 @@ class WaylandConnectionProxy;
+ class GbmPixmapWayland : public gfx::NativePixmap {
+  public:
+   GbmPixmapWayland(WaylandSurfaceFactory* surface_manager,
+-                   WaylandConnectionProxy* connection);
++                   WaylandConnectionProxy* connection,
++                   gfx::AcceleratedWidget widget);
+ 
+   // Creates a buffer object and initializes the pixmap buffer.
+   bool InitializeBuffer(gfx::Size size,
+@@ -57,10 +58,13 @@ class GbmPixmapWayland : public gfx::NativePixmap {
+   // gbm_bo wrapper for struct gbm_bo.
+   std::unique_ptr<GbmBuffer> gbm_bo_;
+ 
+-  WaylandSurfaceFactory* surface_manager_ = nullptr;
++  WaylandSurfaceFactory* const surface_manager_;
+ 
+   // Represents a connection to Wayland.
+-  WaylandConnectionProxy* connection_ = nullptr;
++  WaylandConnectionProxy* const connection_;
++
++  // Represents widget this pixmap backs.
++  const gfx::AcceleratedWidget widget_;
+ 
+   DISALLOW_COPY_AND_ASSIGN(GbmPixmapWayland);
+ };
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+index c4bc47e96b5f..e97eea1dbe7a 100644
+--- a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
++++ b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+@@ -9,6 +9,7 @@
+ #include "base/trace_event/trace_event.h"
+ #include "ui/gfx/gpu_fence.h"
+ #include "ui/ozone/common/egl_util.h"
++#include "ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h"
+ #include "ui/ozone/platform/wayland/gpu/wayland_surface_factory.h"
+ 
+ namespace ui {
+@@ -25,9 +26,11 @@ void WaitForFence(EGLDisplay display, EGLSyncKHR fence) {
+ 
+ GbmSurfacelessWayland::GbmSurfacelessWayland(
+     WaylandSurfaceFactory* surface_factory,
++    WaylandConnectionProxy* connection,
+     gfx::AcceleratedWidget widget)
+     : SurfacelessEGL(gfx::Size()),
+       surface_factory_(surface_factory),
++      connection_(connection),
+       widget_(widget),
+       has_implicit_external_sync_(
+           HasEGLExtension("EGL_ARM_implicit_external_sync")),
+@@ -202,18 +205,23 @@ void GbmSurfacelessWayland::SubmitFrame() {
+         submitted_frame_->ScheduleOverlayPlanes(widget_);
+ 
+     if (!schedule_planes_succeeded) {
+-      OnSubmission(gfx::SwapResult::SWAP_FAILED, nullptr);
+-      OnPresentation(gfx::PresentationFeedback::Failure());
++      last_swap_buffers_result_ = false;
++
++      std::move(submitted_frame_->completion_callback)
++          .Run(gfx::SwapResult::SWAP_FAILED, nullptr);
++      // Notify the caller, the buffer is never presented on a screen.
++      std::move(submitted_frame_->presentation_callback)
++          .Run(gfx::PresentationFeedback::Failure());
++
++      submitted_frame_.reset();
+       return;
+     }
+ 
+-    auto callback =
+-        base::BindOnce(&GbmSurfacelessWayland::OnScheduleBufferSwapDone,
+-                       weak_factory_.GetWeakPtr());
+-    uint32_t buffer_id = planes_.back().pixmap->GetUniqueId();
+-    surface_factory_->ScheduleBufferSwap(widget_, buffer_id,
+-                                         submitted_frame_->damage_region_,
+-                                         std::move(callback));
++    submitted_frame_->buffer_id = planes_.back().pixmap->GetUniqueId();
++    connection_->ScheduleBufferSwap(widget_, submitted_frame_->buffer_id,
++                                    submitted_frame_->damage_region_);
++
++    planes_.clear();
+   }
+ }
+ 
+@@ -230,31 +238,16 @@ void GbmSurfacelessWayland::FenceRetired(PendingFrame* frame) {
+   SubmitFrame();
+ }
+ 
+-void GbmSurfacelessWayland::OnScheduleBufferSwapDone(
+-    gfx::SwapResult result,
+-    const gfx::PresentationFeedback& feedback) {
+-  OnSubmission(result, nullptr);
+-  OnPresentation(feedback);
+-  planes_.clear();
+-}
+-
+-void GbmSurfacelessWayland::OnSubmission(
+-    gfx::SwapResult result,
+-    std::unique_ptr<gfx::GpuFence> out_fence) {
+-  submitted_frame_->swap_result = result;
+-}
+-
+-void GbmSurfacelessWayland::OnPresentation(
+-    const gfx::PresentationFeedback& feedback) {
+-  // Explicitly destroy overlays to free resources (e.g., fences) early.
++void GbmSurfacelessWayland::OnSubmission(uint32_t buffer_id,
++                                         const gfx::SwapResult& swap_result) {
+   submitted_frame_->overlays.clear();
+ 
+-  gfx::SwapResult result = submitted_frame_->swap_result;
+-  std::move(submitted_frame_->completion_callback).Run(result, nullptr);
+-  std::move(submitted_frame_->presentation_callback).Run(feedback);
+-  submitted_frame_.reset();
++  DCHECK_EQ(submitted_frame_->buffer_id, buffer_id);
++  std::move(submitted_frame_->completion_callback).Run(swap_result, nullptr);
+ 
+-  if (result == gfx::SwapResult::SWAP_FAILED) {
++  pending_presentation_frames_.push_back(std::move(submitted_frame_));
++
++  if (swap_result != gfx::SwapResult::SWAP_ACK) {
+     last_swap_buffers_result_ = false;
+     return;
+   }
+@@ -262,4 +255,13 @@ void GbmSurfacelessWayland::OnPresentation(
+   SubmitFrame();
+ }
+ 
++void GbmSurfacelessWayland::OnPresentation(
++    uint32_t buffer_id,
++    const gfx::PresentationFeedback& feedback) {
++  auto* frame = pending_presentation_frames_.front().get();
++  DCHECK_EQ(frame->buffer_id, buffer_id);
++  std::move(frame->presentation_callback).Run(feedback);
++  pending_presentation_frames_.erase(pending_presentation_frames_.begin());
++}
++
+ }  // namespace ui
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
+index 15b5e902989a..0155b8d0460d 100644
+--- a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
++++ b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
+@@ -14,6 +14,7 @@
+ 
+ namespace ui {
+ 
++class WaylandConnectionProxy;
+ class WaylandSurfaceFactory;
+ 
+ // A GLSurface for Wayland Ozone platform that uses surfaceless drawing. Drawing
+@@ -23,6 +24,7 @@ class WaylandSurfaceFactory;
+ class GbmSurfacelessWayland : public gl::SurfacelessEGL {
+  public:
+   GbmSurfacelessWayland(WaylandSurfaceFactory* surface_factory,
++                        WaylandConnectionProxy* connection,
+                         gfx::AcceleratedWidget widget);
+ 
+   void QueueOverlayPlane(OverlayPlane plane);
+@@ -57,6 +59,10 @@ class GbmSurfacelessWayland : public gl::SurfacelessEGL {
+   EGLConfig GetConfig() override;
+   void SetRelyOnImplicitSync() override;
+ 
++  void OnSubmission(uint32_t buffer_id, const gfx::SwapResult& swap_result);
++  void OnPresentation(uint32_t buffer_id,
++                      const gfx::PresentationFeedback& feedback);
++
+  private:
+   ~GbmSurfacelessWayland() override;
+ 
+@@ -68,7 +74,10 @@ class GbmSurfacelessWayland : public gl::SurfacelessEGL {
+     void Flush();
+ 
+     bool ready = false;
+-    gfx::SwapResult swap_result = gfx::SwapResult::SWAP_FAILED;
++
++    // The id of the buffer, which represents this frame.
++    uint32_t buffer_id = 0;
++
+     // A region of the updated content in a corresponding frame. It's used to
+     // advice Wayland which part of a buffer is going to be updated. Passing {0,
+     // 0, 0, 0} results in a whole buffer update on the Wayland compositor side.
+@@ -83,18 +92,14 @@ class GbmSurfacelessWayland : public gl::SurfacelessEGL {
+   EGLSyncKHR InsertFence(bool implicit);
+   void FenceRetired(PendingFrame* frame);
+ 
+-  void OnScheduleBufferSwapDone(gfx::SwapResult result,
+-                                const gfx::PresentationFeedback& feedback);
+-  void OnSubmission(gfx::SwapResult result,
+-                    std::unique_ptr<gfx::GpuFence> out_fence);
+-  void OnPresentation(const gfx::PresentationFeedback& feedback);
+-
+-  WaylandSurfaceFactory* surface_factory_;
++  WaylandSurfaceFactory* const surface_factory_;
++  WaylandConnectionProxy* const connection_;
+   std::vector<OverlayPlane> planes_;
+ 
+   // The native surface. Deleting this is allowed to free the EGLNativeWindow.
+   gfx::AcceleratedWidget widget_;
+   std::vector<std::unique_ptr<PendingFrame>> unsubmitted_frames_;
++  std::vector<std::unique_ptr<PendingFrame>> pending_presentation_frames_;
+   std::unique_ptr<PendingFrame> submitted_frame_;
+   bool has_implicit_external_sync_;
+   bool last_swap_buffers_result_ = true;
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+index c8109597f506..0c46d34c4769 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+@@ -7,14 +7,20 @@
+ #include <utility>
+ 
+ #include "base/process/process.h"
++#include "mojo/public/cpp/bindings/associated_interface_ptr.h"
+ #include "third_party/khronos/EGL/egl.h"
+ #include "ui/ozone/common/linux/drm_util_linux.h"
++#include "ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h"
++#include "ui/ozone/platform/wayland/gpu/wayland_surface_factory.h"
+ #include "ui/ozone/platform/wayland/host/wayland_connection.h"
+ 
+ namespace ui {
+ 
+-WaylandConnectionProxy::WaylandConnectionProxy(WaylandConnection* connection)
++WaylandConnectionProxy::WaylandConnectionProxy(WaylandConnection* connection,
++                                               WaylandSurfaceFactory* factory)
+     : connection_(connection),
++      factory_(factory),
++      associated_binding_(this),
+       gpu_thread_runner_(base::ThreadTaskRunnerHandle::Get()) {}
+ 
+ WaylandConnectionProxy::~WaylandConnectionProxy() = default;
+@@ -34,6 +40,33 @@ void WaylandConnectionProxy::ResetGbmDevice() {
+ #endif
+ }
+ 
++void WaylandConnectionProxy::OnSubmission(gfx::AcceleratedWidget widget,
++                                          uint32_t buffer_id,
++                                          gfx::SwapResult swap_result) {
++  DCHECK(gpu_thread_runner_->BelongsToCurrentThread());
++  DCHECK_NE(widget, gfx::kNullAcceleratedWidget);
++  auto* surface = factory_->GetSurface(widget);
++  // There can be a race between destruction and submitting the last frames. The
++  // surface can be destroyed by the time the host receives a request to destroy
++  // a buffer, and is able to call the OnSubmission for that specific buffer.
++  if (surface)
++    surface->OnSubmission(buffer_id, swap_result);
++}
++
++void WaylandConnectionProxy::OnPresentation(
++    gfx::AcceleratedWidget widget,
++    uint32_t buffer_id,
++    const gfx::PresentationFeedback& feedback) {
++  DCHECK(gpu_thread_runner_->BelongsToCurrentThread());
++  DCHECK_NE(widget, gfx::kNullAcceleratedWidget);
++  auto* surface = factory_->GetSurface(widget);
++  // There can be a race between destruction and presenting the last frames. The
++  // surface can be destroyed by the time the host receives a request to destroy
++  // a buffer, and is able to call the OnPresentation for that specific buffer.
++  if (surface)
++    surface->OnPresentation(buffer_id, feedback);
++}
++
+ void WaylandConnectionProxy::CreateZwpLinuxDmabuf(
+     base::File file,
+     gfx::Size size,
+@@ -68,10 +101,9 @@ void WaylandConnectionProxy::CreateZwpLinuxDmabufInternal(
+   // from the thread, which is used to call these methods. Thus, rebind the
+   // interface on a first call to ensure mojo calls will always happen on a
+   // sequence we want.
+-  if (!bound_) {
+-    wc_ptr_.Bind(std::move(wc_ptr_info_));
+-    bound_ = true;
+-  }
++  if (!wc_ptr_.is_bound())
++    BindHostInterface();
++
+   DCHECK(gpu_thread_runner_->BelongsToCurrentThread());
+   DCHECK(wc_ptr_);
+   wc_ptr_->CreateZwpLinuxDmabuf(std::move(file), size.width(), size.height(),
+@@ -79,31 +111,36 @@ void WaylandConnectionProxy::CreateZwpLinuxDmabufInternal(
+                                 planes_count, buffer_id);
+ }
+ 
+-void WaylandConnectionProxy::DestroyZwpLinuxDmabuf(uint32_t buffer_id) {
++void WaylandConnectionProxy::DestroyZwpLinuxDmabuf(
++    gfx::AcceleratedWidget widget,
++    uint32_t buffer_id) {
+   DCHECK(gpu_thread_runner_);
++
+   // Do a mojo call on the GpuMainThread instead of the io child thread to
+   // ensure proper functionality.
+   gpu_thread_runner_->PostTask(
+       FROM_HERE,
+       base::BindOnce(&WaylandConnectionProxy::DestroyZwpLinuxDmabufInternal,
+-                     base::Unretained(this), buffer_id));
++                     base::Unretained(this), widget, buffer_id));
+ }
+ 
+-void WaylandConnectionProxy::DestroyZwpLinuxDmabufInternal(uint32_t buffer_id) {
++void WaylandConnectionProxy::DestroyZwpLinuxDmabufInternal(
++    gfx::AcceleratedWidget widget,
++    uint32_t buffer_id) {
+   DCHECK(gpu_thread_runner_->BelongsToCurrentThread());
+   DCHECK(wc_ptr_);
++
+   wc_ptr_->DestroyZwpLinuxDmabuf(buffer_id);
+ }
+ 
+ void WaylandConnectionProxy::ScheduleBufferSwap(
+     gfx::AcceleratedWidget widget,
+     uint32_t buffer_id,
+-    const gfx::Rect& damage_region,
+-    wl::BufferSwapCallback callback) {
++    const gfx::Rect& damage_region) {
+   DCHECK(gpu_thread_runner_->BelongsToCurrentThread());
+   DCHECK(wc_ptr_);
+-  wc_ptr_->ScheduleBufferSwap(widget, buffer_id, damage_region,
+-                              std::move(callback));
++
++  wc_ptr_->ScheduleBufferSwap(widget, buffer_id, damage_region);
+ }
+ 
+ void WaylandConnectionProxy::CreateShmBufferForWidget(
+@@ -111,10 +148,9 @@ void WaylandConnectionProxy::CreateShmBufferForWidget(
+     base::File file,
+     size_t length,
+     const gfx::Size size) {
+-  if (!bound_) {
+-    wc_ptr_.Bind(std::move(wc_ptr_info_));
+-    bound_ = true;
+-  }
++  if (!wc_ptr_.is_bound())
++    BindHostInterface();
++
+   DCHECK(wc_ptr_);
+   wc_ptr_->CreateShmBufferForWidget(widget, std::move(file), length, size);
+ }
+@@ -162,4 +198,15 @@ void WaylandConnectionProxy::AddBindingWaylandConnectionClient(
+   bindings_.AddBinding(this, std::move(request));
+ }
+ 
++void WaylandConnectionProxy::BindHostInterface() {
++  DCHECK(!wc_ptr_.is_bound());
++  wc_ptr_.Bind(std::move(wc_ptr_info_));
++
++  // Setup associated interface.
++  ozone::mojom::WaylandConnectionClientAssociatedPtrInfo client_ptr_info;
++  auto request = MakeRequest(&client_ptr_info);
++  wc_ptr_->SetWaylandConnectionClient(std::move(client_ptr_info));
++  associated_binding_.Bind(std::move(request));
++}
++
+ }  // namespace ui
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+index f87d0b5ac4de..2335c93192fa 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+@@ -8,8 +8,10 @@
+ #include "base/macros.h"
+ #include "base/threading/sequenced_task_runner_handle.h"
+ #include "base/threading/thread_checker.h"
++#include "mojo/public/cpp/bindings/associated_binding.h"
+ #include "mojo/public/cpp/bindings/binding_set.h"
+ #include "ui/gfx/native_widget_types.h"
++#include "ui/gl/gl_surface.h"
+ #include "ui/ozone/platform/wayland/common/wayland_util.h"
+ #include "ui/ozone/platform/wayland/host/wayland_connection.h"
+ #include "ui/ozone/public/interfaces/wayland/wayland_connection.mojom.h"
+@@ -26,6 +28,7 @@ class Rect;
+ namespace ui {
+ 
+ class WaylandConnection;
++class WaylandSurfaceFactory;
+ class WaylandWindow;
+ 
+ // Provides a proxy connection to a WaylandConnection object on
+@@ -37,12 +40,22 @@ class WaylandWindow;
+ // sequence.
+ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
+  public:
+-  explicit WaylandConnectionProxy(WaylandConnection* connection);
++  WaylandConnectionProxy(WaylandConnection* connection,
++                         WaylandSurfaceFactory* factory);
+   ~WaylandConnectionProxy() override;
+ 
+   // WaylandConnectionProxy overrides:
+   void SetWaylandConnection(ozone::mojom::WaylandConnectionPtr wc_ptr) override;
+   void ResetGbmDevice() override;
++  // These two calls get the surface, which backs the |widget| and notifies it
++  // about the submission and the presentation. After the surface receives the
++  // OnSubmission call, it can schedule a new buffer for swap.
++  void OnSubmission(gfx::AcceleratedWidget widget,
++                    uint32_t buffer_id,
++                    gfx::SwapResult swap_result) override;
++  void OnPresentation(gfx::AcceleratedWidget widget,
++                      uint32_t buffer_id,
++                      const gfx::PresentationFeedback& feedback) override;
+ 
+   // Methods, which must be used when GPU is hosted on a different process
+   // aka gpu process.
+@@ -59,16 +72,21 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
+                             uint32_t buffer_id);
+ 
+   // Asks Wayland to destroy a wl_buffer.
+-  void DestroyZwpLinuxDmabuf(uint32_t buffer_id);
++  void DestroyZwpLinuxDmabuf(gfx::AcceleratedWidget widget, uint32_t buffer_id);
+ 
+   // Asks Wayland to find a wl_buffer with the |buffer_id| and schedule a
+   // buffer swap for a WaylandWindow, which backs the following |widget|.
+-  // The |callback| is called once a frame callback from the Wayland server
+-  // is received.
++  // Once the buffer is submitted and presented, the OnSubmission and
++  // OnPresentation are called. Note, it's not guaranteed the OnPresentation
++  // will follow the OnSubmission immediately, but the OnPresentation must never
++  // be called before the OnSubmission is called for that particular buffer.
++  // This logic must be checked by the client, though the host ensures this
++  // logic as well. This call must not be done twice for the same |widget| until
++  // the OnSubmission is called (which actually means the client can continue
++  // sending buffer swap requests).
+   void ScheduleBufferSwap(gfx::AcceleratedWidget widget,
+                           uint32_t buffer_id,
+-                          const gfx::Rect& damage_region,
+-                          wl::BufferSwapCallback callback);
++                          const gfx::Rect& damage_region);
+ 
+ #if defined(WAYLAND_GBM)
+   // Returns a gbm_device based on a DRM render node.
+@@ -125,12 +143,19 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
+                                     uint32_t current_format,
+                                     uint32_t planes_count,
+                                     uint32_t buffer_id);
+-  void DestroyZwpLinuxDmabufInternal(uint32_t buffer_id);
++  void DestroyZwpLinuxDmabufInternal(gfx::AcceleratedWidget widget,
++                                     uint32_t buffer_id);
++
++  void BindHostInterface();
+ 
+   // Non-owned pointer to a WaylandConnection. It is only used in a single
+   // process mode, when a shared dmabuf approach is not used.
+   WaylandConnection* const connection_;
+ 
++  // Non-owned. Only used to get registered surfaces and notify them about
++  // submission and presentation of buffers.
++  WaylandSurfaceFactory* const factory_;
++
+ #if defined(WAYLAND_GBM)
+   // A DRM render node based gbm device.
+   std::unique_ptr<GbmDevice> gbm_device_;
+@@ -142,7 +167,9 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
+   // process side. It's used for a multi-process mode.
+   ozone::mojom::WaylandConnectionPtr wc_ptr_;
+   ozone::mojom::WaylandConnectionPtrInfo wc_ptr_info_;
+-  bool bound_ = false;
++
++  mojo::AssociatedBinding<ozone::mojom::WaylandConnectionClient>
++      associated_binding_;
+ 
+   // A task runner, which is initialized in a multi-process mode. It is used to
+   // ensure all the methods of this class are run on GpuMainThread. This is
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_surface_factory.cc b/ui/ozone/platform/wayland/gpu/wayland_surface_factory.cc
+index f21d27293329..d5e32e445d6e 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_surface_factory.cc
++++ b/ui/ozone/platform/wayland/gpu/wayland_surface_factory.cc
+@@ -28,8 +28,9 @@ namespace {
+ 
+ class GLOzoneEGLWayland : public GLOzoneEGL {
+  public:
+-  explicit GLOzoneEGLWayland(WaylandConnectionProxy* connection)
+-      : connection_(connection) {}
++  GLOzoneEGLWayland(WaylandConnectionProxy* connection,
++                    WaylandSurfaceFactory* factory)
++      : connection_(connection), factory_(factory) {}
+   ~GLOzoneEGLWayland() override {}
+ 
+   scoped_refptr<gl::GLSurface> CreateViewGLSurface(
+@@ -46,7 +47,8 @@ class GLOzoneEGLWayland : public GLOzoneEGL {
+   bool LoadGLES2Bindings(gl::GLImplementation impl) override;
+ 
+  private:
+-  WaylandConnectionProxy* connection_ = nullptr;
++  WaylandConnectionProxy* const connection_;
++  WaylandSurfaceFactory* const factory_;
+ 
+   DISALLOW_COPY_AND_ASSIGN(GLOzoneEGLWayland);
+ };
+@@ -80,10 +82,8 @@ scoped_refptr<gl::GLSurface> GLOzoneEGLWayland::CreateSurfacelessViewGLSurface(
+   // If there is a gbm device available, use surfaceless gl surface.
+   if (!connection_->gbm_device())
+     return nullptr;
+-  return gl::InitializeGLSurface(new GbmSurfacelessWayland(
+-      static_cast<WaylandSurfaceFactory*>(
+-          OzonePlatform::GetInstance()->GetSurfaceFactoryOzone()),
+-      window));
++  return gl::InitializeGLSurface(
++      new GbmSurfacelessWayland(factory_, connection_, window));
+ #else
+   return nullptr;
+ #endif
+@@ -112,14 +112,17 @@ bool GLOzoneEGLWayland::LoadGLES2Bindings(gl::GLImplementation impl) {
+ 
+ }  // namespace
+ 
+-WaylandSurfaceFactory::WaylandSurfaceFactory(WaylandConnectionProxy* connection)
+-    : connection_(connection) {
+-  if (connection_)
+-    egl_implementation_ = std::make_unique<GLOzoneEGLWayland>(connection_);
+-}
++WaylandSurfaceFactory::WaylandSurfaceFactory() {}
+ 
+ WaylandSurfaceFactory::~WaylandSurfaceFactory() {}
+ 
++void WaylandSurfaceFactory::SetProxy(WaylandConnectionProxy* proxy) {
++  DCHECK(!connection_ && proxy);
++  connection_ = proxy;
++
++  egl_implementation_ = std::make_unique<GLOzoneEGLWayland>(connection_, this);
++}
++
+ void WaylandSurfaceFactory::RegisterSurface(gfx::AcceleratedWidget widget,
+                                             GbmSurfacelessWayland* surface) {
+   widget_to_surface_map_.insert(std::make_pair(widget, surface));
+@@ -131,18 +134,11 @@ void WaylandSurfaceFactory::UnregisterSurface(gfx::AcceleratedWidget widget) {
+ 
+ GbmSurfacelessWayland* WaylandSurfaceFactory::GetSurface(
+     gfx::AcceleratedWidget widget) const {
++  GbmSurfacelessWayland* surface = nullptr;
+   auto it = widget_to_surface_map_.find(widget);
+-  DCHECK(it != widget_to_surface_map_.end());
+-  return it->second;
+-}
+-
+-void WaylandSurfaceFactory::ScheduleBufferSwap(
+-    gfx::AcceleratedWidget widget,
+-    uint32_t buffer_id,
+-    const gfx::Rect& damage_region,
+-    wl::BufferSwapCallback callback) {
+-  connection_->ScheduleBufferSwap(widget, buffer_id, damage_region,
+-                                  std::move(callback));
++  if (it != widget_to_surface_map_.end())
++    surface = it->second;
++  return surface;
+ }
+ 
+ std::unique_ptr<SurfaceOzoneCanvas>
+@@ -178,7 +174,7 @@ scoped_refptr<gfx::NativePixmap> WaylandSurfaceFactory::CreateNativePixmap(
+     gfx::BufferUsage usage) {
+ #if defined(WAYLAND_GBM)
+   scoped_refptr<GbmPixmapWayland> pixmap =
+-      base::MakeRefCounted<GbmPixmapWayland>(this, connection_);
++      base::MakeRefCounted<GbmPixmapWayland>(this, connection_, widget);
+   if (!pixmap->InitializeBuffer(size, format, usage))
+     return nullptr;
+   return pixmap;
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_surface_factory.h b/ui/ozone/platform/wayland/gpu/wayland_surface_factory.h
+index c18c581e87a0..ce68012dee8d 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_surface_factory.h
++++ b/ui/ozone/platform/wayland/gpu/wayland_surface_factory.h
+@@ -13,10 +13,6 @@
+ #include "ui/ozone/platform/wayland/common/wayland_util.h"
+ #include "ui/ozone/public/surface_factory_ozone.h"
+ 
+-namespace gfx {
+-class Rect;
+-}  // namespace gfx
+-
+ namespace ui {
+ 
+ class GbmSurfacelessWayland;
+@@ -24,14 +20,12 @@ class WaylandConnectionProxy;
+ 
+ class WaylandSurfaceFactory : public SurfaceFactoryOzone {
+  public:
+-  explicit WaylandSurfaceFactory(WaylandConnectionProxy* connection);
++  WaylandSurfaceFactory();
+   ~WaylandSurfaceFactory() override;
+ 
++  void SetProxy(WaylandConnectionProxy* proxy);
++
+   // These methods are used, when a dmabuf based approach is used.
+-  void ScheduleBufferSwap(gfx::AcceleratedWidget widget,
+-                          uint32_t buffer_id,
+-                          const gfx::Rect& damage_region_,
+-                          wl::BufferSwapCallback callback);
+   void RegisterSurface(gfx::AcceleratedWidget widget,
+                        GbmSurfacelessWayland* surface);
+   void UnregisterSurface(gfx::AcceleratedWidget widget);
+diff --git a/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc b/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
+index 98b1d069f26b..0d1b328d62ef 100644
+--- a/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
++++ b/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
+@@ -41,9 +41,9 @@ base::TimeTicks GetPresentationFeedbackTimeStamp(uint32_t tv_sec_hi,
+ 
+ }  // namespace
+ 
+-WaylandBufferManager::Buffer::Buffer() = default;
+-WaylandBufferManager::Buffer::Buffer(const gfx::Size& buffer_size)
+-    : size(buffer_size) {}
++WaylandBufferManager::Buffer::Buffer(const gfx::Size& buffer_size,
++                                     uint32_t buffer_id)
++    : size(buffer_size), buffer_id(buffer_id) {}
+ WaylandBufferManager::Buffer::~Buffer() = default;
+ 
+ WaylandBufferManager::WaylandBufferManager(WaylandConnection* connection)
+@@ -74,7 +74,7 @@ bool WaylandBufferManager::CreateBuffer(base::File file,
+   }
+ 
+   std::unique_ptr<Buffer> buffer =
+-      std::make_unique<Buffer>(gfx::Size(width, height));
++      std::make_unique<Buffer>(gfx::Size(width, height), buffer_id);
+   buffers_.insert(std::make_pair(buffer_id, std::move(buffer)));
+ 
+   auto callback = base::BindOnce(&WaylandBufferManager::OnCreateBufferComplete,
+@@ -85,12 +85,10 @@ bool WaylandBufferManager::CreateBuffer(base::File file,
+   return true;
+ }
+ 
+-// TODO(msisov): handle buffer swap failure or success.
+ bool WaylandBufferManager::ScheduleBufferSwap(gfx::AcceleratedWidget widget,
+                                               uint32_t buffer_id,
+-                                              const gfx::Rect& damage_region,
+-                                              wl::BufferSwapCallback callback) {
+-  TRACE_EVENT1("wayland", "WaylandBufferManager::ScheduleBufferSwap",
++                                              const gfx::Rect& damage_region) {
++  TRACE_EVENT1("wayland", "WaylandBufferManager::ScheduleSwapBuffer",
+                "Buffer id", buffer_id);
+ 
+   if (!ValidateDataFromGpu(widget, buffer_id))
+@@ -105,11 +103,11 @@ bool WaylandBufferManager::ScheduleBufferSwap(gfx::AcceleratedWidget widget,
+ 
+   Buffer* buffer = it->second.get();
+   DCHECK(buffer);
++  DCHECK(!buffer->swapped && !buffer->presented);
+ 
+   // Assign a widget to this buffer, which is used to find a corresponding
+   // WaylandWindow.
+   buffer->widget = widget;
+-  buffer->buffer_swap_callback = std::move(callback);
+   buffer->damage_region = damage_region;
+ 
+   if (buffer->wl_buffer) {
+@@ -129,15 +127,7 @@ bool WaylandBufferManager::DestroyBuffer(uint32_t buffer_id) {
+     error_message_ = "Trying to destroy non-existing buffer";
+     return false;
+   }
+-  // It can happen that a buffer is destroyed before a frame callback comes.
+-  // Thus, just mark this as a successful swap, which is ok to do.
+-  Buffer* buffer = it->second.get();
+-  if (!buffer->buffer_swap_callback.is_null()) {
+-    std::move(buffer->buffer_swap_callback)
+-        .Run(gfx::SwapResult::SWAP_ACK,
+-             gfx::PresentationFeedback(base::TimeTicks::Now(),
+-                                       base::TimeDelta(), 0));
+-  }
++
+   buffers_.erase(it);
+ 
+   connection_->ScheduleFlush();
+@@ -282,10 +272,47 @@ void WaylandBufferManager::OnCreateBufferComplete(
+     SwapBuffer(buffer);
+ }
+ 
+-void WaylandBufferManager::OnBufferSwapped(Buffer* buffer) {
+-  DCHECK(!buffer->buffer_swap_callback.is_null());
+-  std::move(buffer->buffer_swap_callback)
+-      .Run(buffer->swap_result, std::move(buffer->feedback));
++void WaylandBufferManager::OnSubmission(Buffer* buffer,
++                                        const gfx::SwapResult& swap_result) {
++  DCHECK(!buffer->swapped);
++
++  buffer->wl_frame_callback.reset();
++  buffer->swapped = true;
++  connection_->OnSubmission(buffer->widget, buffer->buffer_id,
++                            gfx::SwapResult::SWAP_ACK);
++
++  // If presentation feedback is not supported, use a fake feedback.
++  if (!connection_->presentation()) {
++    DCHECK(!buffer->wp_presentation_feedback && !buffer->presented);
++    OnPresentation(buffer, gfx::PresentationFeedback(base::TimeTicks::Now(),
++                                                     base::TimeDelta(), 0));
++  } else if (buffer->presented) {
++    DCHECK(!buffer->wp_presentation_feedback);
++    // If the buffer has been presented before the frame callback aka
++    // completion callback (in the future, release callback is going to be
++    // used), present the feedback to the GPU.
++    OnPresentation(buffer, buffer->feedback);
++  } else {
++    DCHECK(buffer->wp_presentation_feedback);
++  }
++}
++
++void WaylandBufferManager::OnPresentation(
++    Buffer* buffer,
++    const gfx::PresentationFeedback& feedback) {
++  buffer->presented = true;
++  buffer->feedback = feedback;
++
++  // If buffer has already been swapped, we can safely notify about the
++  // presentation as well.
++  if (buffer->swapped) {
++    connection_->OnPresentation(buffer->widget, buffer->buffer_id,
++                                buffer->feedback);
++
++    // Reset the status so that DCHECK passes in ::ScheduleBufferSwap call.
++    buffer->presented = false;
++    buffer->swapped = false;
++  }
+ }
+ 
+ // static
+@@ -294,27 +321,15 @@ void WaylandBufferManager::FrameCallbackDone(void* data,
+                                              uint32_t time) {
+   WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+   DCHECK(self);
++
+   for (auto& item : self->buffers_) {
+     Buffer* buffer = item.second.get();
+     if (buffer->wl_frame_callback.get() == callback) {
+-      buffer->swap_result = gfx::SwapResult::SWAP_ACK;
+       buffer->wl_frame_callback.reset();
+-
+-      // If presentation feedback is not supported, use a fake feedback
+-      if (!self->connection_->presentation()) {
+-        buffer->feedback = gfx::PresentationFeedback(base::TimeTicks::Now(),
+-                                                     base::TimeDelta(), 0);
+-      }
+-      // If presentation feedback event either has already been fired or
+-      // has not been set, trigger swap callback.
+-      if (!buffer->wp_presentation_feedback)
+-        self->OnBufferSwapped(buffer);
+-
++      self->OnSubmission(buffer, gfx::SwapResult::SWAP_ACK);
+       return;
+     }
+   }
+-
+-  NOTREACHED();
+ }
+ 
+ // static
+@@ -338,29 +353,20 @@ void WaylandBufferManager::FeedbackPresented(
+     uint32_t flags) {
+   WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+   DCHECK(self);
+-
+   for (auto& item : self->buffers_) {
+     Buffer* buffer = item.second.get();
+     if (buffer->wp_presentation_feedback.get() == wp_presentation_feedback) {
+-      buffer->feedback = gfx::PresentationFeedback(
+-          GetPresentationFeedbackTimeStamp(tv_sec_hi, tv_sec_lo, tv_nsec),
+-          base::TimeDelta::FromNanoseconds(refresh),
+-          GetPresentationKindFlags(flags));
++      DCHECK(!buffer->presented);
+       buffer->wp_presentation_feedback.reset();
+-
+-      // Some compositors not always fire PresentationFeedback and Frame
+-      // events in the same order (i.e, frame callbacks coming always before
+-      // feedback presented/discaded ones). So, check FrameCallbackDone has
+-      // already been called at this point, if yes, trigger the swap callback.
+-      // otherwise it will be triggered in the upcoming frame callback.
+-      if (!buffer->wl_frame_callback)
+-        self->OnBufferSwapped(buffer);
+-
++      self->OnPresentation(
++          buffer,
++          gfx::PresentationFeedback(
++              GetPresentationFeedbackTimeStamp(tv_sec_hi, tv_sec_lo, tv_nsec),
++              base::TimeDelta::FromNanoseconds(refresh),
++              GetPresentationKindFlags(flags)));
+       return;
+     }
+   }
+-
+-  NOTREACHED();
+ }
+ 
+ // static
+@@ -369,27 +375,15 @@ void WaylandBufferManager::FeedbackDiscarded(
+     struct wp_presentation_feedback* wp_presentation_feedback) {
+   WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+   DCHECK(self);
+-
+   for (auto& item : self->buffers_) {
+     Buffer* buffer = item.second.get();
+     if (buffer->wp_presentation_feedback.get() == wp_presentation_feedback) {
+-      // Frame callback must come before a feedback is presented.
+-      buffer->feedback = gfx::PresentationFeedback::Failure();
++      DCHECK(!buffer->presented);
+       buffer->wp_presentation_feedback.reset();
+-
+-      // Some compositors not always fire PresentationFeedback and Frame
+-      // events in the same order (i.e, frame callbacks coming always before
+-      // feedback presented/discaded ones). So, check FrameCallbackDone has
+-      // already been called at this point, if yes, trigger the swap callback.
+-      // Otherwise it will be triggered in the upcoming frame callback.
+-      if (!buffer->wl_frame_callback)
+-        self->OnBufferSwapped(buffer);
+-
++      self->OnPresentation(buffer, gfx::PresentationFeedback::Failure());
+       return;
+     }
+   }
+-
+-  NOTREACHED();
+ }
+ 
+ }  // namespace ui
+diff --git a/ui/ozone/platform/wayland/host/wayland_buffer_manager.h b/ui/ozone/platform/wayland/host/wayland_buffer_manager.h
+index 633eba0c9e34..f4b0183cc3a1 100644
+--- a/ui/ozone/platform/wayland/host/wayland_buffer_manager.h
++++ b/ui/ozone/platform/wayland/host/wayland_buffer_manager.h
+@@ -49,11 +49,13 @@ class WaylandBufferManager {
+   // Assigns a wl_buffer with |buffer_id| to a window with the same |widget|. On
+   // error, false is returned and |error_message_| is set. A |damage_region|
+   // identifies which part of the buffer is updated. If an empty region is
+-  // provided, the whole buffer is updated.
++  // provided, the whole buffer is updated. Once a frame callback or
++  // presentation callback is received, WaylandConnection::OnSubmission and
++  // WaylandConnection::OnPresentation are called. Though, it is guaranteed
++  // OnPresentation won't be called earlier than OnSubmission.
+   bool ScheduleBufferSwap(gfx::AcceleratedWidget widget,
+                           uint32_t buffer_id,
+-                          const gfx::Rect& damage_region,
+-                          wl::BufferSwapCallback callback);
++                          const gfx::Rect& damage_region);
+ 
+   // Destroys a buffer with |buffer_id| in |buffers_|. On error, false is
+   // returned and |error_message_| is set.
+@@ -71,13 +73,16 @@ class WaylandBufferManager {
+   // to, its buffer id for simplier buffer management and other members specific
+   // to this Buffer object on run-time.
+   struct Buffer {
+-    Buffer();
+-    explicit Buffer(const gfx::Size& buffer_size);
++    Buffer() = delete;
++    Buffer(const gfx::Size& buffer_size, uint32_t buffer_id);
+     ~Buffer();
+ 
+     // Actual buffer size.
+     const gfx::Size size;
+ 
++    // The id of the buffer.
++    const uint32_t buffer_id;
++
+     // Widget to attached/being attach WaylandWindow.
+     gfx::AcceleratedWidget widget = gfx::kNullAcceleratedWidget;
+ 
+@@ -86,9 +91,6 @@ class WaylandBufferManager {
+     // repainted.
+     gfx::Rect damage_region;
+ 
+-    // A buffer swap result once the buffer is committed.
+-    gfx::SwapResult swap_result;
+-
+     // A feedback, which is received if a presentation feedback protocol is
+     // supported.
+     gfx::PresentationFeedback feedback;
+@@ -96,9 +98,9 @@ class WaylandBufferManager {
+     // A wl_buffer backed by a dmabuf created on the GPU side.
+     wl::Object<struct wl_buffer> wl_buffer;
+ 
+-    // A callback, which is called once the |wl_frame_callback| from the server
+-    // is received.
+-    wl::BufferSwapCallback buffer_swap_callback;
++    // Provide the status of this buffer. Reset on each new swap.
++    bool swapped = false;
++    bool presented = false;
+ 
+     // A Wayland callback, which is triggered once wl_buffer has been committed
+     // and it is right time to notify the GPU that it can start a new drawing
+@@ -133,7 +135,9 @@ class WaylandBufferManager {
+   void OnCreateBufferComplete(uint32_t buffer_id,
+                               wl::Object<struct wl_buffer> new_buffer);
+ 
+-  void OnBufferSwapped(Buffer* buffer);
++  void OnSubmission(Buffer* buffer, const gfx::SwapResult& swap_result);
++  void OnPresentation(Buffer* buffer,
++                      const gfx::PresentationFeedback& feedback);
+ 
+   // wl_callback_listener
+   static void FrameCallbackDone(void* data,
+diff --git a/ui/ozone/platform/wayland/host/wayland_connection.cc b/ui/ozone/platform/wayland/host/wayland_connection.cc
+index 4eb8db596fdb..7604e9abd4a4 100644
+--- a/ui/ozone/platform/wayland/host/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/host/wayland_connection.cc
+@@ -182,6 +182,11 @@ int WaylandConnection::GetKeyboardModifiers() const {
+   return modifiers;
+ }
+ 
++void WaylandConnection::SetWaylandConnectionClient(
++    ozone::mojom::WaylandConnectionClientAssociatedPtrInfo client) {
++  client_associated_ptr_.Bind(std::move(client));
++}
++
+ void WaylandConnection::CreateZwpLinuxDmabuf(
+     base::File file,
+     uint32_t width,
+@@ -211,18 +216,14 @@ void WaylandConnection::DestroyZwpLinuxDmabuf(uint32_t buffer_id) {
+   }
+ }
+ 
+-void WaylandConnection::ScheduleBufferSwap(
+-    gfx::AcceleratedWidget widget,
+-    uint32_t buffer_id,
+-    const gfx::Rect& damage_region,
+-    ScheduleBufferSwapCallback callback) {
++void WaylandConnection::ScheduleBufferSwap(gfx::AcceleratedWidget widget,
++                                           uint32_t buffer_id,
++                                           const gfx::Rect& damage_region) {
+   DCHECK(base::MessageLoopCurrentForUI::IsSet());
+ 
+   CHECK(buffer_manager_);
+-  if (!buffer_manager_->ScheduleBufferSwap(widget, buffer_id, damage_region,
+-                                           std::move(callback))) {
++  if (!buffer_manager_->ScheduleBufferSwap(widget, buffer_id, damage_region))
+     TerminateGpuProcess(buffer_manager_->error_message());
+-  }
+ }
+ 
+ void WaylandConnection::CreateShmBufferForWidget(gfx::AcceleratedWidget widget,
+@@ -248,6 +249,21 @@ void WaylandConnection::DestroyShmBuffer(gfx::AcceleratedWidget widget) {
+     TerminateGpuProcess("Failed to destroy SHM buffer.");
+ }
+ 
++void WaylandConnection::OnSubmission(gfx::AcceleratedWidget widget,
++                                     uint32_t buffer_id,
++                                     const gfx::SwapResult& swap_result) {
++  DCHECK(client_associated_ptr_);
++  client_associated_ptr_->OnSubmission(widget, buffer_id, swap_result);
++}
++
++void WaylandConnection::OnPresentation(
++    gfx::AcceleratedWidget widget,
++    uint32_t buffer_id,
++    const gfx::PresentationFeedback& feedback) {
++  DCHECK(client_associated_ptr_);
++  client_associated_ptr_->OnPresentation(widget, buffer_id, feedback);
++}
++
+ PlatformClipboard* WaylandConnection::GetPlatformClipboard() {
+   return this;
+ }
+@@ -293,7 +309,8 @@ ozone::mojom::WaylandConnectionPtr WaylandConnection::BindInterface() {
+ }
+ 
+ void WaylandConnection::OnChannelDestroyed() {
+-  binding_.Unbind();
++  client_associated_ptr_.reset();
++  binding_.Close();
+   if (buffer_manager_)
+     buffer_manager_->ClearState();
+ }
+diff --git a/ui/ozone/platform/wayland/host/wayland_connection.h b/ui/ozone/platform/wayland/host/wayland_connection.h
+index c1ec0412bee6..2edbdb7e403d 100644
+--- a/ui/ozone/platform/wayland/host/wayland_connection.h
++++ b/ui/ozone/platform/wayland/host/wayland_connection.h
+@@ -52,6 +52,8 @@ class WaylandConnection : public PlatformEventSource,
+   //
+   // These overridden methods below are invoked by the GPU when hardware
+   // accelerated rendering is used.
++  void SetWaylandConnectionClient(
++      ozone::mojom::WaylandConnectionClientAssociatedPtrInfo client) override;
+   //
+   // Called by the GPU and asks to import a wl_buffer based on a gbm file
+   // descriptor.
+@@ -68,13 +70,14 @@ class WaylandConnection : public PlatformEventSource,
+   void DestroyZwpLinuxDmabuf(uint32_t buffer_id) override;
+   // Called by the GPU and asks to attach a wl_buffer with a |buffer_id| to a
+   // WaylandWindow with the specified |widget|.
++  // Calls OnSubmission and OnPresentation on successful swap and pixels
++  // presented.
+   void ScheduleBufferSwap(gfx::AcceleratedWidget widget,
+                           uint32_t buffer_id,
+-                          const gfx::Rect& damage_region,
+-                          ScheduleBufferSwapCallback callback) override;
++                          const gfx::Rect& damage_region) override;
+   // These overridden methods below are invoked by the GPU when hardware
+   // accelerated rendering is not used. Check comments in the
+-  // ui/ozone/public/interfaces/wayland/host/wayland_connection.mojom.
++  // ui/ozone/public/interfaces/wayland/wayland_connection.mojom.
+   void CreateShmBufferForWidget(gfx::AcceleratedWidget widget,
+                                 base::File file,
+                                 uint64_t length,
+@@ -83,6 +86,20 @@ class WaylandConnection : public PlatformEventSource,
+                                  const gfx::Rect& damage) override;
+   void DestroyShmBuffer(gfx::AcceleratedWidget widget) override;
+ 
++  // These methods are exclusively used by the WaylandBufferManager to notify
++  // the |client_associated_ptr_| about buffer swaps' results.
++  // TODO(msisov): move these and the above mojo methods into the
++  // WaylandBufferManager and establish end-to-end communication with
++  // WaylandBufferManagerGpu and WaylandBufferManagerHost instead (basically, to
++  // avoid having the WaylandConnection as proxy in between).
++  // https://crbug.com/947411
++  void OnSubmission(gfx::AcceleratedWidget widget,
++                    uint32_t buffer_id,
++                    const gfx::SwapResult& swap_result);
++  void OnPresentation(gfx::AcceleratedWidget widget,
++                      uint32_t buffer_id,
++                      const gfx::PresentationFeedback& feedback);
++
+   // Schedules a flush of the Wayland connection.
+   void ScheduleFlush();
+ 
+@@ -278,6 +295,7 @@ class WaylandConnection : public PlatformEventSource,
+   // Stores the callback to be invoked upon data reading from clipboard.
+   RequestDataClosure read_clipboard_closure_;
+ 
++  ozone::mojom::WaylandConnectionClientAssociatedPtr client_associated_ptr_;
+   mojo::Binding<ozone::mojom::WaylandConnection> binding_;
+ 
+   // A callback, which is used to terminate a GPU process in case of invalid
+diff --git a/ui/ozone/platform/wayland/ozone_platform_wayland.cc b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+index 2aa399952736..c95344355fa2 100644
+--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
++++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+@@ -167,8 +167,10 @@ class OzonePlatformWayland : public OzonePlatform {
+   }
+ 
+   void InitializeGPU(const InitParams& args) override {
+-    proxy_.reset(new WaylandConnectionProxy(connection_.get()));
+-    surface_factory_.reset(new WaylandSurfaceFactory(proxy_.get()));
++    surface_factory_ = std::make_unique<WaylandSurfaceFactory>();
++    proxy_ = std::make_unique<WaylandConnectionProxy>(connection_.get(),
++                                                      surface_factory_.get());
++    surface_factory_->SetProxy(proxy_.get());
+ #if defined(WAYLAND_GBM)
+     const base::FilePath drm_node_path = path_finder_.GetDrmRenderNodePath();
+     if (drm_node_path.empty()) {
+diff --git a/ui/ozone/platform/wayland/test/wayland_test.cc b/ui/ozone/platform/wayland/test/wayland_test.cc
+index e4e97db49539..55b15076cde3 100644
+--- a/ui/ozone/platform/wayland/test/wayland_test.cc
++++ b/ui/ozone/platform/wayland/test/wayland_test.cc
+@@ -28,7 +28,8 @@ WaylandTest::WaylandTest() {
+       std::make_unique<StubKeyboardLayoutEngine>());
+ #endif
+   connection_.reset(new WaylandConnection);
+-  connection_proxy_.reset(new WaylandConnectionProxy(connection_.get()));
++  connection_proxy_.reset(
++      new WaylandConnectionProxy(connection_.get(), nullptr));
+   window_ = std::make_unique<WaylandWindow>(&delegate_, connection_.get());
+ }
+ 
+diff --git a/ui/ozone/public/interfaces/wayland/wayland_connection.mojom b/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
+index f7fc67762911..713ac9a210e7 100644
+--- a/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
++++ b/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
+@@ -14,6 +14,9 @@ import "ui/gfx/mojo/swap_result.mojom";
+ // Used by the GPU for communication with a WaylandConnection on the browser
+ // process.
+ interface WaylandConnection {
++  // Sets up an associated pipe between the Client and Host.
++  SetWaylandConnectionClient(associated WaylandConnectionClient client);
++
+   // Methods used for hardware accelerated rendering:
+   //
+   // Asks Wayland to create a wl_buffer based on the dmabuf |file| descriptor.
+@@ -32,9 +35,7 @@ interface WaylandConnection {
+ 
+   // Swaps wl_buffers for a WaylandWindow with the following |widget|.
+   ScheduleBufferSwap(gfx.mojom.AcceleratedWidget widget, uint32 buffer_id,
+-                     gfx.mojom.Rect damage_region)
+-      => (gfx.mojom.SwapResult swap_result,
+-          gfx.mojom.PresentationFeedback feedback);
++                     gfx.mojom.Rect damage_region);
+ 
+   // Methods used for software rendering:
+   //
+@@ -65,4 +66,14 @@ interface WaylandConnectionClient {
+   // avoid using zwp_linux_dmabuf protocol, which means using wl_egl_surface in
+   // a single process mode, and software rendering in a multiple process mode.
+   ResetGbmDevice();
++
++  // Signals about swap completion.
++  OnSubmission(gfx.mojom.AcceleratedWidget widget,
++               uint32 buffer_id,
++               gfx.mojom.SwapResult swap_result);
++
++  // Signals about presentation.
++  OnPresentation(gfx.mojom.AcceleratedWidget widget,
++                 uint32 buffer_id,
++                 gfx.mojom.PresentationFeedback feedback);
+ };
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0009-Ease-the-buffer-swap-and-maintenance.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0009-Ease-the-buffer-swap-and-maintenance.patch
@@ -1,0 +1,1155 @@
+Upstream-Status: Submitted [https://crrev.com/c/1570014]
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 2d442618f548098fbb9483823aaeb9c3d32d6536 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Thu, 18 Apr 2019 09:41:39 +0300
+Subject: [PATCH 09/11] Ease the buffer swap and maintenance
+
+This CL adds a Surface class, which has 1:1 relationship
+with a WaylandWindow (whenever the former is created, the
+manager is notified, and it creates an internal representation
+of the window).
+
+The CL does not bring any major changes, but rather improves
+and eases the maintenance of buffers and distinguishes
+buffers by the widget they have been created for.
+
+This is a prerequisite to switch from post frame callback wait
+to the pre frame callback wait.
+
+Bug: 943096
+Change-Id: Ia70f061c4c47a9675c2a018a346b6bc38d0e8cf7
+---
+ .../wayland/gpu/gbm_pixmap_wayland.cc         |   6 +-
+ .../wayland/gpu/gbm_surfaceless_wayland.cc    |   1 +
+ .../wayland/gpu/wayland_connection_proxy.cc   |  14 +-
+ .../wayland/gpu/wayland_connection_proxy.h    |   6 +-
+ .../wayland/host/wayland_buffer_manager.cc    | 589 +++++++++++-------
+ .../wayland/host/wayland_buffer_manager.h     | 117 +---
+ .../wayland/host/wayland_connection.cc        |  22 +-
+ .../wayland/host/wayland_connection.h         |  11 +-
+ .../wayland/wayland_connection.mojom          |  39 +-
+ 9 files changed, 456 insertions(+), 349 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+index 585a3d8f31c6..ee8d622f95cc 100644
+--- a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
++++ b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+@@ -181,9 +181,9 @@ void GbmPixmapWayland::CreateZwpLinuxDmabuf() {
+   base::File file(fd.release());
+ 
+   // Asks Wayland to create a wl_buffer based on the |file| fd.
+-  connection_->CreateZwpLinuxDmabuf(std::move(file), GetBufferSize(), strides,
+-                                    offsets, modifiers, gbm_bo_->GetFormat(),
+-                                    plane_count, GetUniqueId());
++  connection_->CreateZwpLinuxDmabuf(
++      widget_, std::move(file), GetBufferSize(), strides, offsets, modifiers,
++      gbm_bo_->GetFormat(), plane_count, GetUniqueId());
+ }
+ 
+ }  // namespace ui
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+index e97eea1dbe7a..c348472bb3eb 100644
+--- a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
++++ b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+@@ -258,6 +258,7 @@ void GbmSurfacelessWayland::OnSubmission(uint32_t buffer_id,
+ void GbmSurfacelessWayland::OnPresentation(
+     uint32_t buffer_id,
+     const gfx::PresentationFeedback& feedback) {
++  DCHECK(!pending_presentation_frames_.empty());
+   auto* frame = pending_presentation_frames_.front().get();
+   DCHECK_EQ(frame->buffer_id, buffer_id);
+   std::move(frame->presentation_callback).Run(feedback);
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+index 0c46d34c4769..230ee57fe9d2 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+@@ -68,6 +68,7 @@ void WaylandConnectionProxy::OnPresentation(
+ }
+ 
+ void WaylandConnectionProxy::CreateZwpLinuxDmabuf(
++    gfx::AcceleratedWidget widget,
+     base::File file,
+     gfx::Size size,
+     const std::vector<uint32_t>& strides,
+@@ -82,13 +83,14 @@ void WaylandConnectionProxy::CreateZwpLinuxDmabuf(
+   gpu_thread_runner_->PostTask(
+       FROM_HERE,
+       base::BindOnce(&WaylandConnectionProxy::CreateZwpLinuxDmabufInternal,
+-                     base::Unretained(this), std::move(file), std::move(size),
+-                     std::move(strides), std::move(offsets),
++                     base::Unretained(this), widget, std::move(file),
++                     std::move(size), std::move(strides), std::move(offsets),
+                      std::move(modifiers), current_format, planes_count,
+                      buffer_id));
+ }
+ 
+ void WaylandConnectionProxy::CreateZwpLinuxDmabufInternal(
++    gfx::AcceleratedWidget widget,
+     base::File file,
+     gfx::Size size,
+     const std::vector<uint32_t>& strides,
+@@ -106,9 +108,9 @@ void WaylandConnectionProxy::CreateZwpLinuxDmabufInternal(
+ 
+   DCHECK(gpu_thread_runner_->BelongsToCurrentThread());
+   DCHECK(wc_ptr_);
+-  wc_ptr_->CreateZwpLinuxDmabuf(std::move(file), size.width(), size.height(),
+-                                strides, offsets, current_format, modifiers,
+-                                planes_count, buffer_id);
++  wc_ptr_->CreateZwpLinuxDmabuf(widget, std::move(file), size, strides, offsets,
++                                modifiers, current_format, planes_count,
++                                buffer_id);
+ }
+ 
+ void WaylandConnectionProxy::DestroyZwpLinuxDmabuf(
+@@ -130,7 +132,7 @@ void WaylandConnectionProxy::DestroyZwpLinuxDmabufInternal(
+   DCHECK(gpu_thread_runner_->BelongsToCurrentThread());
+   DCHECK(wc_ptr_);
+ 
+-  wc_ptr_->DestroyZwpLinuxDmabuf(buffer_id);
++  wc_ptr_->DestroyZwpLinuxDmabuf(widget, buffer_id);
+ }
+ 
+ void WaylandConnectionProxy::ScheduleBufferSwap(
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+index 2335c93192fa..d507d06f03cb 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
++++ b/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.h
+@@ -62,7 +62,8 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
+   //
+   // Asks Wayland to create a wl_buffer based on a shared buffer file
+   // descriptor backed (gbm_bo).
+-  void CreateZwpLinuxDmabuf(base::File file,
++  void CreateZwpLinuxDmabuf(gfx::AcceleratedWidget widget,
++                            base::File file,
+                             gfx::Size size,
+                             const std::vector<uint32_t>& strides,
+                             const std::vector<uint32_t>& offsets,
+@@ -135,7 +136,8 @@ class WaylandConnectionProxy : public ozone::mojom::WaylandConnectionClient {
+   WaylandConnection* connection() const { return connection_; }
+ 
+  private:
+-  void CreateZwpLinuxDmabufInternal(base::File file,
++  void CreateZwpLinuxDmabufInternal(gfx::AcceleratedWidget widget,
++                                    base::File file,
+                                     gfx::Size size,
+                                     const std::vector<uint32_t>& strides,
+                                     const std::vector<uint32_t>& offsets,
+diff --git a/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc b/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
+index 0d1b328d62ef..99877e12bbc1 100644
+--- a/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
++++ b/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
+@@ -6,6 +6,8 @@
+ 
+ #include <presentation-time-client-protocol.h>
+ 
++#include "base/i18n/number_formatting.h"
++#include "base/strings/utf_string_conversions.h"
+ #include "base/trace_event/trace_event.h"
+ #include "ui/ozone/common/linux/drm_util_linux.h"
+ #include "ui/ozone/platform/wayland/host/wayland_connection.h"
+@@ -41,47 +43,351 @@ base::TimeTicks GetPresentationFeedbackTimeStamp(uint32_t tv_sec_hi,
+ 
+ }  // namespace
+ 
+-WaylandBufferManager::Buffer::Buffer(const gfx::Size& buffer_size,
+-                                     uint32_t buffer_id)
+-    : size(buffer_size), buffer_id(buffer_id) {}
+-WaylandBufferManager::Buffer::~Buffer() = default;
++class WaylandBufferManager::Surface {
++ public:
++  Surface(WaylandWindow* window, WaylandConnection* connection)
++      : window_(window), connection_(connection) {}
++  ~Surface() = default;
++
++  bool CommitBuffer(uint32_t buffer_id, const gfx::Rect& damage_region) {
++    DCHECK(!submitted_buffer_);
++
++    WaylandBuffer* buffer = GetBuffer(buffer_id);
++    if (!buffer)
++      return false;
++
++    // This request may come earlier than the Wayland compositor has imported a
++    // wl_buffer. Wait until the buffer is created. The wait takes place only
++    // once. Though, the case when a request to attach a buffer comes earlier
++    // than the wl_buffer is created does not happen often. 1) Depending on the
++    // zwp linux dmabuf protocol version, the wl_buffer can be created
++    // immediately without asynchronous wait 2) the wl_buffer can have been
++    // created by this time.
++    while (!buffer->wl_buffer) {
++      if (wl_display_dispatch(connection_->display()) == -1)
++        return false;
++    }
++
++    AttachAndDamageBuffer(buffer, damage_region);
++
++    SetupFrameCallback();
++    SetupPresentationFeedback(buffer_id);
++
++    CommitSurface();
++
++    connection_->ScheduleFlush();
++    return true;
++  }
++
++  bool CreateBuffer(const gfx::Size& size, uint32_t buffer_id) {
++    auto result = buffers_.insert(std::make_pair(
++        buffer_id, std::make_unique<WaylandBuffer>(size, buffer_id)));
++    return result.second;
++  }
++
++  size_t DestroyBuffer(uint32_t buffer_id) {
++    if (submitted_buffer_ && submitted_buffer_->buffer_id == buffer_id)
++      submitted_buffer_ = nullptr;
++    auto result = buffers_.erase(buffer_id);
++    return result;
++  }
++
++  void AttachWlBuffer(uint32_t buffer_id, wl::Object<wl_buffer> new_buffer) {
++    // It can happen that a buffer was destroyed by a client while the Wayland
++    // compositor was processing a request to create a wl_buffer.
++    WaylandBuffer* buffer = GetBuffer(buffer_id);
++    if (!buffer)
++      return;
++
++    DCHECK(!buffer->wl_buffer);
++    buffer->wl_buffer = std::move(new_buffer);
++  }
++
++  void ClearState() {
++    buffers_.clear();
++    wl_frame_callback_.reset();
++    base::queue<
++        std::pair<uint32_t, wl::Object<struct wp_presentation_feedback>>>
++        empty;
++    std::swap(presentation_feedbacks_, empty);
++  }
++
++ private:
++  // This is an internal helper representation of a wayland buffer object, which
++  // the GPU process creates when CreateBuffer is called. It's used for
++  // asynchronous buffer creation and stores |params| parameter to find out,
++  // which Buffer the wl_buffer corresponds to when CreateSucceeded is called.
++  // What is more, the Buffer stores such information as a widget it is attached
++  // to, its buffer id for simpler buffer management and other members specific
++  // to this Buffer object on run-time.
++  struct WaylandBuffer {
++    WaylandBuffer() = delete;
++    WaylandBuffer(const gfx::Size& size, uint32_t buffer_id);
++    ~WaylandBuffer();
++
++    // Actual buffer size.
++    const gfx::Size size;
++
++    // The id of this buffer.
++    const uint32_t buffer_id;
++
++    // A wl_buffer backed by a dmabuf created on the GPU side.
++    wl::Object<struct wl_buffer> wl_buffer;
++
++    gfx::PresentationFeedback feedback;
++
++    bool swapped = false;
++    bool presented = false;
++
++    DISALLOW_COPY_AND_ASSIGN(WaylandBuffer);
++  };
++
++  void AttachAndDamageBuffer(WaylandBuffer* buffer,
++                             const gfx::Rect& damage_region) {
++    gfx::Rect pending_damage_region = damage_region;
++    // If the size of the damage region is empty, wl_surface_damage must be
++    // supplied with the actual size of the buffer, which is going to be
++    // committed.
++    if (pending_damage_region.size().IsEmpty())
++      pending_damage_region.set_size(buffer->size);
++    DCHECK(!pending_damage_region.size().IsEmpty());
++
++    auto* surface = window_->surface();
++    wl_surface_damage_buffer(
++        surface, pending_damage_region.x(), pending_damage_region.y(),
++        pending_damage_region.width(), pending_damage_region.height());
++    wl_surface_attach(surface, buffer->wl_buffer.get(), 0, 0);
++
++    submitted_buffer_ = buffer;
++  }
++
++  void CommitSurface() { wl_surface_commit(window_->surface()); }
++
++  void SetupFrameCallback() {
++    static const wl_callback_listener frame_listener = {
++        &Surface::FrameCallbackDone};
++
++    DCHECK(!wl_frame_callback_);
++    wl_frame_callback_.reset(wl_surface_frame(window_->surface()));
++    wl_callback_add_listener(wl_frame_callback_.get(), &frame_listener, this);
++  }
++
++  void SetupPresentationFeedback(uint32_t buffer_id) {
++    // Set up presentation feedback.
++    if (!connection_->presentation())
++      return;
++
++    static const wp_presentation_feedback_listener feedback_listener = {
++        &Surface::FeedbackSyncOutput, &Surface::FeedbackPresented,
++        &Surface::FeedbackDiscarded};
++
++    presentation_feedbacks_.push(std::make_pair(
++        buffer_id,
++        wl::Object<struct wp_presentation_feedback>(wp_presentation_feedback(
++            connection_->presentation(), window_->surface()))));
++    wp_presentation_feedback_add_listener(
++        presentation_feedbacks_.back().second.get(), &feedback_listener, this);
++  }
++
++  WaylandBuffer* GetBuffer(uint32_t buffer_id) {
++    auto it = buffers_.find(buffer_id);
++    return it != buffers_.end() ? it->second.get() : nullptr;
++  }
++
++  void OnFrameCallback(struct wl_callback* callback) {
++    DCHECK(wl_frame_callback_.get() == callback);
++    wl_frame_callback_.reset();
++
++    if (!submitted_buffer_)
++      return;
++
++    // TODO(msisov): remove these once pending buffers logic goes to the
++    // manager as long as it will always notify about successful swap once the
++    // surface is committed.
++    DCHECK(submitted_buffer_);
++    WaylandBuffer* buffer = submitted_buffer_;
++    submitted_buffer_ = nullptr;
++
++    buffer->swapped = true;
++    DCHECK(connection_);
++    connection_->OnSubmission(window_->GetWidget(), buffer->buffer_id,
++                              gfx::SwapResult::SWAP_ACK);
++
++    // If presentation feedback is not supported, use a fake feedback. This
++    // literally means there are no presentation feedback callbacks created.
++    if (!connection_->presentation()) {
++      DCHECK(presentation_feedbacks_.empty() && !buffer->presented);
++      OnPresentation(
++          buffer->buffer_id,
++          gfx::PresentationFeedback(base::TimeTicks::Now(), base::TimeDelta(),
++                                    GetPresentationKindFlags(0)));
++    } else if (buffer->presented) {
++      // If the buffer has been presented before the frame callback aka
++      // completion callback (in the future, release callback is going to be
++      // used), present the feedback to the GPU.
++      OnPresentation(buffer->buffer_id, buffer->feedback);
++    } else {
++      DCHECK(!presentation_feedbacks_.empty());
++    }
++  }
++
++  // wl_callback_listener
++  static void FrameCallbackDone(void* data,
++                                struct wl_callback* callback,
++                                uint32_t time) {
++    Surface* self = static_cast<Surface*>(data);
++    if (self)
++      self->OnFrameCallback(callback);
++  }
++
++  void OnPresentation(uint32_t buffer_id,
++                      const gfx::PresentationFeedback& feedback) {
++    WaylandBuffer* buffer = GetBuffer(buffer_id);
++    DCHECK(buffer);
++
++    if (buffer->swapped) {
++      DCHECK(connection_);
++      connection_->OnPresentation(window_->GetWidget(), buffer_id, feedback);
++
++      buffer->swapped = false;
++      buffer->presented = false;
++    } else {
++      buffer->presented = true;
++      buffer->feedback = feedback;
++    }
++  }
++
++  // wp_presentation_feedback_listener
++  static void FeedbackSyncOutput(
++      void* data,
++      struct wp_presentation_feedback* wp_presentation_feedback,
++      struct wl_output* output) {}
++
++  static void FeedbackPresented(
++      void* data,
++      struct wp_presentation_feedback* wp_presentation_feedback,
++      uint32_t tv_sec_hi,
++      uint32_t tv_sec_lo,
++      uint32_t tv_nsec,
++      uint32_t refresh,
++      uint32_t seq_hi,
++      uint32_t seq_lo,
++      uint32_t flags) {
++    Surface* self = static_cast<Surface*>(data);
++    if (self) {
++      auto presentation = std::move(self->presentation_feedbacks_.front());
++      DCHECK(presentation.second.get() == wp_presentation_feedback);
++      self->presentation_feedbacks_.pop();
++      self->OnPresentation(
++          presentation.first,
++          gfx::PresentationFeedback(
++              GetPresentationFeedbackTimeStamp(tv_sec_hi, tv_sec_lo, tv_nsec),
++              base::TimeDelta::FromNanoseconds(refresh),
++              GetPresentationKindFlags(flags)));
++    }
++  }
++
++  static void FeedbackDiscarded(
++      void* data,
++      struct wp_presentation_feedback* wp_presentation_feedback) {
++    Surface* self = static_cast<Surface*>(data);
++    if (self) {
++      auto presentation = std::move(self->presentation_feedbacks_.front());
++      DCHECK(presentation.second.get() == wp_presentation_feedback);
++      self->presentation_feedbacks_.pop();
++      self->OnPresentation(presentation.first,
++                           gfx::PresentationFeedback::Failure());
++    }
++  }
++
++  // Widget this helper surface backs and has 1:1 relationship with the
++  // WaylandWindow.
++
++  // Non-owned. The window this helper surface stores and submits buffers for.
++  const WaylandWindow* const window_;
++
++  // Non-owned pointer to the connection.
++  WaylandConnection* const connection_;
++
++  // A buffer the surface has committed. Reset on frame callback.
++  WaylandBuffer* submitted_buffer_ = nullptr;
++
++  // A container of created buffers.
++  base::flat_map<uint32_t, std::unique_ptr<WaylandBuffer>> buffers_;
++
++  // A Wayland callback, which is triggered once wl_buffer has been committed
++  // and it is right time to notify the GPU that it can start a new drawing
++  // operation.
++  wl::Object<wl_callback> wl_frame_callback_;
++
++  // A presentation feedback provided by the Wayland server once frame is
++  // shown.
++  base::queue<std::pair<uint32_t, wl::Object<struct wp_presentation_feedback>>>
++      presentation_feedbacks_;
++
++  DISALLOW_COPY_AND_ASSIGN(Surface);
++};
++
++WaylandBufferManager::Surface::WaylandBuffer::WaylandBuffer(
++    const gfx::Size& size,
++    uint32_t buffer_id)
++    : size(size), buffer_id(buffer_id) {}
++WaylandBufferManager::Surface::WaylandBuffer::~WaylandBuffer() = default;
+ 
+ WaylandBufferManager::WaylandBufferManager(WaylandConnection* connection)
+     : connection_(connection), weak_factory_(this) {}
+ 
+ WaylandBufferManager::~WaylandBufferManager() {
+-  DCHECK(buffers_.empty());
++  DCHECK(surfaces_.empty());
+ }
+ 
+-bool WaylandBufferManager::CreateBuffer(base::File file,
+-                                        uint32_t width,
+-                                        uint32_t height,
++void WaylandBufferManager::OnWindowAdded(WaylandWindow* window) {
++  DCHECK(window);
++  surfaces_[window->GetWidget()] =
++      std::make_unique<Surface>(window, connection_);
++}
++
++void WaylandBufferManager::OnWindowRemoved(WaylandWindow* window) {
++  DCHECK(window);
++  DCHECK(surfaces_.erase(window->GetWidget()));
++}
++
++bool WaylandBufferManager::CreateBuffer(gfx::AcceleratedWidget widget,
++                                        base::File file,
++                                        const gfx::Size& size,
+                                         const std::vector<uint32_t>& strides,
+                                         const std::vector<uint32_t>& offsets,
+-                                        uint32_t format,
+                                         const std::vector<uint64_t>& modifiers,
++                                        uint32_t format,
+                                         uint32_t planes_count,
+                                         uint32_t buffer_id) {
+   TRACE_EVENT2("wayland", "WaylandBufferManager::CreateZwpLinuxDmabuf",
+                "Format", format, "Buffer id", buffer_id);
+ 
+-  if (!ValidateDataFromGpu(file, width, height, strides, offsets, format,
+-                           modifiers, planes_count, buffer_id)) {
++  if (!ValidateDataFromGpu(widget, file, size, strides, offsets, modifiers,
++                           format, planes_count, buffer_id)) {
+     // base::File::Close() has an assertion that checks if blocking operations
+     // are allowed. Thus, manually close the fd here.
+     base::ScopedFD deleter(file.TakePlatformFile());
+     return false;
+   }
+ 
+-  std::unique_ptr<Buffer> buffer =
+-      std::make_unique<Buffer>(gfx::Size(width, height), buffer_id);
+-  buffers_.insert(std::make_pair(buffer_id, std::move(buffer)));
++  WaylandBufferManager::Surface* surface = GetSurface(widget);
++  DCHECK(surface);
++
++  if (!surface->CreateBuffer(size, buffer_id)) {
++    error_message_ = "A buffer with id= " +
++                     base::UTF16ToUTF8(base::FormatNumber(buffer_id)) +
++                     " already exists";
++    return false;
++  }
+ 
++  // Create wl_buffer associated with the internal Buffer.
+   auto callback = base::BindOnce(&WaylandBufferManager::OnCreateBufferComplete,
+-                                 weak_factory_.GetWeakPtr(), buffer_id);
+-  connection_->zwp_dmabuf()->CreateBuffer(
+-      std::move(file), gfx::Size(width, height), strides, offsets, modifiers,
+-      format, planes_count, std::move(callback));
++                                 weak_factory_.GetWeakPtr(), widget, buffer_id);
++  connection_->zwp_dmabuf()->CreateBuffer(std::move(file), size, strides,
++                                          offsets, modifiers, format,
++                                          planes_count, std::move(callback));
+   return true;
+ }
+ 
+@@ -94,111 +400,76 @@ bool WaylandBufferManager::ScheduleBufferSwap(gfx::AcceleratedWidget widget,
+   if (!ValidateDataFromGpu(widget, buffer_id))
+     return false;
+ 
+-  auto it = buffers_.find(buffer_id);
+-  if (it == buffers_.end()) {
+-    error_message_ =
+-        "Buffer with " + std::to_string(buffer_id) + " id does not exist";
++  Surface* surface = GetSurface(widget);
++  if (!surface) {
++    error_message_ = "Surface does not exist";
+     return false;
+   }
+ 
+-  Buffer* buffer = it->second.get();
+-  DCHECK(buffer);
+-  DCHECK(!buffer->swapped && !buffer->presented);
+-
+-  // Assign a widget to this buffer, which is used to find a corresponding
+-  // WaylandWindow.
+-  buffer->widget = widget;
+-  buffer->damage_region = damage_region;
+-
+-  if (buffer->wl_buffer) {
+-    // A wl_buffer might not exist by this time. Silently return.
+-    // TODO: check this.
+-    return SwapBuffer(buffer);
+-  }
+-  return true;
++  return SwapBuffer(surface, buffer_id, damage_region);
+ }
+ 
+-bool WaylandBufferManager::DestroyBuffer(uint32_t buffer_id) {
++bool WaylandBufferManager::DestroyBuffer(gfx::AcceleratedWidget widget,
++                                         uint32_t buffer_id) {
+   TRACE_EVENT1("wayland", "WaylandBufferManager::DestroyZwpLinuxDmabuf",
+                "Buffer id", buffer_id);
+ 
+-  auto it = buffers_.find(buffer_id);
+-  if (it == buffers_.end()) {
+-    error_message_ = "Trying to destroy non-existing buffer";
++  Surface* surface = GetSurface(widget);
++  // On browser shutdown, the surface might have already been destroyed.
++  if (!surface)
++    return true;
++
++  if (surface->DestroyBuffer(buffer_id) != 1u) {
++    error_message_ = "Buffer with " +
++                     base::UTF16ToUTF8(base::FormatNumber(buffer_id)) +
++                     " id does not exist";
+     return false;
+   }
+ 
+-  buffers_.erase(it);
+-
+   connection_->ScheduleFlush();
+   return true;
+ }
+ 
+ void WaylandBufferManager::ClearState() {
+-  buffers_.clear();
++  for (auto& surface_pair : surfaces_)
++    surface_pair.second->ClearState();
+ }
+ 
+-// TODO(msisov): handle buffer swap failure or success.
+-bool WaylandBufferManager::SwapBuffer(Buffer* buffer) {
+-  WaylandWindow* window = connection_->GetWindow(buffer->widget);
+-  if (!window) {
+-    error_message_ = "A WaylandWindow with current widget does not exist";
+-    return false;
+-  }
++WaylandBufferManager::Surface* WaylandBufferManager::GetSurface(
++    gfx::AcceleratedWidget widget) const {
++  auto it = surfaces_.find(widget);
++  return it != surfaces_.end() ? it->second.get() : nullptr;
++}
+ 
+-  gfx::Rect damage_region = buffer->damage_region;
+-  // If the size of the damage region is empty, wl_surface_damage must be
+-  // supplied with the actual size of the buffer, which is going to be
+-  // committed.
+-  if (damage_region.size().IsEmpty())
+-    damage_region.set_size(buffer->size);
+-
+-  wl_surface_damage_buffer(window->surface(), damage_region.x(),
+-                           damage_region.y(), damage_region.width(),
+-                           damage_region.height());
+-  wl_surface_attach(window->surface(), buffer->wl_buffer.get(), 0, 0);
+-
+-  static const wl_callback_listener frame_listener = {
+-      WaylandBufferManager::FrameCallbackDone};
+-  DCHECK(!buffer->wl_frame_callback);
+-  buffer->wl_frame_callback.reset(wl_surface_frame(window->surface()));
+-  wl_callback_add_listener(buffer->wl_frame_callback.get(), &frame_listener,
+-                           this);
+-
+-  // Set up presentation feedback.
+-  static const wp_presentation_feedback_listener feedback_listener = {
+-      WaylandBufferManager::FeedbackSyncOutput,
+-      WaylandBufferManager::FeedbackPresented,
+-      WaylandBufferManager::FeedbackDiscarded};
+-  if (connection_->presentation()) {
+-    DCHECK(!buffer->wp_presentation_feedback);
+-    buffer->wp_presentation_feedback.reset(wp_presentation_feedback(
+-        connection_->presentation(), window->surface()));
+-    wp_presentation_feedback_add_listener(
+-        buffer->wp_presentation_feedback.get(), &feedback_listener, this);
++bool WaylandBufferManager::SwapBuffer(Surface* surface,
++                                      uint32_t buffer_id,
++                                      const gfx::Rect& damage_region) {
++  if (!surface->CommitBuffer(buffer_id, damage_region)) {
++    error_message_ = "Buffer with " +
++                     base::UTF16ToUTF8(base::FormatNumber(buffer_id)) +
++                     " id does not exist";
+   }
+-
+-  wl_surface_commit(window->surface());
+-
+-  connection_->ScheduleFlush();
+-  return true;
++  return error_message_.empty();
+ }
+ 
+ bool WaylandBufferManager::ValidateDataFromGpu(
++    const gfx::AcceleratedWidget& widget,
+     const base::File& file,
+-    uint32_t width,
+-    uint32_t height,
++    const gfx::Size& size,
+     const std::vector<uint32_t>& strides,
+     const std::vector<uint32_t>& offsets,
+-    uint32_t format,
+     const std::vector<uint64_t>& modifiers,
++    uint32_t format,
+     uint32_t planes_count,
+     uint32_t buffer_id) {
++  if (!ValidateDataFromGpu(widget, buffer_id))
++    return false;
++
+   std::string reason;
+   if (!file.IsValid())
+     reason = "Buffer fd is invalid";
+ 
+-  if (width == 0 || height == 0)
++  if (size.IsEmpty())
+     reason = "Buffer size is invalid";
+ 
+   if (planes_count < 1)
+@@ -221,15 +492,6 @@ bool WaylandBufferManager::ValidateDataFromGpu(
+   if (!IsValidBufferFormat(format))
+     reason = "Buffer format is invalid";
+ 
+-  if (buffer_id < 1)
+-    reason = "Invalid buffer id: " + std::to_string(buffer_id);
+-
+-  auto it = buffers_.find(buffer_id);
+-  if (it != buffers_.end()) {
+-    reason = "A buffer with " + std::to_string(buffer_id) +
+-             " id has already existed";
+-  }
+-
+   if (!reason.empty()) {
+     error_message_ = std::move(reason);
+     return false;
+@@ -241,7 +503,6 @@ bool WaylandBufferManager::ValidateDataFromGpu(
+     const gfx::AcceleratedWidget& widget,
+     uint32_t buffer_id) {
+   std::string reason;
+-
+   if (widget == gfx::kNullAcceleratedWidget)
+     reason = "Invalid accelerated widget";
+ 
+@@ -257,133 +518,15 @@ bool WaylandBufferManager::ValidateDataFromGpu(
+ }
+ 
+ void WaylandBufferManager::OnCreateBufferComplete(
++    gfx::AcceleratedWidget widget,
+     uint32_t buffer_id,
+     wl::Object<struct wl_buffer> new_buffer) {
+-  auto it = buffers_.find(buffer_id);
+-  // It can happen that buffer was destroyed by a client while the Wayland
+-  // compositor was processing a request to create a wl_buffer.
+-  if (it == buffers_.end())
++  Surface* surface = GetSurface(widget);
++  // A surface can have been destroyed if it does not have buffers left.
++  if (!surface)
+     return;
+ 
+-  Buffer* buffer = it->second.get();
+-  buffer->wl_buffer = std::move(new_buffer);
+-
+-  if (buffer->widget != gfx::kNullAcceleratedWidget)
+-    SwapBuffer(buffer);
+-}
+-
+-void WaylandBufferManager::OnSubmission(Buffer* buffer,
+-                                        const gfx::SwapResult& swap_result) {
+-  DCHECK(!buffer->swapped);
+-
+-  buffer->wl_frame_callback.reset();
+-  buffer->swapped = true;
+-  connection_->OnSubmission(buffer->widget, buffer->buffer_id,
+-                            gfx::SwapResult::SWAP_ACK);
+-
+-  // If presentation feedback is not supported, use a fake feedback.
+-  if (!connection_->presentation()) {
+-    DCHECK(!buffer->wp_presentation_feedback && !buffer->presented);
+-    OnPresentation(buffer, gfx::PresentationFeedback(base::TimeTicks::Now(),
+-                                                     base::TimeDelta(), 0));
+-  } else if (buffer->presented) {
+-    DCHECK(!buffer->wp_presentation_feedback);
+-    // If the buffer has been presented before the frame callback aka
+-    // completion callback (in the future, release callback is going to be
+-    // used), present the feedback to the GPU.
+-    OnPresentation(buffer, buffer->feedback);
+-  } else {
+-    DCHECK(buffer->wp_presentation_feedback);
+-  }
+-}
+-
+-void WaylandBufferManager::OnPresentation(
+-    Buffer* buffer,
+-    const gfx::PresentationFeedback& feedback) {
+-  buffer->presented = true;
+-  buffer->feedback = feedback;
+-
+-  // If buffer has already been swapped, we can safely notify about the
+-  // presentation as well.
+-  if (buffer->swapped) {
+-    connection_->OnPresentation(buffer->widget, buffer->buffer_id,
+-                                buffer->feedback);
+-
+-    // Reset the status so that DCHECK passes in ::ScheduleBufferSwap call.
+-    buffer->presented = false;
+-    buffer->swapped = false;
+-  }
+-}
+-
+-// static
+-void WaylandBufferManager::FrameCallbackDone(void* data,
+-                                             wl_callback* callback,
+-                                             uint32_t time) {
+-  WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+-  DCHECK(self);
+-
+-  for (auto& item : self->buffers_) {
+-    Buffer* buffer = item.second.get();
+-    if (buffer->wl_frame_callback.get() == callback) {
+-      buffer->wl_frame_callback.reset();
+-      self->OnSubmission(buffer, gfx::SwapResult::SWAP_ACK);
+-      return;
+-    }
+-  }
+-}
+-
+-// static
+-void WaylandBufferManager::FeedbackSyncOutput(
+-    void* data,
+-    struct wp_presentation_feedback* wp_presentation_feedback,
+-    struct wl_output* output) {
+-  NOTIMPLEMENTED_LOG_ONCE();
+-}
+-
+-// static
+-void WaylandBufferManager::FeedbackPresented(
+-    void* data,
+-    struct wp_presentation_feedback* wp_presentation_feedback,
+-    uint32_t tv_sec_hi,
+-    uint32_t tv_sec_lo,
+-    uint32_t tv_nsec,
+-    uint32_t refresh,
+-    uint32_t seq_hi,
+-    uint32_t seq_lo,
+-    uint32_t flags) {
+-  WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+-  DCHECK(self);
+-  for (auto& item : self->buffers_) {
+-    Buffer* buffer = item.second.get();
+-    if (buffer->wp_presentation_feedback.get() == wp_presentation_feedback) {
+-      DCHECK(!buffer->presented);
+-      buffer->wp_presentation_feedback.reset();
+-      self->OnPresentation(
+-          buffer,
+-          gfx::PresentationFeedback(
+-              GetPresentationFeedbackTimeStamp(tv_sec_hi, tv_sec_lo, tv_nsec),
+-              base::TimeDelta::FromNanoseconds(refresh),
+-              GetPresentationKindFlags(flags)));
+-      return;
+-    }
+-  }
+-}
+-
+-// static
+-void WaylandBufferManager::FeedbackDiscarded(
+-    void* data,
+-    struct wp_presentation_feedback* wp_presentation_feedback) {
+-  WaylandBufferManager* self = static_cast<WaylandBufferManager*>(data);
+-  DCHECK(self);
+-  for (auto& item : self->buffers_) {
+-    Buffer* buffer = item.second.get();
+-    if (buffer->wp_presentation_feedback.get() == wp_presentation_feedback) {
+-      DCHECK(!buffer->presented);
+-      buffer->wp_presentation_feedback.reset();
+-      self->OnPresentation(buffer, gfx::PresentationFeedback::Failure());
+-      return;
+-    }
+-  }
++  surface->AttachWlBuffer(buffer_id, std::move(new_buffer));
+ }
+ 
+ }  // namespace ui
+diff --git a/ui/ozone/platform/wayland/host/wayland_buffer_manager.h b/ui/ozone/platform/wayland/host/wayland_buffer_manager.h
+index f4b0183cc3a1..eac05d955416 100644
+--- a/ui/ozone/platform/wayland/host/wayland_buffer_manager.h
++++ b/ui/ozone/platform/wayland/host/wayland_buffer_manager.h
+@@ -19,14 +19,14 @@
+ #include "ui/ozone/platform/wayland/common/wayland_object.h"
+ #include "ui/ozone/platform/wayland/common/wayland_util.h"
+ 
+-struct wp_presentation_feedback;
+-
+ namespace ui {
+ 
+ class WaylandConnection;
++class WaylandWindow;
+ 
+ // The manager uses zwp_linux_dmabuf protocol to create wl_buffers from added
+-// dmabuf buffers. Only used when GPU runs in own process.
++// dmabuf buffers, and uses internal representation of surfaces, which store
++// buffers associated with the WaylandWindow.
+ class WaylandBufferManager {
+  public:
+   explicit WaylandBufferManager(WaylandConnection* connection);
+@@ -34,15 +34,18 @@ class WaylandBufferManager {
+ 
+   std::string error_message() { return std::move(error_message_); }
+ 
++  void OnWindowAdded(WaylandWindow* window);
++  void OnWindowRemoved(WaylandWindow* window);
++
+   // Creates a wl_buffer based on the dmabuf |file| descriptor. On error, false
+   // is returned and |error_message_| is set.
+-  bool CreateBuffer(base::File file,
+-                    uint32_t width,
+-                    uint32_t height,
++  bool CreateBuffer(gfx::AcceleratedWidget widget,
++                    base::File file,
++                    const gfx::Size& size,
+                     const std::vector<uint32_t>& strides,
+                     const std::vector<uint32_t>& offsets,
+-                    uint32_t format,
+                     const std::vector<uint64_t>& modifiers,
++                    uint32_t format,
+                     uint32_t planes_count,
+                     uint32_t buffer_id);
+ 
+@@ -59,72 +62,32 @@ class WaylandBufferManager {
+ 
+   // Destroys a buffer with |buffer_id| in |buffers_|. On error, false is
+   // returned and |error_message_| is set.
+-  bool DestroyBuffer(uint32_t buffer_id);
++  bool DestroyBuffer(gfx::AcceleratedWidget widget, uint32_t buffer_id);
+ 
+   // Destroys all the data and buffers stored in own containers.
+   void ClearState();
+ 
+  private:
+-  // This is an internal helper representation of a wayland buffer object, which
+-  // the GPU process creates when CreateBuffer is called. It's used for
+-  // asynchronous buffer creation and stores |params| parameter to find out,
+-  // which Buffer the wl_buffer corresponds to when CreateSucceeded is called.
+-  // What is more, the Buffer stores such information as a widget it is attached
+-  // to, its buffer id for simplier buffer management and other members specific
+-  // to this Buffer object on run-time.
+-  struct Buffer {
+-    Buffer() = delete;
+-    Buffer(const gfx::Size& buffer_size, uint32_t buffer_id);
+-    ~Buffer();
+-
+-    // Actual buffer size.
+-    const gfx::Size size;
+-
+-    // The id of the buffer.
+-    const uint32_t buffer_id;
+-
+-    // Widget to attached/being attach WaylandWindow.
+-    gfx::AcceleratedWidget widget = gfx::kNullAcceleratedWidget;
+-
+-    // Describes the region where the pending buffer is different from the
+-    // current surface contents, and where the surface therefore needs to be
+-    // repainted.
+-    gfx::Rect damage_region;
++  // This is an internal representation of a real surface, which holds a pointer
++  // to WaylandWindow. Also, this object holds buffers, frame callbacks and
++  // presentation callbacks for that window's surface.
++  class Surface;
+ 
+-    // A feedback, which is received if a presentation feedback protocol is
+-    // supported.
+-    gfx::PresentationFeedback feedback;
++  Surface* GetSurface(gfx::AcceleratedWidget widget) const;
+ 
+-    // A wl_buffer backed by a dmabuf created on the GPU side.
+-    wl::Object<struct wl_buffer> wl_buffer;
+-
+-    // Provide the status of this buffer. Reset on each new swap.
+-    bool swapped = false;
+-    bool presented = false;
+-
+-    // A Wayland callback, which is triggered once wl_buffer has been committed
+-    // and it is right time to notify the GPU that it can start a new drawing
+-    // operation.
+-    wl::Object<wl_callback> wl_frame_callback;
+-
+-    // A presentation feedback provided by the Wayland server once frame is
+-    // shown.
+-    wl::Object<struct wp_presentation_feedback> wp_presentation_feedback;
+-
+-    DISALLOW_COPY_AND_ASSIGN(Buffer);
+-  };
+-
+-  bool SwapBuffer(Buffer* buffer);
++  bool SwapBuffer(Surface* surface,
++                  uint32_t buffer_id,
++                  const gfx::Rect& damage_region);
+ 
+   // Validates data sent from GPU. If invalid, returns false and sets an error
+   // message to |error_message_|.
+-  bool ValidateDataFromGpu(const base::File& file,
+-                           uint32_t width,
+-                           uint32_t height,
++  bool ValidateDataFromGpu(const gfx::AcceleratedWidget& widget,
++                           const base::File& file,
++                           const gfx::Size& size,
+                            const std::vector<uint32_t>& strides,
+                            const std::vector<uint32_t>& offsets,
+-                           uint32_t format,
+                            const std::vector<uint64_t>& modifiers,
++                           uint32_t format,
+                            uint32_t planes_count,
+                            uint32_t buffer_id);
+   bool ValidateDataFromGpu(const gfx::AcceleratedWidget& widget,
+@@ -132,39 +95,11 @@ class WaylandBufferManager {
+ 
+   // Callback method. Receives a result for the request to create a wl_buffer
+   // backend by dmabuf file descriptor from ::CreateBuffer call.
+-  void OnCreateBufferComplete(uint32_t buffer_id,
++  void OnCreateBufferComplete(gfx::AcceleratedWidget widget,
++                              uint32_t buffer_id,
+                               wl::Object<struct wl_buffer> new_buffer);
+ 
+-  void OnSubmission(Buffer* buffer, const gfx::SwapResult& swap_result);
+-  void OnPresentation(Buffer* buffer,
+-                      const gfx::PresentationFeedback& feedback);
+-
+-  // wl_callback_listener
+-  static void FrameCallbackDone(void* data,
+-                                wl_callback* callback,
+-                                uint32_t time);
+-
+-  // wp_presentation_feedback_listener
+-  static void FeedbackSyncOutput(
+-      void* data,
+-      struct wp_presentation_feedback* wp_presentation_feedback,
+-      struct wl_output* output);
+-  static void FeedbackPresented(
+-      void* data,
+-      struct wp_presentation_feedback* wp_presentation_feedback,
+-      uint32_t tv_sec_hi,
+-      uint32_t tv_sec_lo,
+-      uint32_t tv_nsec,
+-      uint32_t refresh,
+-      uint32_t seq_hi,
+-      uint32_t seq_lo,
+-      uint32_t flags);
+-  static void FeedbackDiscarded(
+-      void* data,
+-      struct wp_presentation_feedback* wp_presentation_feedback);
+-
+-  // A container of created buffers.
+-  base::flat_map<uint32_t, std::unique_ptr<Buffer>> buffers_;
++  base::flat_map<gfx::AcceleratedWidget, std::unique_ptr<Surface>> surfaces_;
+ 
+   // Set when invalid data is received from the GPU process.
+   std::string error_message_;
+diff --git a/ui/ozone/platform/wayland/host/wayland_connection.cc b/ui/ozone/platform/wayland/host/wayland_connection.cc
+index 7604e9abd4a4..010f7a75d23d 100644
+--- a/ui/ozone/platform/wayland/host/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/host/wayland_connection.cc
+@@ -159,12 +159,19 @@ WaylandWindow* WaylandConnection::GetCurrentKeyboardFocusedWindow() const {
+ 
+ void WaylandConnection::AddWindow(gfx::AcceleratedWidget widget,
+                                   WaylandWindow* window) {
++  DCHECK(buffer_manager_);
++  buffer_manager_->OnWindowAdded(window);
++
+   window_map_[widget] = window;
+ }
+ 
+ void WaylandConnection::RemoveWindow(gfx::AcceleratedWidget widget) {
+   if (touch_)
+     touch_->RemoveTouchPoints(window_map_[widget]);
++
++  DCHECK(buffer_manager_);
++  buffer_manager_->OnWindowRemoved(window_map_[widget]);
++
+   window_map_.erase(widget);
+ }
+ 
+@@ -188,30 +195,31 @@ void WaylandConnection::SetWaylandConnectionClient(
+ }
+ 
+ void WaylandConnection::CreateZwpLinuxDmabuf(
++    gfx::AcceleratedWidget widget,
+     base::File file,
+-    uint32_t width,
+-    uint32_t height,
++    const gfx::Size& size,
+     const std::vector<uint32_t>& strides,
+     const std::vector<uint32_t>& offsets,
+-    uint32_t format,
+     const std::vector<uint64_t>& modifiers,
++    uint32_t format,
+     uint32_t planes_count,
+     uint32_t buffer_id) {
+   DCHECK(base::MessageLoopCurrentForUI::IsSet());
+ 
+   DCHECK(buffer_manager_);
+-  if (!buffer_manager_->CreateBuffer(std::move(file), width, height, strides,
+-                                     offsets, format, modifiers, planes_count,
++  if (!buffer_manager_->CreateBuffer(widget, std::move(file), size, strides,
++                                     offsets, modifiers, format, planes_count,
+                                      buffer_id)) {
+     TerminateGpuProcess(buffer_manager_->error_message());
+   }
+ }
+ 
+-void WaylandConnection::DestroyZwpLinuxDmabuf(uint32_t buffer_id) {
++void WaylandConnection::DestroyZwpLinuxDmabuf(gfx::AcceleratedWidget widget,
++                                              uint32_t buffer_id) {
+   DCHECK(base::MessageLoopCurrentForUI::IsSet());
+ 
+   DCHECK(buffer_manager_);
+-  if (!buffer_manager_->DestroyBuffer(buffer_id)) {
++  if (!buffer_manager_->DestroyBuffer(widget, buffer_id)) {
+     TerminateGpuProcess(buffer_manager_->error_message());
+   }
+ }
+diff --git a/ui/ozone/platform/wayland/host/wayland_connection.h b/ui/ozone/platform/wayland/host/wayland_connection.h
+index 2edbdb7e403d..5ffc6191599c 100644
+--- a/ui/ozone/platform/wayland/host/wayland_connection.h
++++ b/ui/ozone/platform/wayland/host/wayland_connection.h
+@@ -57,17 +57,18 @@ class WaylandConnection : public PlatformEventSource,
+   //
+   // Called by the GPU and asks to import a wl_buffer based on a gbm file
+   // descriptor.
+-  void CreateZwpLinuxDmabuf(base::File file,
+-                            uint32_t width,
+-                            uint32_t height,
++  void CreateZwpLinuxDmabuf(gfx::AcceleratedWidget widget,
++                            base::File file,
++                            const gfx::Size& size,
+                             const std::vector<uint32_t>& strides,
+                             const std::vector<uint32_t>& offsets,
+-                            uint32_t format,
+                             const std::vector<uint64_t>& modifiers,
++                            uint32_t format,
+                             uint32_t planes_count,
+                             uint32_t buffer_id) override;
+   // Called by the GPU to destroy the imported wl_buffer with a |buffer_id|.
+-  void DestroyZwpLinuxDmabuf(uint32_t buffer_id) override;
++  void DestroyZwpLinuxDmabuf(gfx::AcceleratedWidget widget,
++                             uint32_t buffer_id) override;
+   // Called by the GPU and asks to attach a wl_buffer with a |buffer_id| to a
+   // WaylandWindow with the specified |widget|.
+   // Calls OnSubmission and OnPresentation on successful swap and pixels
+diff --git a/ui/ozone/public/interfaces/wayland/wayland_connection.mojom b/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
+index 713ac9a210e7..8272883d7190 100644
+--- a/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
++++ b/ui/ozone/public/interfaces/wayland/wayland_connection.mojom
+@@ -19,21 +19,36 @@ interface WaylandConnection {
+ 
+   // Methods used for hardware accelerated rendering:
+   //
+-  // Asks Wayland to create a wl_buffer based on the dmabuf |file| descriptor.
+-  CreateZwpLinuxDmabuf(mojo_base.mojom.File file,
+-                            uint32 width,
+-                            uint32 height,
+-                            array<uint32> strides,
+-                            array<uint32> offsets,
+-                            uint32 format,
+-                            array<uint64> modifiers,
+-                            uint32 planes_count,
+-                            uint32 buffer_id);
++  // Asks Wayland to create a wl_buffer based on the dmabuf |file| descriptor
++  // for the WaylandWindow, which has the following |widget|. The |size|
++  // is the size of the buffer, the |strides|, |offsets| and |modifiers|
++  // are the descriptions of the drm buffer object. The |format| describes
++  // the buffer format (check gfx::BufferFormat) in fourcc form. The
++  // |planes_count| says how many planes the buffer, backed by the |file|
++  // descriptor has. And the |buffer_id| is a unique id for the buffer, which
++  // is used to identify imported wl_buffers on the browser process side and
++  // map them with the buffer objects on the gpu process side.
++  CreateZwpLinuxDmabuf(gfx.mojom.AcceleratedWidget widget,
++                       mojo_base.mojom.File file,
++                       gfx.mojom.Size size,
++                       array<uint32> strides,
++                       array<uint32> offsets,
++                       array<uint64> modifiers,
++                       uint32 format,
++                       uint32 planes_count,
++                       uint32 buffer_id);
+ 
+-  // Destroys a wl_buffer created by WaylandConnection based on the |buffer_id|.
+-  DestroyZwpLinuxDmabuf(uint32 buffer_id);
++  // Destroys a wl_buffer created by WaylandConnection based on the |buffer_id|
++  // for the WaylandWindow, which has the following |widget|. The |buffer_id|
++  // is the unique id of the buffer objects being destroyed on the browser
++  // process side.
++  DestroyZwpLinuxDmabuf(gfx.mojom.AcceleratedWidget widget, uint32 buffer_id);
+ 
+   // Swaps wl_buffers for a WaylandWindow with the following |widget|.
++  // The |damage_region| describes changed the region of the buffer.
++  // The |buffer_id| is a unique id for the buffer, which is used to
++  // identify imported wl_buffers on the browser process side mapped with
++  // the ones on the gpu process.
+   ScheduleBufferSwap(gfx.mojom.AcceleratedWidget widget, uint32 buffer_id,
+                      gfx.mojom.Rect damage_region);
+ 
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0010-ozone-wayland-Don-t-wait-for-frame-callback-after-su.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0010-ozone-wayland-Don-t-wait-for-frame-callback-after-su.patch
@@ -1,0 +1,184 @@
+Upstream-Status: Submitted [https://crrev.com/c/1570028]
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 3d025ab1f3524308d13d2be918c16c6c8dc58b24 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Wed, 17 Apr 2019 11:59:46 +0300
+Subject: [PATCH 10/11] [ozone/wayland] Don't wait for frame callback after
+ submission
+
+Right now, the surface waits until the frame callback is fired,
+which results in undesired wait when the display compositor
+can submit new frame (the AsyncSwapBuffers takes about ~10ms).
+
+Instead, notify the client on successfull submission
+right after the buffer is attached, but as soon as
+a new frame comes, do not submit it, but rather wait
+the frame callback.
+
+The advantage of this approach is that the browser process
+does not block the display compositor's scheduler and allows
+it to operate as fast as possible (the AsyncSwapBuffers
+takes about ~0.6-1ms).
+
+Bug: 943096
+Change-Id: I808896350a8cd33b87e956b0cec51d8fa0ff1cdb
+---
+ .../wayland/host/wayland_buffer_manager.cc    | 79 ++++++-------------
+ 1 file changed, 22 insertions(+), 57 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc b/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
+index 99877e12bbc1..24ef255b06aa 100644
+--- a/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
++++ b/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
+@@ -50,8 +50,6 @@ class WaylandBufferManager::Surface {
+   ~Surface() = default;
+ 
+   bool CommitBuffer(uint32_t buffer_id, const gfx::Rect& damage_region) {
+-    DCHECK(!submitted_buffer_);
+-
+     WaylandBuffer* buffer = GetBuffer(buffer_id);
+     if (!buffer)
+       return false;
+@@ -63,7 +61,11 @@ class WaylandBufferManager::Surface {
+     // zwp linux dmabuf protocol version, the wl_buffer can be created
+     // immediately without asynchronous wait 2) the wl_buffer can have been
+     // created by this time.
+-    while (!buffer->wl_buffer) {
++    //
++    // Another case, which always happen is waiting until the frame callback is
++    // completed. Thus, wait here when the Wayland compositor fires the frame
++    // callback.
++    while (!buffer->wl_buffer || !!wl_frame_callback_) {
+       if (wl_display_dispatch(connection_->display()) == -1)
+         return false;
+     }
+@@ -76,6 +78,8 @@ class WaylandBufferManager::Surface {
+     CommitSurface();
+ 
+     connection_->ScheduleFlush();
++
++    OnSubmission(buffer_id);
+     return true;
+   }
+ 
+@@ -86,8 +90,6 @@ class WaylandBufferManager::Surface {
+   }
+ 
+   size_t DestroyBuffer(uint32_t buffer_id) {
+-    if (submitted_buffer_ && submitted_buffer_->buffer_id == buffer_id)
+-      submitted_buffer_ = nullptr;
+     auto result = buffers_.erase(buffer_id);
+     return result;
+   }
+@@ -134,11 +136,6 @@ class WaylandBufferManager::Surface {
+     // A wl_buffer backed by a dmabuf created on the GPU side.
+     wl::Object<struct wl_buffer> wl_buffer;
+ 
+-    gfx::PresentationFeedback feedback;
+-
+-    bool swapped = false;
+-    bool presented = false;
+-
+     DISALLOW_COPY_AND_ASSIGN(WaylandBuffer);
+   };
+ 
+@@ -157,8 +154,6 @@ class WaylandBufferManager::Surface {
+         surface, pending_damage_region.x(), pending_damage_region.y(),
+         pending_damage_region.width(), pending_damage_region.height());
+     wl_surface_attach(surface, buffer->wl_buffer.get(), 0, 0);
+-
+-    submitted_buffer_ = buffer;
+   }
+ 
+   void CommitSurface() { wl_surface_commit(window_->surface()); }
+@@ -197,38 +192,6 @@ class WaylandBufferManager::Surface {
+   void OnFrameCallback(struct wl_callback* callback) {
+     DCHECK(wl_frame_callback_.get() == callback);
+     wl_frame_callback_.reset();
+-
+-    if (!submitted_buffer_)
+-      return;
+-
+-    // TODO(msisov): remove these once pending buffers logic goes to the
+-    // manager as long as it will always notify about successful swap once the
+-    // surface is committed.
+-    DCHECK(submitted_buffer_);
+-    WaylandBuffer* buffer = submitted_buffer_;
+-    submitted_buffer_ = nullptr;
+-
+-    buffer->swapped = true;
+-    DCHECK(connection_);
+-    connection_->OnSubmission(window_->GetWidget(), buffer->buffer_id,
+-                              gfx::SwapResult::SWAP_ACK);
+-
+-    // If presentation feedback is not supported, use a fake feedback. This
+-    // literally means there are no presentation feedback callbacks created.
+-    if (!connection_->presentation()) {
+-      DCHECK(presentation_feedbacks_.empty() && !buffer->presented);
+-      OnPresentation(
+-          buffer->buffer_id,
+-          gfx::PresentationFeedback(base::TimeTicks::Now(), base::TimeDelta(),
+-                                    GetPresentationKindFlags(0)));
+-    } else if (buffer->presented) {
+-      // If the buffer has been presented before the frame callback aka
+-      // completion callback (in the future, release callback is going to be
+-      // used), present the feedback to the GPU.
+-      OnPresentation(buffer->buffer_id, buffer->feedback);
+-    } else {
+-      DCHECK(!presentation_feedbacks_.empty());
+-    }
+   }
+ 
+   // wl_callback_listener
+@@ -240,21 +203,26 @@ class WaylandBufferManager::Surface {
+       self->OnFrameCallback(callback);
+   }
+ 
++  void OnSubmission(uint32_t buffer_id) {
++    connection_->OnSubmission(window_->GetWidget(), buffer_id,
++                              gfx::SwapResult::SWAP_ACK);
++
++    // If presentation feedback is not supported, use a fake feedback. This
++    // literally means there are no presentation feedback callbacks created.
++    if (!connection_->presentation()) {
++      DCHECK(presentation_feedbacks_.empty());
++      OnPresentation(buffer_id, gfx::PresentationFeedback(
++                                    base::TimeTicks::Now(), base::TimeDelta(),
++                                    GetPresentationKindFlags(0)));
++    }
++  }
++
+   void OnPresentation(uint32_t buffer_id,
+                       const gfx::PresentationFeedback& feedback) {
+     WaylandBuffer* buffer = GetBuffer(buffer_id);
+     DCHECK(buffer);
+ 
+-    if (buffer->swapped) {
+-      DCHECK(connection_);
+-      connection_->OnPresentation(window_->GetWidget(), buffer_id, feedback);
+-
+-      buffer->swapped = false;
+-      buffer->presented = false;
+-    } else {
+-      buffer->presented = true;
+-      buffer->feedback = feedback;
+-    }
++    connection_->OnPresentation(window_->GetWidget(), buffer_id, feedback);
+   }
+ 
+   // wp_presentation_feedback_listener
+@@ -309,9 +277,6 @@ class WaylandBufferManager::Surface {
+   // Non-owned pointer to the connection.
+   WaylandConnection* const connection_;
+ 
+-  // A buffer the surface has committed. Reset on frame callback.
+-  WaylandBuffer* submitted_buffer_ = nullptr;
+-
+   // A container of created buffers.
+   base::flat_map<uint32_t, std::unique_ptr<WaylandBuffer>> buffers_;
+ 
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0011-ozone-wayland-Fix-presentation-feedback-flags.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0011-ozone-wayland-Fix-presentation-feedback-flags.patch
@@ -1,0 +1,60 @@
+Upstream-Status: Submitted [https://crrev.com/c/1571655]
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 30d5ed8585e62707f2cc38c2bef739c195cbca40 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Thu, 18 Apr 2019 11:48:58 +0300
+Subject: [PATCH 11/11] [ozone/wayland] Fix presentation feedback flags.
+
+Wayland VSync is different from what Chromium expects.
+
+In Chromium, VSync means that the timestamp and the interval
+must be taken into the account to update scheduling of the next frames.
+
+Also, some compositors do not provide presentation flags. Thus,
+make an assumption they are HWClock and HWCompletion.
+
+Bug: 954087
+Change-Id: I7c441e3fa7d1b9c4fbc3d7835bd99302a93b3a61
+---
+ .../wayland/host/wayland_buffer_manager.cc       | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc b/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
+index 24ef255b06aa..db3197ceef6b 100644
+--- a/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
++++ b/ui/ozone/platform/wayland/host/wayland_buffer_manager.cc
+@@ -20,8 +20,9 @@ namespace {
+ 
+ uint32_t GetPresentationKindFlags(uint32_t flags) {
+   uint32_t presentation_flags = 0;
+-  if (flags & WP_PRESENTATION_FEEDBACK_KIND_VSYNC)
+-    presentation_flags |= gfx::PresentationFeedback::kVSync;
++  // Wayland spec has different meaning of VSync. In Chromium, VSync means to
++  // update the begin frame vsync timing based on presentation feedback.
++  presentation_flags |= gfx::PresentationFeedback::kVSync;
+   if (flags & WP_PRESENTATION_FEEDBACK_KIND_HW_CLOCK)
+     presentation_flags |= gfx::PresentationFeedback::kHWClock;
+   if (flags & WP_PRESENTATION_FEEDBACK_KIND_HW_COMPLETION)
+@@ -246,6 +247,17 @@ class WaylandBufferManager::Surface {
+       auto presentation = std::move(self->presentation_feedbacks_.front());
+       DCHECK(presentation.second.get() == wp_presentation_feedback);
+       self->presentation_feedbacks_.pop();
++
++      // Workaround: some compositors do not provide presentation flags. Thus,
++      // manually fix it.
++      if (!flags) {
++        // The display hardware provided measurements that the hardware driver
++        // converted into a presentation timestamp.
++        flags |= WP_PRESENTATION_FEEDBACK_KIND_HW_CLOCK;
++        // The buffer has been presented on the screen.
++        flags |= WP_PRESENTATION_FEEDBACK_KIND_HW_COMPLETION;
++      }
++
+       self->OnPresentation(
+           presentation.first,
+           gfx::PresentationFeedback(
+-- 
+2.17.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland_73.0.3683.103.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_73.0.3683.103.bb
@@ -45,6 +45,17 @@ SRC_URI += " \
         file://0040-ozone-wayland-Support-NumLock-in-non-chromeos-builds.patch \
         file://0041-ozone-xkbcommon-Pre-compute-masks-when-setting-keyma.patch \
         file://0042-ozone-wayland-Use-opaque-region-for-opaque-windows.patch \
+        file://0001-ozone-wayland-Add-const-keyword-to-getters.patch \
+        file://0002-ozone-wayland-Clean-up-data-device-related-code.patch \
+        file://0003-ozone-Allow-running-presentation-feedback-any-time-a.patch \
+        file://0004-ozone-wayland-Factor-out-zwp-linux-dmabuf-from-the-m.patch \
+        file://0005-ozone-wayland-Handle-viz-process-restart.patch \
+        file://0006-ozone-wayland-Move-the-host-gpu-common-and-test-code.patch \
+        file://0007-Change-the-order-when-the-opaque-region-is-updated.patch \
+        file://0008-Separate-swap-buffer-and-presentation-callbacks.patch \
+        file://0009-Ease-the-buffer-swap-and-maintenance.patch \
+        file://0010-ozone-wayland-Don-t-wait-for-frame-callback-after-su.patch \
+        file://0011-ozone-wayland-Fix-presentation-feedback-flags.patch \
 "
 
 # Chromium can use v4l2 device for hardware accelerated video decoding. Make sure that
@@ -65,6 +76,4 @@ GN_ARGS += "\
 "
 
 # The chromium binary must always be started with those arguments.
-# The VizDisplayCompositor is temporarely disabled.
-# See https://crbug.com/c/943096
-CHROMIUM_EXTRA_ARGS_append = " --disable-features=VizDisplayCompositor --ozone-platform=wayland"
+CHROMIUM_EXTRA_ARGS_append = " --ozone-platform=wayland"


### PR DESCRIPTION
This commit includes fixes for the performance regression and
enables the VizDisplayCompositor back.

The fix is to reduce the time spend on swap. On Rpi3 the total
swap time dropped from ~35 ms to ~13ms, which resulted in
stable FPS rate and no significant FPS drops.

Signed-off-by: Maksim Sisov <msisov@igalia.com>