### PR TITLE
chromium-ozone-wayland: Stop depending on the system's wayland-scanner binary

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland_73.0.3683.103.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_73.0.3683.103.bb
@@ -58,6 +58,15 @@ SRC_URI += " \
         file://0011-ozone-wayland-Fix-presentation-feedback-flags.patch \
 "
 
+REQUIRED_DISTRO_FEATURES = "wayland"
+
+DEPENDS += "\
+        libxkbcommon \
+        virtual/egl \
+        wayland \
+        wayland-native \
+"
+
 # Chromium can use v4l2 device for hardware accelerated video decoding. Make sure that
 # /dev/video-dec exists.
 PACKAGECONFIG[use-linux-v4l2] = "use_v4l2_codec=true use_v4lplugin=true use_linux_v4l2_only=true"
@@ -69,6 +78,7 @@ GN_ARGS += "\
         ozone_platform_headless=true \
         ozone_platform_wayland=true \
         ozone_platform_x11=false \
+        system_wayland_scanner_path="${STAGING_BINDIR_NATIVE}/wayland-scanner" \
         use_xkbcommon=true \
         use_system_libwayland=true \
         use_system_minigbm=true \


### PR DESCRIPTION
So far, we were using Chromium's default GN path for the system
wayland-scanner binary, "/usr/bin/wayland-scanner", which may not be present
at all and which should never be used anyway. Instead, we now point to the
version built by the wayland-native recipe.

Doing so of course requires depending on wayland-native in the first place,
and that requires adding back REQUIRED_DISTRO_FEATURES and a DEPENDS block
that got removed with no explanation when the recipe was updated to
M72 (commit 97876fab, "chromium: Update to 72.0.3626.81").

Fixes #241