### PR TITLE
firefox: Add a missing dependency "dbus-glib"

### DIFF
--- a/dynamic-layers/rust-layer/recipes-browser/firefox/firefox_60.4.0esr.bb
+++ b/dynamic-layers/rust-layer/recipes-browser/firefox/firefox_60.4.0esr.bb
@@ -2,7 +2,7 @@
 # Released under the MIT license (see packages/COPYING)
 
 DESCRIPTION ?= "Browser made by mozilla"
-DEPENDS += "curl startup-notification libevent cairo libnotify \
+DEPENDS += "curl startup-notification libevent cairo libnotify dbus-glib \
             virtual/libgl pulseaudio yasm-native icu unzip-native \
             virtual/${TARGET_PREFIX}rust cargo-native ${RUSTLIB_DEP} \
            "


### PR DESCRIPTION
I failed to build firefox without this dependency against poky:master(bc5f6725af04417dcf5c65981d8b85abee9c61d8).