### PR TITLE
Firefox, chromium: Add CVE_PRODUCT names.

### DIFF
--- a/dynamic-layers/rust-layer/recipes-browser/firefox/firefox_68.0esr.bb
+++ b/dynamic-layers/rust-layer/recipes-browser/firefox/firefox_68.0esr.bb
@@ -13,6 +13,8 @@ RDEPENDS_${PN}-dev = "dbus"
 LICENSE = "MPLv2"
 LIC_FILES_CHKSUM = "file://toolkit/content/license.html;endline=33;md5=35d7fa1c4b86c115051c925fd624a5be"
 
+CVE_PRODUCT = "mozilla:firefox"
+
 SRC_URI = "https://ftp.mozilla.org/pub/firefox/releases/${PV}/source/firefox-${PV}.source.tar.xz;name=archive \
            file://mozconfig \
            file://mozilla-firefox.png \

--- a/recipes-browser/chromium/chromium.inc
+++ b/recipes-browser/chromium/chromium.inc
@@ -1,6 +1,8 @@
 DESCRIPTION = "Chromium is an open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web."
 HOMEPAGE = "https://www.chromium.org/Home"
 
+CVE_PRODUCT = "chromium:chromium google:chrome"
+
 SRC_URI = "https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${PV}.tar.xz"
 SRC_URI[md5sum] = "69729e1cbabfe5a6fe135f690b2ef9b9"
 SRC_URI[sha256sum] = "d792f9b09b1dcfd64e68f47a611c540dd1383dd9abd78ca1e06b2a7e2ff06af8"


### PR DESCRIPTION
These names follow the following cpe naming from nvd:

firefox:
https://nvd.nist.gov/products/cpe/detail/7356?keyword=firefox&status=FINAL&orderBy=CPEURI&namingFormat=2.3&startIndex=20

chromium:
https://nvd.nist.gov/products/cpe/detail/621194?keyword=chromium&status=FINAL&orderBy=CPEURI&namingFormat=2.3
https://nvd.nist.gov/products/cpe/detail/200115?keyword=chromium&status=FINAL&orderBy=CPEURI&namingFormat=2.3

Fixes: #325

Signed-off-by: Maksim Sisov <msisov@igalia.com>