### PR TITLE
Chromium/Wayland: Backport fix for the native gpu memory buffers.

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland/0001-ozone-wayland-Implement-CreateNativePixmapAsync.patch
+++ b/recipes-browser/chromium/chromium-ozone-wayland/0001-ozone-wayland-Implement-CreateNativePixmapAsync.patch
@@ -1,0 +1,69 @@
+Upstream-Status: Backport
+
+https://crrev.com/c/1728655
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From c9b2ec4801d317817c786e16d5d9c7bec187e8e3 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Thu, 1 Aug 2019 08:22:39 +0000
+Subject: [PATCH] [ozone/wayland] Implement CreateNativePixmapAsync
+
+Fix native GpuMemoryBuffers for Ozone/Wayland by implementing
+non implemented CreateNativePixmapAsync call.
+
+Bug: 989433
+Change-Id: Ic178ac2d4f0716e4c4a00a0abb6686e64b980b90
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1728655
+Reviewed-by: Robert Kroeger <rjkroege@chromium.org>
+Commit-Queue: Maksim Sisov <msisov@igalia.com>
+Cr-Commit-Position: refs/heads/master@{#683102}
+---
+ .../platform/wayland/gpu/wayland_surface_factory.cc | 13 +++++++++++++
+ .../platform/wayland/gpu/wayland_surface_factory.h  |  6 ++++++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_surface_factory.cc b/ui/ozone/platform/wayland/gpu/wayland_surface_factory.cc
+index b5dba5fd525b..2446ce76298f 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_surface_factory.cc
++++ b/ui/ozone/platform/wayland/gpu/wayland_surface_factory.cc
+@@ -168,6 +168,19 @@ scoped_refptr<gfx::NativePixmap> WaylandSurfaceFactory::CreateNativePixmap(
+ #endif
+ }
+ 
++void WaylandSurfaceFactory::CreateNativePixmapAsync(
++    gfx::AcceleratedWidget widget,
++    VkDevice vk_device,
++    gfx::Size size,
++    gfx::BufferFormat format,
++    gfx::BufferUsage usage,
++    NativePixmapCallback callback) {
++  // CreateNativePixmap is non-blocking operation. Thus, it is safe to call it
++  // and return the result with the provided callback.
++  std::move(callback).Run(
++      CreateNativePixmap(widget, vk_device, size, format, usage));
++}
++
+ scoped_refptr<gfx::NativePixmap>
+ WaylandSurfaceFactory::CreateNativePixmapFromHandle(
+     gfx::AcceleratedWidget widget,
+diff --git a/ui/ozone/platform/wayland/gpu/wayland_surface_factory.h b/ui/ozone/platform/wayland/gpu/wayland_surface_factory.h
+index 23f4f92a5959..53545ed9a328 100644
+--- a/ui/ozone/platform/wayland/gpu/wayland_surface_factory.h
++++ b/ui/ozone/platform/wayland/gpu/wayland_surface_factory.h
+@@ -37,6 +37,12 @@ class WaylandSurfaceFactory : public SurfaceFactoryOzone {
+       gfx::Size size,
+       gfx::BufferFormat format,
+       gfx::BufferUsage usage) override;
++  void CreateNativePixmapAsync(gfx::AcceleratedWidget widget,
++                               VkDevice vk_device,
++                               gfx::Size size,
++                               gfx::BufferFormat format,
++                               gfx::BufferUsage usage,
++                               NativePixmapCallback callback) override;
+   scoped_refptr<gfx::NativePixmap> CreateNativePixmapFromHandle(
+       gfx::AcceleratedWidget widget,
+       gfx::Size size,
+-- 
+2.23.0
+

--- a/recipes-browser/chromium/chromium-ozone-wayland_77.0.3865.90.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_77.0.3865.90.bb
@@ -3,6 +3,7 @@ require chromium-gn.inc
 SRC_URI += " \
         file://V4L2/0001-Add-support-for-V4L2VDA-on-Linux.patch \
         file://V4L2/0002-Add-mmap-via-libv4l-to-generic_v4l2_device.patch \
+        file://0001-ozone-wayland-Implement-CreateNativePixmapAsync.patch \
 "
 
 REQUIRED_DISTRO_FEATURES = "wayland"


### PR DESCRIPTION
Chromium may want to create native pixmaps in async way now.
The Ozone/Wayland in the current stable release did not include
the fix to allow async creation of the pixmaps, which exists in
the upstream.

Thus, backport that.

Signed-off-by: Maksim Sisov <msisov@igalia.com>