### PR TITLE
chromium-ozone-wayland: Fix usage without zwp_linux_dmabuf and NGMB.

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland/0001-ozone-wayland-Do-not-add-window-if-manager-does-not-.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0001-ozone-wayland-Do-not-add-window-if-manager-does-not-.patch
@@ -1,0 +1,60 @@
+Upstream-Status: Backport
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 5b70aa27f495667f8c436242f4197c1e5645ac68 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Tue, 14 May 2019 06:50:15 +0000
+Subject: [PATCH] [ozone/wayland] Do not add window if manager does not exist
+
+It may happen that the zwp linux dmabuf protocol is not available.
+In this case, we have already been resetting the gbm device and
+make the gpu use wl_egl instead, but the WaylandConnection still
+has been trying to add a window to the WaylandBufferManager upon
+creation. However, as previously said, the manager may not exist
+because the zwp linux dmabuf had not been advertised as supported
+protocol.
+
+Without this patch, it just crashes.
+
+Bug: 578890
+Change-Id: I15bcd7ae968590d358a4590d79a54067de02e8d6
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1609822
+Reviewed-by: Michael Spang <spang@chromium.org>
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#659405}
+---
+ ui/ozone/platform/wayland/host/wayland_connection.cc | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/host/wayland_connection.cc b/ui/ozone/platform/wayland/host/wayland_connection.cc
+index 8bb0844d8d6a..9d3fe04c3c61 100644
+--- a/ui/ozone/platform/wayland/host/wayland_connection.cc
++++ b/ui/ozone/platform/wayland/host/wayland_connection.cc
+@@ -160,8 +160,10 @@ WaylandWindow* WaylandConnection::GetCurrentKeyboardFocusedWindow() const {
+ 
+ void WaylandConnection::AddWindow(gfx::AcceleratedWidget widget,
+                                   WaylandWindow* window) {
+-  DCHECK(buffer_manager_);
+-  buffer_manager_->OnWindowAdded(window);
++  if (buffer_manager_) {
++    DCHECK(zwp_dmabuf_);
++    buffer_manager_->OnWindowAdded(window);
++  }
+ 
+   window_map_[widget] = window;
+ }
+@@ -170,8 +172,8 @@ void WaylandConnection::RemoveWindow(gfx::AcceleratedWidget widget) {
+   if (touch_)
+     touch_->RemoveTouchPoints(window_map_[widget]);
+ 
+-  DCHECK(buffer_manager_);
+-  buffer_manager_->OnWindowRemoved(window_map_[widget]);
++  if (buffer_manager_)
++    buffer_manager_->OnWindowRemoved(window_map_[widget]);
+ 
+   window_map_.erase(widget);
+ }
+-- 
+2.20.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland/0001-ozone-wayland-Fix-NativeGpuMemoryBuffers-usage.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0001-ozone-wayland-Fix-NativeGpuMemoryBuffers-usage.patch
@@ -1,0 +1,66 @@
+Upstream-Status: Submitted [https://crrev.com/c/1609781]
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 496c6dee4195bffe2a7ed607782117a60a198813 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Mon, 13 May 2019 16:31:06 +0300
+Subject: [PATCH] [ozone/wayland] Fix NativeGpuMemoryBuffers usage.
+
+After https://crrev.com/c/1570014, Chromium started to
+crash immediately because of null accelerated widget provided
+to the WaylandBufferManager and hitting data validation
+error when --enable-native-gpu-memory-buffer with
+the --enable-gpu-rasterization passed.
+
+The problem was that the raster buffer provided can
+create a staging buffer for rasterization, which is not
+tight to any of the existing widgets. Thus, it seems like
+it just passes a null widget [1][2].
+
+But, when the GbmPixmapWayland was created and the dmabuf handle
+was passed to the WaylandBufferManager to import a wl_buffer,
+it crashed on the data validation, because the widget was null.
+
+Thus, when a null widget is passed, just create a native pixmap
+and do not call the WaylandBufferManager with a request to import
+a wl_buffer as long as they can also be used as staging buffers
+and not meant for attaching to Wayland surfaces.
+
+[1] https://cs.chromium.org/chromium/src/cc/raster/one_copy_raster_buffer_provider.cc?type=cs&g=0&l=296
+[2] https://cs.chromium.org/chromium/src/cc/raster/zero_copy_raster_buffer_provider.cc?type=cs&g=0&l=125
+
+Bug: 962466
+Change-Id: Ied6fd6d3e29fdd21939c8b159682537f9239ab84
+---
+ ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+index e7aeb029dbb6..5899a352343b 100644
+--- a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
++++ b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+@@ -35,7 +35,7 @@ GbmPixmapWayland::GbmPixmapWayland(WaylandSurfaceFactory* surface_manager,
+       widget_(widget) {}
+ 
+ GbmPixmapWayland::~GbmPixmapWayland() {
+-  if (gbm_bo_)
++  if (gbm_bo_ && widget_ != gfx::kNullAcceleratedWidget)
+     connection_->DestroyZwpLinuxDmabuf(widget_, GetUniqueId());
+ }
+ 
+@@ -81,7 +81,10 @@ bool GbmPixmapWayland::InitializeBuffer(gfx::Size size,
+     return false;
+   }
+ 
+-  CreateZwpLinuxDmabuf();
++  // The pixmap can be created as a staging buffer and not be mapped to any of
++  // the existing widgets.
++  if (widget_ != gfx::kNullAcceleratedWidget)
++    CreateZwpLinuxDmabuf();
+   return true;
+ }
+ 
+-- 
+2.20.1
+

--- a/recipes-browser/chromium/chromium-ozone-wayland_74.0.3729.131.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_74.0.3729.131.bb
@@ -32,6 +32,8 @@ SRC_URI += " \
         file://0001-ozone-wayland-Don-t-wait-for-frame-callback-after-su.patch \
         file://0001-Add-support-for-V4L2VDA-on-Linux.patch \
         file://0002-Add-mmap-via-libv4l-to-generic_v4l2_device.patch \
+        file://0001-ozone-wayland-Do-not-add-window-if-manager-does-not-.patch \
+        file://0001-ozone-wayland-Fix-NativeGpuMemoryBuffers-usage.patch \
 "
 
 # Chromium can use v4l2 device for hardware accelerated video decoding. Make sure that


### PR DESCRIPTION
This commit fixes two issues:
1) When the zwp_linux_dmabuf protocol is not available, the
WaylandConnection still has been trying to access the manager
and add a Window to it. This patch avoids this behaviour.

2) NativeGpuMemoryBuffers support was broken after a major refactoring
done. Now, it works again.

Signed-off-by: Maksim Sisov <msisov@igalia.com>