### PR TITLE
chromium: Use the right bb.utils call in do_check_fdlimit_for_linking

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -304,7 +304,7 @@ CHROMIUM_EXTRA_ARGS ?= " \
 python do_check_fdlimit_for_linking () {
     """Checks if enough files can be open at the same time by the linker."""
     # The best option would be checking if the linker is ld.bfd instead.
-    if bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold ld-is-lld', True, False, d):
+    if bb.utils.contains_any('DISTRO_FEATURES', 'ld-is-gold ld-is-lld', True, False, d):
         return
     import resource
     nofile_limit = resource.getrlimit(resource.RLIMIT_NOFILE)


### PR DESCRIPTION
`bb.utils.contains()` requires both "ld-is-gold" and "ld-is-lld" to be
present in `DISTRO_FEATURES`, which in practice means the rlimit check will
happen even when one is not using ld.bfd.

Switch to `bb.utils.contains_any()`, which tests for the presence of any of
the arguments, as we originally intended.