### PR TITLE
chromium: Stop passing use_atk to GN.

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -115,7 +115,6 @@ PACKAGECONFIG[proprietary-codecs] = ' \
 GN_ARGS = " \
         ${PACKAGECONFIG_CONFARGS} \
         is_component_build=${@bb.utils.contains('PACKAGECONFIG', 'component-build', 'true', 'false', d)} \
-        use_atk=${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'true', 'false', d)} \
         use_gnome_keyring=false \
         use_jumbo_build=${@bb.utils.contains('PACKAGECONFIG', 'jumbo-build', 'true', 'false', d)} \
         use_kerberos=false \


### PR DESCRIPTION
This was introduced in commit 0f625720 ("chromium: fix x11 dependency
brought by at-spi2-core package") but never worked; `use_atk` is an internal
GN variable that cannot be set by users. Any `do_configure` log shows that
all GN invocations show a message about how setting `use_atk` has no effect.

This is not a problem though, as it is set in Chromium by checking if
`use_x11` is true (corroborated by the fact that this argument has always
been a no-op while not breaking chromium-ozone-wayland).