### PR TITLE
Fixup v4l2 vda on Linux patch to include VP9

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland/0001-Add-support-for-V4L2VDA-on-Linux.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0001-Add-support-for-V4L2VDA-on-Linux.patch
@@ -29,20 +29,28 @@ fixup! avoid building not declared formats
 
 Signed-off-by: Ryo Kodama <ryo.kodama.vz@renesas.com>
 
+fixup! add V4L2_PIX_FMT_VP9 support back again as it is now
+included in mainline Linux kernel. This allows VP9 codec
+to work with upstream kernel and v4l2 vda. Tested on db820c
+with Venus v4l2 driver.
+
+Signed-off-by: Peter Griffin <peter.griffin@linaro.org>
+Signed-off-by: Stanimir Varbanov <stanimir.varbanov@linaro.org>
+
 Issue #437
 ---
- media/gpu/BUILD.gn                            | 34 +++++++++++--------
- media/gpu/args.gni                            |  4 +++
- .../gpu_jpeg_decode_accelerator_factory.cc    |  3 +-
- .../gpu_video_decode_accelerator_factory.cc   |  8 +++++
- .../gpu_video_decode_accelerator_factory.h    |  2 ++
- media/gpu/v4l2/generic_v4l2_device.cc         |  6 +++-
- media/gpu/v4l2/v4l2_device.cc                 | 25 ++++++++++++++
- .../gpu/v4l2/v4l2_video_decode_accelerator.cc |  6 +++-
- 8 files changed, 71 insertions(+), 17 deletions(-)
+ media/gpu/BUILD.gn                                | 34 +++++++++++++----------
+ media/gpu/args.gni                                |  4 +++
+ media/gpu/gpu_jpeg_decode_accelerator_factory.cc  |  3 +-
+ media/gpu/gpu_video_decode_accelerator_factory.cc |  8 ++++++
+ media/gpu/gpu_video_decode_accelerator_factory.h  |  2 ++
+ media/gpu/v4l2/generic_v4l2_device.cc             |  6 +++-
+ media/gpu/v4l2/v4l2_device.cc                     | 31 +++++++++++++++++++++
+ media/gpu/v4l2/v4l2_video_decode_accelerator.cc   |  1 +
+ 8 files changed, 73 insertions(+), 16 deletions(-)
 
 diff --git a/media/gpu/BUILD.gn b/media/gpu/BUILD.gn
-index af79bc724210..db6d92d3ff03 100644
+index af79bc7..db6d92d 100644
 --- a/media/gpu/BUILD.gn
 +++ b/media/gpu/BUILD.gn
 @@ -17,6 +17,7 @@ buildflag_header("buildflags") {
@@ -113,7 +121,7 @@ index af79bc724210..db6d92d3ff03 100644
        "EGL",
        "GLESv2",
 diff --git a/media/gpu/args.gni b/media/gpu/args.gni
-index df4b0f980ba4..ac740ffeead4 100644
+index df4b0f9..ac740ff 100644
 --- a/media/gpu/args.gni
 +++ b/media/gpu/args.gni
 @@ -10,6 +10,10 @@ declare_args() {
@@ -128,7 +136,7 @@ index df4b0f980ba4..ac740ffeead4 100644
    # is typically the case on x86-based ChromeOS devices.
    use_vaapi = false
 diff --git a/media/gpu/gpu_jpeg_decode_accelerator_factory.cc b/media/gpu/gpu_jpeg_decode_accelerator_factory.cc
-index c0dfb52cc775..1148e752fcf4 100644
+index c0dfb52..1148e75 100644
 --- a/media/gpu/gpu_jpeg_decode_accelerator_factory.cc
 +++ b/media/gpu/gpu_jpeg_decode_accelerator_factory.cc
 @@ -13,7 +13,8 @@
@@ -142,7 +150,7 @@ index c0dfb52cc775..1148e752fcf4 100644
  #endif
  
 diff --git a/media/gpu/gpu_video_decode_accelerator_factory.cc b/media/gpu/gpu_video_decode_accelerator_factory.cc
-index 27b3fe4e65da..4c39f8aefa7b 100644
+index 27b3fe4..4c39f8a 100644
 --- a/media/gpu/gpu_video_decode_accelerator_factory.cc
 +++ b/media/gpu/gpu_video_decode_accelerator_factory.cc
 @@ -24,7 +24,9 @@
@@ -196,7 +204,7 @@ index 27b3fe4e65da..4c39f8aefa7b 100644
  #if BUILDFLAG(USE_VAAPI)
  std::unique_ptr<VideoDecodeAccelerator>
 diff --git a/media/gpu/gpu_video_decode_accelerator_factory.h b/media/gpu/gpu_video_decode_accelerator_factory.h
-index 74f10ebeb8a2..e779ef50fcbc 100644
+index 74f10eb..e779ef5 100644
 --- a/media/gpu/gpu_video_decode_accelerator_factory.h
 +++ b/media/gpu/gpu_video_decode_accelerator_factory.h
 @@ -111,11 +111,13 @@ class MEDIA_GPU_EXPORT GpuVideoDecodeAcceleratorFactory {
@@ -214,7 +222,7 @@ index 74f10ebeb8a2..e779ef50fcbc 100644
    std::unique_ptr<VideoDecodeAccelerator> CreateVaapiVDA(
        const gpu::GpuDriverBugWorkarounds& workarounds,
 diff --git a/media/gpu/v4l2/generic_v4l2_device.cc b/media/gpu/v4l2/generic_v4l2_device.cc
-index 63d688b3654e..845a134b5b63 100644
+index 63d688b..845a134 100644
 --- a/media/gpu/v4l2/generic_v4l2_device.cc
 +++ b/media/gpu/v4l2/generic_v4l2_device.cc
 @@ -479,9 +479,13 @@ bool GenericV4L2Device::OpenDevicePath(const std::string& path, Type type) {
@@ -233,10 +241,10 @@ index 63d688b3654e..845a134b5b63 100644
      use_libv4l2_ = true;
    }
 diff --git a/media/gpu/v4l2/v4l2_device.cc b/media/gpu/v4l2/v4l2_device.cc
-index 4f87445b552c..121c60b1e054 100644
+index 4f87445..9b3c55f 100644
 --- a/media/gpu/v4l2/v4l2_device.cc
 +++ b/media/gpu/v4l2/v4l2_device.cc
-@@ -978,6 +978,21 @@ uint32_t V4L2Device::VideoFrameLayoutToV4L2PixFmt(
+@@ -978,6 +978,23 @@ uint32_t V4L2Device::VideoFrameLayoutToV4L2PixFmt(
                                        layout.num_buffers() == 1);
  }
  
@@ -249,6 +257,8 @@ index 4f87445b552c..121c60b1e054 100644
 +    return V4L2_PIX_FMT_H264;
 +  } else if (profile >= VP8PROFILE_MIN && profile <= VP8PROFILE_MAX) {
 +    return V4L2_PIX_FMT_VP8;
++  } else if (profile >= VP9PROFILE_MIN && profile <= VP9PROFILE_MAX) {
++    return V4L2_PIX_FMT_VP9;
 +  } else {
 +    LOG(FATAL) << "Add more cases as needed";
 +    return 0;
@@ -258,7 +268,7 @@ index 4f87445b552c..121c60b1e054 100644
  // static
  uint32_t V4L2Device::VideoCodecProfileToV4L2PixFmt(VideoCodecProfile profile,
                                                     bool slice_based) {
-@@ -1019,6 +1034,7 @@ VideoCodecProfile V4L2Device::V4L2VP9ProfileToVideoCodecProfile(
+@@ -1019,6 +1036,7 @@ VideoCodecProfile V4L2Device::V4L2VP9ProfileToVideoCodecProfile(
        return VIDEO_CODEC_PROFILE_UNKNOWN;
    }
  }
@@ -266,7 +276,7 @@ index 4f87445b552c..121c60b1e054 100644
  
  // static
  std::vector<VideoCodecProfile> V4L2Device::V4L2PixFmtToVideoCodecProfiles(
-@@ -1029,7 +1045,9 @@ std::vector<VideoCodecProfile> V4L2Device::V4L2PixFmtToVideoCodecProfiles(
+@@ -1029,7 +1047,9 @@ std::vector<VideoCodecProfile> V4L2Device::V4L2PixFmtToVideoCodecProfiles(
  
    switch (pix_fmt) {
      case V4L2_PIX_FMT_H264:
@@ -276,7 +286,7 @@ index 4f87445b552c..121c60b1e054 100644
        if (is_encoder) {
          // TODO(posciak): need to query the device for supported H.264 profiles,
          // for now choose Main as a sensible default.
-@@ -1042,11 +1060,14 @@ std::vector<VideoCodecProfile> V4L2Device::V4L2PixFmtToVideoCodecProfiles(
+@@ -1042,11 +1062,14 @@ std::vector<VideoCodecProfile> V4L2Device::V4L2PixFmtToVideoCodecProfiles(
        break;
  
      case V4L2_PIX_FMT_VP8:
@@ -291,15 +301,19 @@ index 4f87445b552c..121c60b1e054 100644
      case V4L2_PIX_FMT_VP9:
      case V4L2_PIX_FMT_VP9_FRAME: {
        v4l2_queryctrl query_ctrl = {};
-@@ -1073,6 +1094,7 @@ std::vector<VideoCodecProfile> V4L2Device::V4L2PixFmtToVideoCodecProfiles(
+@@ -1073,6 +1096,11 @@ std::vector<VideoCodecProfile> V4L2Device::V4L2PixFmtToVideoCodecProfiles(
        }
        break;
      }
 +#endif
++    case V4L2_PIX_FMT_VP9:
++      min_profile = VP9PROFILE_MIN;
++      max_profile = VP9PROFILE_MAX;
++      break;
  
      default:
        VLOGF(1) << "Unhandled pixelformat " << FourccToString(pix_fmt);
-@@ -1103,7 +1125,10 @@ uint32_t V4L2Device::V4L2PixFmtToDrmFormat(uint32_t format) {
+@@ -1103,7 +1131,10 @@ uint32_t V4L2Device::V4L2PixFmtToDrmFormat(uint32_t format) {
        return DRM_FORMAT_ARGB8888;
  
      case V4L2_PIX_FMT_MT21C:
@@ -311,7 +325,7 @@ index 4f87445b552c..121c60b1e054 100644
      default:
        DVLOGF(1) << "Unrecognized format " << FourccToString(format);
 diff --git a/media/gpu/v4l2/v4l2_video_decode_accelerator.cc b/media/gpu/v4l2/v4l2_video_decode_accelerator.cc
-index 7e361c3de223..3eb436d69d75 100644
+index 7e361c3..1d916d1 100644
 --- a/media/gpu/v4l2/v4l2_video_decode_accelerator.cc
 +++ b/media/gpu/v4l2/v4l2_video_decode_accelerator.cc
 @@ -33,6 +33,7 @@
@@ -322,18 +336,6 @@ index 7e361c3de223..3eb436d69d75 100644
  #include "media/gpu/v4l2/v4l2_image_processor.h"
  #include "media/video/h264_parser.h"
  #include "ui/gfx/geometry/rect.h"
-@@ -82,7 +83,10 @@ size_t GetNumPlanesOfV4L2PixFmt(uint32_t pix_fmt) {
- 
- // static
- const uint32_t V4L2VideoDecodeAccelerator::supported_input_fourccs_[] = {
--    V4L2_PIX_FMT_H264, V4L2_PIX_FMT_VP8, V4L2_PIX_FMT_VP9,
-+    V4L2_PIX_FMT_H264, V4L2_PIX_FMT_VP8,
-+#if !BUILDFLAG(USE_LINUX_V4L2)
-+    V4L2_PIX_FMT_VP9,
-+#endif
- };
- 
- struct V4L2VideoDecodeAccelerator::BitstreamBufferRef {
 -- 
-2.20.1
+2.7.4
 


### PR DESCRIPTION
This patch fixes up V4L2VDA support to add back in VP9 codec support which is now present in mainline kernel.

This was tested on db820c with venus v4l2 driver. I've also included Stanimir SoB as he is venus v4l2
driver maintainer and helped debug/fix this issue.
