### PR TITLE
chromium: Fix build with musl/x86_64

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -23,6 +23,7 @@ SRC_URI += " \
         file://0005-Remove-banned-designated-initializer-list-usage-from.patch \
         file://0006-GCC-add-std-move-to-return-to-base-Optional.patch \
         file://0001-GCC-fix-another-GCC-bug-by-implementing-copy-assign-.patch \
+        file://add_internal_define_armv7ve.patch \
 "
 
 SRC_URI_append_libc-musl = "\

--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -42,6 +42,7 @@ SRC_URI_append_libc-musl = "\
         file://musl/musl_crashpad.patch \
         file://musl/musl_replace_libc_fpstate.patch \
         file://musl/musl_fix_stack_trace.patch \
+        file://musl/musl_portable_msghdr.patch \
 "
 # This patch could be enabled for clang builds, one just needs to make it work.
 # On sumo and MACHINE="raspberrypi3", the build fails with errors such as

--- a/recipes-browser/chromium/files/add_internal_define_armv7ve.patch
+++ b/recipes-browser/chromium/files/add_internal_define_armv7ve.patch
@@ -1,0 +1,18 @@
+Consider armv7ve define
+
+when using -march=armv7ve, clang emits internal architecture define to be
+__ARM_ARCH_7VE__ which we do not check to decide if its armv 7 or not, therefore
+add this to check as well.
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+--- a/third_party/tcmalloc/gperftools-2.0/chromium/src/base/arm_instruction_set_select.h
++++ b/third_party/tcmalloc/gperftools-2.0/chromium/src/base/arm_instruction_set_select.h
+@@ -42,6 +42,7 @@
+ #if defined(ARMV8) || \
+     defined(__ARM_ARCH_7__) || \
+     defined(__ARM_ARCH_7R__) || \
++    defined(__ARM_ARCH_7VE__) || \
+     defined(__ARM_ARCH_7A__)
+ # define ARMV7 1
+ #endif

--- a/recipes-browser/chromium/files/musl/musl_lss-match_syscalls.patch
+++ b/recipes-browser/chromium/files/musl/musl_lss-match_syscalls.patch
@@ -4,17 +4,25 @@ Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 --- a/third_party/lss/linux_syscall_support.h
 +++ b/third_party/lss/linux_syscall_support.h
-@@ -816,6 +816,9 @@ struct kernel_statfs {
+@@ -816,6 +816,17 @@ struct kernel_statfs {
  #define FUTEX_TRYLOCK_PI_PRIVATE  (FUTEX_TRYLOCK_PI | FUTEX_PRIVATE_FLAG)
  #endif
  
++#ifndef __NR_stat
++#define __NR_stat __NR_stat64
++#endif
++
++#ifndef __NR_fstat
++#define __NR_fstat __NR_fstat64
++#endif
++
 +#ifndef __NR_fstatat
 +#define __NR_fstatat __NR_fstatat64
 +#endif
  
  #if defined(__x86_64__)
  #ifndef ARCH_SET_GS
-@@ -1239,6 +1242,12 @@ struct kernel_statfs {
+@@ -1239,6 +1250,12 @@ struct kernel_statfs {
  #ifndef __NR_fallocate
  #define __NR_fallocate          285
  #endif

--- a/recipes-browser/chromium/files/musl/musl_portable_msghdr.patch
+++ b/recipes-browser/chromium/files/musl/musl_portable_msghdr.patch
@@ -1,0 +1,35 @@
+initialize msghdr in a compatible manner
+
+msghdr stuct from socket.h is not same between musl and glibc
+where musl claims to be more posix  compliant where as glibc seems
+to fill whats needed for linux sizewise and chooses long enough types
+which maybe questionable, therefore constructing a structure with explicit
+constructor is not going to work correctly for musl and glibc at same time
+
+see
+https://git.musl-libc.org/cgit/musl/commit/arch/x86_64/bits/socket.h?id=7168790763cdeb794df52be6e3b39fbb021c5a64
+
+This fix initialized the struct to 0 first and then sets the struct elements
+by name, so we dont have to hard code the positions of elements when initializing
+structure
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+--- a/net/socket/udp_socket_posix.cc
++++ b/net/socket/udp_socket_posix.cc
+@@ -1193,8 +1193,12 @@ SendResult UDPSocketPosixSender::Interna
+   for (auto& buffer : buffers)
+     msg_iov->push_back({const_cast<char*>(buffer->data()), buffer->length()});
+   msgvec->reserve(buffers.size());
+-  for (size_t j = 0; j < buffers.size(); j++)
+-    msgvec->push_back({{nullptr, 0, &msg_iov[j], 1, nullptr, 0, 0}, 0});
++  for (size_t j = 0; j < buffers.size(); j++) {
++    struct msghdr m = {0};
++    m.msg_iov = &msg_iov[j];
++    m.msg_iovlen = 1;
++    msgvec->push_back({m, 0});
++  }
+   int result = HANDLE_EINTR(Sendmmsg(fd, &msgvec[0], buffers.size(), 0));
+   SendResult send_result(0, 0, std::move(buffers));
+   if (result < 0) {

--- a/recipes-browser/chromium/gn-native_75.0.3770.90.bb
+++ b/recipes-browser/chromium/gn-native_75.0.3770.90.bb
@@ -36,3 +36,5 @@ do_install() {
 	install -d ${D}${bindir}
 	install -m 0755 ${S}/out/Release/gn ${D}${bindir}/gn
 }
+
+INSANE_SKIP_${PN} += "already-stripped"


### PR DESCRIPTION
msghdr is not same on musl and glibc but chromium assumes so
so lets fix it such that we can initialize the msghdr structure
in a clever way such that we don't have to know how its laid out

Signed-off-by: Khem Raj <raj.khem@gmail.com>