### PR TITLE
chromium: Fix build on 32bit arches with 64bit time_t

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -20,6 +20,7 @@ SRC_URI += " \
         file://do-not-specify-march-on-arm.patch \
         file://add_internal_define_armv7ve.patch \
         file://delete_not_yet_released_clang_warnings.patch \
+        file://64bit_time_t.patch \
 "
 
 SRC_URI_append_libc-musl = "\

--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -21,6 +21,11 @@ SRC_URI += " \
         file://add_internal_define_armv7ve.patch \
         file://delete_not_yet_released_clang_warnings.patch \
         file://64bit_time_t.patch \
+        file://std_size_t.patch \
+        file://stdint.patch \
+        file://include_string.patch \
+        file://0023-chromium-Move-CharAllocator-definition-to-a-header-f.patch \
+        file://0001-Remove-glslang-pool_allocator-setAllocator.patch \
 "
 
 SRC_URI_append_libc-musl = "\

--- a/recipes-browser/chromium/files/0001-Remove-glslang-pool_allocator-setAllocator.patch
+++ b/recipes-browser/chromium/files/0001-Remove-glslang-pool_allocator-setAllocator.patch
@@ -1,0 +1,26 @@
+From 49dd914109fd1ee9e1e917890bf18f85dd95ff31 Mon Sep 17 00:00:00 2001
+From: Reid Kleckner <rnk@google.com>
+Date: Sun, 29 Dec 2019 23:17:16 -0800
+Subject: [PATCH] Remove glslang::pool_allocator::setAllocator
+
+TPoolAllocator is not copy assignable, so this setter could never have
+been used. After a recent change (878a24ee2), new versions of Clang
+reject this code outright.
+
+Upstream-Status: Backport [https://github.com/KhronosGroup/glslang/commit/0de87ee9a5bf5d094a3faa1a71fd9080e80b6be0]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ third_party/glslang/src/glslang/Include/PoolAlloc.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+--- a/third_party/glslang/src/glslang/Include/PoolAlloc.h
++++ b/third_party/glslang/src/glslang/Include/PoolAlloc.h
+@@ -304,7 +304,6 @@ public:
+     size_type max_size() const { return static_cast<size_type>(-1) / sizeof(T); }
+     size_type max_size(int size) const { return static_cast<size_type>(-1) / size; }
+ 
+-    void setAllocator(TPoolAllocator* a) { allocator = *a; }
+     TPoolAllocator& getAllocator() const { return allocator; }
+ 
+ protected:

--- a/recipes-browser/chromium/files/0023-chromium-Move-CharAllocator-definition-to-a-header-f.patch
+++ b/recipes-browser/chromium/files/0023-chromium-Move-CharAllocator-definition-to-a-header-f.patch
@@ -1,0 +1,546 @@
+From 3324558fb02b720cd394e0cc270d10dc6db0c915 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 2 Jan 2020 17:13:55 -0800
+Subject: [PATCH] chromium: Move CharAllocator definition to a header file
+
+Fixes
+error: invalid application of 'sizeof' to an incomplete type 'cc::ListContainerHelper::CharAllocator'
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ chromium/cc/base/list_container_helper.cc | 245 ---------------------
+ chromium/cc/base/list_container_helper.h  | 250 ++++++++++++++++++++++
+ 2 files changed, 250 insertions(+), 245 deletions(-)
+
+--- a/cc/base/list_container_helper.cc
++++ b/cc/base/list_container_helper.cc
+@@ -12,258 +12,12 @@
+ #include "base/logging.h"
+ #include "base/memory/aligned_memory.h"
+ 
+-namespace {
+-const size_t kDefaultNumElementTypesToReserve = 32;
+-}  // namespace
+-
+ namespace cc {
+ 
+ // CharAllocator
+ ////////////////////////////////////////////////////
+ // This class deals only with char* and void*. It does allocation and passing
+ // out raw pointers, as well as memory deallocation when being destroyed.
+-class ListContainerHelper::CharAllocator {
+- public:
+-  // CharAllocator::InnerList
+-  /////////////////////////////////////////////
+-  // This class holds the raw memory chunk, as well as information about its
+-  // size and availability.
+-  struct InnerList {
+-    InnerList(const InnerList&) = delete;
+-    InnerList& operator=(const InnerList&) = delete;
+-
+-    std::unique_ptr<char[], base::AlignedFreeDeleter> data;
+-    // The number of elements in total the memory can hold. The difference
+-    // between capacity and size is the how many more elements this list can
+-    // hold.
+-    size_t capacity;
+-    // The number of elements have been put into this list.
+-    size_t size;
+-    // The size of each element is in bytes. This is used to move from between
+-    // elements' memory locations.
+-    size_t step;
+-
+-    InnerList() : capacity(0), size(0), step(0) {}
+-
+-    void Erase(char* position) {
+-      // Confident that destructor is called by caller of this function. Since
+-      // CharAllocator does not handle construction after
+-      // allocation, it doesn't handle desctrution before deallocation.
+-      DCHECK_LE(position, LastElement());
+-      DCHECK_GE(position, Begin());
+-      char* start = position + step;
+-      std::copy(start, End(), position);
+-
+-      --size;
+-      // Decrease capacity to avoid creating not full not last InnerList.
+-      --capacity;
+-    }
+-
+-    void InsertBefore(size_t alignment, char** position, size_t count) {
+-      DCHECK_LE(*position, LastElement() + step);
+-      DCHECK_GE(*position, Begin());
+-
+-      // Adjust the size and capacity
+-      size_t old_size = size;
+-      size += count;
+-      capacity = size;
+-
+-      // Allocate the new data and update the iterator's pointer.
+-      std::unique_ptr<char[], base::AlignedFreeDeleter> new_data(
+-          static_cast<char*>(base::AlignedAlloc(size * step, alignment)));
+-      size_t position_offset = *position - Begin();
+-      *position = new_data.get() + position_offset;
+-
+-      // Copy the data before the inserted segment
+-      memcpy(new_data.get(), data.get(), position_offset);
+-      // Copy the data after the inserted segment.
+-      memcpy(new_data.get() + position_offset + count * step,
+-             data.get() + position_offset, old_size * step - position_offset);
+-      data = std::move(new_data);
+-    }
+-
+-    bool IsEmpty() const { return !size; }
+-    bool IsFull() { return capacity == size; }
+-    size_t NumElementsAvailable() const { return capacity - size; }
+-
+-    void* AddElement() {
+-      DCHECK_LT(size, capacity);
+-      ++size;
+-      return LastElement();
+-    }
+-
+-    void RemoveLast() {
+-      DCHECK(!IsEmpty());
+-      --size;
+-    }
+-
+-    char* Begin() const { return data.get(); }
+-    char* End() const { return data.get() + size * step; }
+-    char* LastElement() const { return data.get() + (size - 1) * step; }
+-    char* ElementAt(size_t index) const { return data.get() + index * step; }
+-  };
+-
+-  CharAllocator(size_t alignment, size_t element_size, size_t element_count)
+-      // base::AlignedAlloc does not accept alignment less than sizeof(void*).
+-      : alignment_(std::max(sizeof(void*), alignment)),
+-        element_size_(element_size),
+-        size_(0),
+-        last_list_index_(0),
+-        last_list_(nullptr) {
+-    // If this fails, then alignment of elements after the first could be wrong,
+-    // and we need to pad sizes to fix that.
+-    DCHECK_EQ(element_size % alignment, 0u);
+-    AllocateNewList(element_count > 0 ? element_count
+-                                      : kDefaultNumElementTypesToReserve);
+-    last_list_ = storage_[last_list_index_].get();
+-  }
+-
+-  CharAllocator(const CharAllocator&) = delete;
+-  ~CharAllocator() = default;
+-
+-  CharAllocator& operator=(const CharAllocator&) = delete;
+-
+-  void* Allocate() {
+-    if (last_list_->IsFull()) {
+-      // Only allocate a new list if there isn't a spare one still there from
+-      // previous usage.
+-      if (last_list_index_ + 1 >= storage_.size())
+-        AllocateNewList(last_list_->capacity * 2);
+-
+-      ++last_list_index_;
+-      last_list_ = storage_[last_list_index_].get();
+-    }
+-
+-    ++size_;
+-    return last_list_->AddElement();
+-  }
+-
+-  size_t alignment() const { return alignment_; }
+-  size_t element_size() const { return element_size_; }
+-  size_t list_count() const { return storage_.size(); }
+-  size_t size() const { return size_; }
+-  bool IsEmpty() const { return size() == 0; }
+-
+-  size_t Capacity() const {
+-    size_t capacity_sum = 0;
+-    for (const auto& inner_list : storage_)
+-      capacity_sum += inner_list->capacity;
+-    return capacity_sum;
+-  }
+-
+-  void Clear() {
+-    // Remove all except for the first InnerList.
+-    DCHECK(!storage_.empty());
+-    storage_.erase(storage_.begin() + 1, storage_.end());
+-    last_list_index_ = 0;
+-    last_list_ = storage_[0].get();
+-    last_list_->size = 0;
+-    size_ = 0;
+-  }
+-
+-  void RemoveLast() {
+-    DCHECK(!IsEmpty());
+-    last_list_->RemoveLast();
+-    if (last_list_->IsEmpty() && last_list_index_ > 0) {
+-      --last_list_index_;
+-      last_list_ = storage_[last_list_index_].get();
+-
+-      // If there are now two empty inner lists, free one of them.
+-      if (last_list_index_ + 2 < storage_.size())
+-        storage_.pop_back();
+-    }
+-    --size_;
+-  }
+-
+-  void Erase(PositionInCharAllocator* position) {
+-    DCHECK_EQ(this, position->ptr_to_container);
+-
+-    // Update |position| to point to the element after the erased element.
+-    InnerList* list = storage_[position->vector_index].get();
+-    char* item_iterator = position->item_iterator;
+-    if (item_iterator == list->LastElement())
+-      position->Increment();
+-
+-    list->Erase(item_iterator);
+-    // TODO(weiliangc): Free the InnerList if it is empty.
+-    --size_;
+-  }
+-
+-  void InsertBefore(ListContainerHelper::Iterator* position, size_t count) {
+-    if (!count)
+-      return;
+-
+-    // If |position| is End(), then append |count| elements at the end. This
+-    // will happen to not invalidate any iterators or memory.
+-    if (!position->item_iterator) {
+-      // Set |position| to be the first inserted element.
+-      Allocate();
+-      position->vector_index = storage_.size() - 1;
+-      position->item_iterator = storage_[position->vector_index]->LastElement();
+-      // Allocate the rest.
+-      for (size_t i = 1; i < count; ++i)
+-        Allocate();
+-    } else {
+-      storage_[position->vector_index]->InsertBefore(
+-          alignment_, &position->item_iterator, count);
+-      size_ += count;
+-    }
+-  }
+-
+-  InnerList* InnerListById(size_t id) const {
+-    DCHECK_LT(id, storage_.size());
+-    return storage_[id].get();
+-  }
+-
+-  size_t FirstInnerListId() const {
+-    // |size_| > 0 means that at least one vector in |storage_| will be
+-    // non-empty.
+-    DCHECK_GT(size_, 0u);
+-    size_t id = 0;
+-    while (storage_[id]->size == 0)
+-      ++id;
+-    return id;
+-  }
+-
+-  size_t LastInnerListId() const {
+-    // |size_| > 0 means that at least one vector in |storage_| will be
+-    // non-empty.
+-    DCHECK_GT(size_, 0u);
+-    size_t id = storage_.size() - 1;
+-    while (storage_[id]->size == 0)
+-      --id;
+-    return id;
+-  }
+-
+-  size_t NumAvailableElementsInLastList() const {
+-    return last_list_->NumElementsAvailable();
+-  }
+-
+- private:
+-  void AllocateNewList(size_t list_size) {
+-    std::unique_ptr<InnerList> new_list(new InnerList);
+-    new_list->capacity = list_size;
+-    new_list->size = 0;
+-    new_list->step = element_size_;
+-    new_list->data.reset(static_cast<char*>(
+-        base::AlignedAlloc(list_size * element_size_, alignment_)));
+-    storage_.push_back(std::move(new_list));
+-  }
+-
+-  std::vector<std::unique_ptr<InnerList>> storage_;
+-  const size_t alignment_;
+-  const size_t element_size_;
+-
+-  // The number of elements in the list.
+-  size_t size_;
+-
+-  // The index of the last list to have had elements added to it, or the only
+-  // list if the container has not had elements added since being cleared.
+-  size_t last_list_index_;
+-
+-  // This is equivalent to |storage_[last_list_index_]|.
+-  InnerList* last_list_;
+-};
+ 
+ // PositionInCharAllocator
+ //////////////////////////////////////////////////////
+--- a/cc/base/list_container_helper.h
++++ b/cc/base/list_container_helper.h
+@@ -8,9 +8,18 @@
+ #include <stddef.h>
+ 
+ #include <memory>
++#include <algorithm>
++#include <vector>
++
++#include "base/logging.h"
++#include "base/memory/aligned_memory.h"
+ 
+ #include "cc/base/base_export.h"
+ 
++namespace {
++const size_t kDefaultNumElementTypesToReserve = 32;
++}  // namespace
++
+ namespace cc {
+ 
+ // Helper class for ListContainer non-templated logic. All methods are private,
+@@ -174,6 +183,249 @@ class CC_BASE_EXPORT ListContainerHelper
+   std::unique_ptr<CharAllocator> data_;
+ };
+ 
++class ListContainerHelper::CharAllocator {
++ public:
++  // CharAllocator::InnerList
++  /////////////////////////////////////////////
++  // This class holds the raw memory chunk, as well as information about its
++  // size and availability.
++  struct InnerList {
++    InnerList(const InnerList&) = delete;
++    InnerList& operator=(const InnerList&) = delete;
++
++    std::unique_ptr<char[], base::AlignedFreeDeleter> data;
++    // The number of elements in total the memory can hold. The difference
++    // between capacity and size is the how many more elements this list can
++    // hold.
++    size_t capacity;
++    // The number of elements have been put into this list.
++    size_t size;
++    // The size of each element is in bytes. This is used to move from between
++    // elements' memory locations.
++    size_t step;
++
++    InnerList() : capacity(0), size(0), step(0) {}
++
++    void Erase(char* position) {
++      // Confident that destructor is called by caller of this function. Since
++      // CharAllocator does not handle construction after
++      // allocation, it doesn't handle desctrution before deallocation.
++      DCHECK_LE(position, LastElement());
++      DCHECK_GE(position, Begin());
++      char* start = position + step;
++      std::copy(start, End(), position);
++
++      --size;
++      // Decrease capacity to avoid creating not full not last InnerList.
++      --capacity;
++    }
++
++    void InsertBefore(size_t alignment, char** position, size_t count) {
++      DCHECK_LE(*position, LastElement() + step);
++      DCHECK_GE(*position, Begin());
++
++      // Adjust the size and capacity
++      size_t old_size = size;
++      size += count;
++      capacity = size;
++
++      // Allocate the new data and update the iterator's pointer.
++      std::unique_ptr<char[], base::AlignedFreeDeleter> new_data(
++          static_cast<char*>(base::AlignedAlloc(size * step, alignment)));
++      size_t position_offset = *position - Begin();
++      *position = new_data.get() + position_offset;
++
++      // Copy the data before the inserted segment
++      memcpy(new_data.get(), data.get(), position_offset);
++      // Copy the data after the inserted segment.
++      memcpy(new_data.get() + position_offset + count * step,
++             data.get() + position_offset, old_size * step - position_offset);
++      data = std::move(new_data);
++    }
++
++    bool IsEmpty() const { return !size; }
++    bool IsFull() { return capacity == size; }
++    size_t NumElementsAvailable() const { return capacity - size; }
++
++    void* AddElement() {
++      DCHECK_LT(size, capacity);
++      ++size;
++      return LastElement();
++    }
++
++    void RemoveLast() {
++      DCHECK(!IsEmpty());
++      --size;
++    }
++
++    char* Begin() const { return data.get(); }
++    char* End() const { return data.get() + size * step; }
++    char* LastElement() const { return data.get() + (size - 1) * step; }
++    char* ElementAt(size_t index) const { return data.get() + index * step; }
++  };
++
++  CharAllocator(size_t alignment, size_t element_size, size_t element_count)
++      // base::AlignedAlloc does not accept alignment less than sizeof(void*).
++      : alignment_(std::max(sizeof(void*), alignment)),
++        element_size_(element_size),
++        size_(0),
++        last_list_index_(0),
++        last_list_(nullptr) {
++    // If this fails, then alignment of elements after the first could be wrong,
++    // and we need to pad sizes to fix that.
++    DCHECK_EQ(element_size % alignment, 0u);
++    AllocateNewList(element_count > 0 ? element_count
++                                      : kDefaultNumElementTypesToReserve);
++    last_list_ = storage_[last_list_index_].get();
++  }
++
++  CharAllocator(const CharAllocator&) = delete;
++  ~CharAllocator() = default;
++
++  CharAllocator& operator=(const CharAllocator&) = delete;
++
++  void* Allocate() {
++    if (last_list_->IsFull()) {
++      // Only allocate a new list if there isn't a spare one still there from
++      // previous usage.
++      if (last_list_index_ + 1 >= storage_.size())
++        AllocateNewList(last_list_->capacity * 2);
++
++      ++last_list_index_;
++      last_list_ = storage_[last_list_index_].get();
++    }
++
++    ++size_;
++    return last_list_->AddElement();
++  }
++
++  size_t alignment() const { return alignment_; }
++  size_t element_size() const { return element_size_; }
++  size_t list_count() const { return storage_.size(); }
++  size_t size() const { return size_; }
++  bool IsEmpty() const { return size() == 0; }
++
++  size_t Capacity() const {
++    size_t capacity_sum = 0;
++    for (const auto& inner_list : storage_)
++      capacity_sum += inner_list->capacity;
++    return capacity_sum;
++  }
++
++  void Clear() {
++    // Remove all except for the first InnerList.
++    DCHECK(!storage_.empty());
++    storage_.erase(storage_.begin() + 1, storage_.end());
++    last_list_index_ = 0;
++    last_list_ = storage_[0].get();
++    last_list_->size = 0;
++    size_ = 0;
++  }
++
++  void RemoveLast() {
++    DCHECK(!IsEmpty());
++    last_list_->RemoveLast();
++    if (last_list_->IsEmpty() && last_list_index_ > 0) {
++      --last_list_index_;
++      last_list_ = storage_[last_list_index_].get();
++
++      // If there are now two empty inner lists, free one of them.
++      if (last_list_index_ + 2 < storage_.size())
++        storage_.pop_back();
++    }
++    --size_;
++  }
++
++  void Erase(PositionInCharAllocator* position) {
++    DCHECK_EQ(this, position->ptr_to_container);
++
++    // Update |position| to point to the element after the erased element.
++    InnerList* list = storage_[position->vector_index].get();
++    char* item_iterator = position->item_iterator;
++    if (item_iterator == list->LastElement())
++      position->Increment();
++
++    list->Erase(item_iterator);
++    // TODO(weiliangc): Free the InnerList if it is empty.
++    --size_;
++  }
++
++  void InsertBefore(ListContainerHelper::Iterator* position, size_t count) {
++    if (!count)
++      return;
++
++    // If |position| is End(), then append |count| elements at the end. This
++    // will happen to not invalidate any iterators or memory.
++    if (!position->item_iterator) {
++      // Set |position| to be the first inserted element.
++      Allocate();
++      position->vector_index = storage_.size() - 1;
++      position->item_iterator = storage_[position->vector_index]->LastElement();
++      // Allocate the rest.
++      for (size_t i = 1; i < count; ++i)
++        Allocate();
++    } else {
++      storage_[position->vector_index]->InsertBefore(
++          alignment_, &position->item_iterator, count);
++      size_ += count;
++    }
++  }
++
++  InnerList* InnerListById(size_t id) const {
++    DCHECK_LT(id, storage_.size());
++    return storage_[id].get();
++  }
++
++  size_t FirstInnerListId() const {
++    // |size_| > 0 means that at least one vector in |storage_| will be
++    // non-empty.
++    DCHECK_GT(size_, 0u);
++    size_t id = 0;
++    while (storage_[id]->size == 0)
++      ++id;
++    return id;
++  }
++
++  size_t LastInnerListId() const {
++    // |size_| > 0 means that at least one vector in |storage_| will be
++    // non-empty.
++    DCHECK_GT(size_, 0u);
++    size_t id = storage_.size() - 1;
++    while (storage_[id]->size == 0)
++      --id;
++    return id;
++  }
++
++  size_t NumAvailableElementsInLastList() const {
++    return last_list_->NumElementsAvailable();
++  }
++
++ private:
++  void AllocateNewList(size_t list_size) {
++    std::unique_ptr<InnerList> new_list(new InnerList);
++    new_list->capacity = list_size;
++    new_list->size = 0;
++    new_list->step = element_size_;
++    new_list->data.reset(static_cast<char*>(
++        base::AlignedAlloc(list_size * element_size_, alignment_)));
++    storage_.push_back(std::move(new_list));
++  }
++
++  std::vector<std::unique_ptr<InnerList>> storage_;
++  const size_t alignment_;
++  const size_t element_size_;
++
++  // The number of elements in the list.
++  size_t size_;
++
++  // The index of the last list to have had elements added to it, or the only
++  // list if the container has not had elements added since being cleared.
++  size_t last_list_index_;
++
++  // This is equivalent to |storage_[last_list_index_]|.
++  InnerList* last_list_;
++};
++
+ }  // namespace cc
+ 
+ #endif  // CC_BASE_LIST_CONTAINER_HELPER_H_

--- a/recipes-browser/chromium/files/64bit_time_t.patch
+++ b/recipes-browser/chromium/files/64bit_time_t.patch
@@ -1,0 +1,54 @@
+Fix build on 32bit arches with 64bit time_t
+
+time element is deprecated on new input_event structure in kernel's
+input.h [1]
+
+[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=152194fe9c3f
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+--- a/ui/events/ozone/evdev/touch_evdev_debug_buffer.cc
++++ b/ui/events/ozone/evdev/touch_evdev_debug_buffer.cc
+@@ -59,11 +59,11 @@ void TouchEventLogEvdev::DumpLog(const c
+   for (int i = 0; i < kDebugBufferSize; ++i) {
+     struct TouchEvent* te =
+         &logged_events_[(debug_buffer_tail_ + i) % kDebugBufferSize];
+-    if (te->ev.time.tv_sec == 0 && te->ev.time.tv_usec == 0)
++    if (te->ev.input_event_sec == 0 && te->ev.input_event_usec == 0)
+       continue;
+     std::string event_string = base::StringPrintf(
+-        "E: %ld.%06ld %04x %04x %d %d\n", te->ev.time.tv_sec,
+-        te->ev.time.tv_usec, te->ev.type, te->ev.code, te->ev.value, te->slot);
++        "E: %ld.%06ld %04x %04x %d %d\n", te->ev.input_event_sec,
++        te->ev.input_event_usec, te->ev.type, te->ev.code, te->ev.value, te->slot);
+     report_content += event_string;
+   }
+   file.Write(0, report_content.c_str(), report_content.length());
+--- a/ui/events/ozone/evdev/touch_evdev_debug_buffer.h
++++ b/ui/events/ozone/evdev/touch_evdev_debug_buffer.h
+@@ -14,6 +14,11 @@
+ 
+ #include "ui/events/ozone/evdev/events_ozone_evdev_export.h"
+ 
++#ifndef input_event_sec
++#define input_event_sec time.tv_sec
++#define input_event_usec time.tv_usec
++#endif
++
+ namespace ui {
+ 
+ class EventDeviceInfo;
+--- a/ui/events/ozone/evdev/event_converter_evdev.cc
++++ b/ui/events/ozone/evdev/event_converter_evdev.cc
+@@ -176,8 +176,8 @@ void EventConverterEvdev::SetPalmSuppres
+ base::TimeTicks EventConverterEvdev::TimeTicksFromInputEvent(
+     const input_event& event) {
+   base::TimeTicks timestamp =
+-      ui::EventTimeStampFromSeconds(event.time.tv_sec) +
+-      base::TimeDelta::FromMicroseconds(event.time.tv_usec);
++      ui::EventTimeStampFromSeconds(event.input_event_sec) +
++      base::TimeDelta::FromMicroseconds(event.input_event_usec);
+   ValidateEventTimeClock(&timestamp);
+   return timestamp;
+ }

--- a/recipes-browser/chromium/files/include_string.patch
+++ b/recipes-browser/chromium/files/include_string.patch
@@ -1,0 +1,10 @@
+include missing header string.h
+
+Fixes
+
+trace_event_memory_overhead.h:60:29: error: no type named 'string' in namespace 'std' 
+void AddString(const std::string& str);                                                                                                                                                                                                                            ~~~~~^
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+

--- a/recipes-browser/chromium/files/std_size_t.patch
+++ b/recipes-browser/chromium/files/std_size_t.patch
@@ -1,0 +1,42 @@
+--- a/third_party/webrtc/modules/audio_processing/aec3/clockdrift_detector.h
++++ b/third_party/webrtc/modules/audio_processing/aec3/clockdrift_detector.h
+@@ -11,6 +11,7 @@
+ #ifndef MODULES_AUDIO_PROCESSING_AEC3_CLOCKDRIFT_DETECTOR_H_
+ #define MODULES_AUDIO_PROCESSING_AEC3_CLOCKDRIFT_DETECTOR_H_
+ 
++#include <cstddef>
+ #include <array>
+ 
+ namespace webrtc {
+--- a/third_party/angle/include/platform/Platform.h
++++ b/third_party/angle/include/platform/Platform.h
+@@ -9,7 +9,8 @@
+ #ifndef ANGLE_PLATFORM_H
+ #define ANGLE_PLATFORM_H
+ 
+-#include <stdint.h>
++#include <cstdint>
++#include <cstddef>
+ #include <array>
+ 
+ #define EGL_PLATFORM_ANGLE_PLATFORM_METHODS_ANGLEX 0x3482
+--- a/media/cdm/supported_cdm_versions.h
++++ b/media/cdm/supported_cdm_versions.h
+@@ -5,6 +5,7 @@
+ #ifndef MEDIA_CDM_SUPPORTED_CDM_VERSIONS_H_
+ #define MEDIA_CDM_SUPPORTED_CDM_VERSIONS_H_
+ 
++#include <cstddef>
+ #include <array>
+ 
+ #include "media/base/media_export.h"
+--- a/chrome/browser/search/background/ntp_backgrounds.h
++++ b/chrome/browser/search/background/ntp_backgrounds.h
+@@ -5,6 +5,7 @@
+ #ifndef CHROME_BROWSER_SEARCH_BACKGROUND_NTP_BACKGROUNDS_H_
+ #define CHROME_BROWSER_SEARCH_BACKGROUND_NTP_BACKGROUNDS_H_
+ 
++#include <cstddef>
+ #include <array>
+ 
+ class GURL;

--- a/recipes-browser/chromium/files/stdint.patch
+++ b/recipes-browser/chromium/files/stdint.patch
@@ -1,0 +1,30 @@
+include stdint.h for uint_XX
+
+Fixes
+task_runner.h:48:55: error: unknown type name 'uint32_t'
+  virtual void PostDelayedTask(std::function<void()>, uint32_t delay_ms) = 0;
+                                                      ^
+1 error generated.
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+--- a/third_party/perfetto/include/perfetto/base/task_runner.h
++++ b/third_party/perfetto/include/perfetto/base/task_runner.h
+@@ -17,6 +17,7 @@
+ #ifndef INCLUDE_PERFETTO_BASE_TASK_RUNNER_H_
+ #define INCLUDE_PERFETTO_BASE_TASK_RUNNER_H_
+ 
++#include <cstdint>
+ #include <functional>
+ 
+ #include "perfetto/base/export.h"
+--- a/third_party/webrtc/call/rtx_receive_stream.h
++++ b/third_party/webrtc/call/rtx_receive_stream.h
+@@ -11,6 +11,7 @@
+ #ifndef CALL_RTX_RECEIVE_STREAM_H_
+ #define CALL_RTX_RECEIVE_STREAM_H_
+ 
++#include <cstdint>
+ #include <map>
+ 
+ #include "call/rtp_packet_sink_interface.h"


### PR DESCRIPTION
64bit time_t is being added to glibc/musl and will be enabled by default
for 32bit arches atleast its is on musl. This patch ensures that we use
portable defines in a backward compatible way

Signed-off-by: Khem Raj <raj.khem@gmail.com>