### PR TITLE
chromium: Fix arm64 build.

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -24,6 +24,7 @@ SRC_URI += " \
         file://0005-Remove-banned-designated-initializer-list-usage-from.patch \
         file://0006-GCC-add-std-move-to-return-to-base-Optional.patch \
         file://0001-GCC-fix-another-GCC-bug-by-implementing-copy-assign-.patch \
+        file://0001-crc32c-Re-enable-crc-and-crypto-extensions-to-arm64-.patch \
 "
 
 SRC_URI_append_libc-musl = "\

--- a/recipes-browser/chromium/files/0001-crc32c-Re-enable-crc-and-crypto-extensions-to-arm64-.patch
+++ b/recipes-browser/chromium/files/0001-crc32c-Re-enable-crc-and-crypto-extensions-to-arm64-.patch
@@ -1,0 +1,47 @@
+Upstream-Status: Backport
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 83a6f36f0e316a318ce1e9281114da779646b602 Mon Sep 17 00:00:00 2001
+From: Jose Dapena Paz <jose.dapena@lge.com>
+Date: Fri, 5 Apr 2019 18:47:56 +0000
+Subject: [PATCH] crc32c: Re-enable crc and crypto extensions to arm64 crc32c
+ build.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The commit https://crrev.com/c/1492489 introduces a regression on
+GCC build, as GCC will not enable the aarch64 feature modifiers
+crc and crypto anymore.
+
+This change keeps clang implementation using the target feature
+extensions, but keeps the old implementation for GCC.
+
+Bug: 819294
+
+Change-Id: I343ba9587e0356ecdab2ed95513d6d58feb5e75e
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1553319
+Commit-Queue: José Dapena Paz <jose.dapena@lge.com>
+Reviewed-by: Victor Costan <pwnall@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#648273}
+---
+ third_party/crc32c/BUILD.gn | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/third_party/crc32c/BUILD.gn b/third_party/crc32c/BUILD.gn
+index 963a3c08cbf3..db9f98dfcad5 100644
+--- a/third_party/crc32c/BUILD.gn
++++ b/third_party/crc32c/BUILD.gn
+@@ -129,6 +129,8 @@ source_set("crc32c_arm64") {
+         "-Xclang",
+         "+crypto",
+       ]
++    } else {
++      cflags = [ "-march=armv8-a+crc+crypto" ]
+     }
+   }
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
Currently, it fails when compiling on arm64 due to disabled crc
and crypto extensions.