### PR TITLE
firefox: Remove PACKAGECONFIG[disable-e10s]

### DIFF
--- a/dynamic-layers/rust-layer/recipes-browser/firefox/README.md
+++ b/dynamic-layers/rust-layer/recipes-browser/firefox/README.md
@@ -36,12 +36,6 @@ PACKAGECONFIG knobs
   Firefox on Linux doesn't enable WebGL against most GPUs by default. This
   option adds a config file to enable it focedly.
 
-* disable-e10s: (off by default)
-  This option disables Electrolysis (e10s) fearture which hosts, renders, or
-  executes web related content in background child processes. This feature
-  improves security and reactivity of UI, but may eat much more memory or may
-  breaks GPU acceleration on certain platforms.
-
 * forbit-multiple-compositors: (off by default)
   This option allows to create only one GPU accelerated compositor, second and
   the following windows will use basic compositors. Multiple compositor may

--- a/dynamic-layers/rust-layer/recipes-browser/firefox/firefox/prefs/disable-e10s.js
+++ b/dynamic-layers/rust-layer/recipes-browser/firefox/firefox/prefs/disable-e10s.js
@@ -1,4 +1,0 @@
-pref("browser.tabs.remote.force-enable", false);
-pref("browser.tabs.remote.force-disable", true);
-pref("browser.tabs.remote.autostart", false);
-pref("browser.tabs.remote.autostart.2", false);

--- a/dynamic-layers/rust-layer/recipes-browser/firefox/firefox_68.0esr.bb
+++ b/dynamic-layers/rust-layer/recipes-browser/firefox/firefox_68.0esr.bb
@@ -81,7 +81,6 @@ PACKAGECONFIG[gpu] = ",,,"
 PACKAGECONFIG[openmax] = "--enable-openmax,,,"
 PACKAGECONFIG[webgl] = ",,,"
 PACKAGECONFIG[webrtc] = "--enable-webrtc,--disable-webrtc,,"
-PACKAGECONFIG[disable-e10s] = ",,,"
 PACKAGECONFIG[forbit-multiple-compositors] = ",,,"
 
 # Add a config file to enable GPU acceleration by default.
@@ -96,9 +95,6 @@ SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'openmax', \
 
 SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'webgl', \
            'file://prefs/webgl.js', '', d)}"
-
-SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'disable-e10s', \
-           'file://prefs/disable-e10s.js', '', d)}"
 
 SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'forbit-multiple-compositors', \
            'file://prefs/single-compositor.js \
@@ -120,9 +116,6 @@ do_install_append() {
     fi
     if [ -n "${@bb.utils.contains('PACKAGECONFIG', 'webgl', '1', '', d)}" ]; then
         install -m 0644 ${WORKDIR}/prefs/webgl.js ${D}${libdir}/${PN}/defaults/pref/
-    fi
-    if [ -n "${@bb.utils.contains('PACKAGECONFIG', 'disable-e10s', '1', '', d)}" ]; then
-        install -m 0644 ${WORKDIR}/prefs/disable-e10s.js ${D}${libdir}/${PN}/defaults/pref/
     fi
     if [ -n "${@bb.utils.contains('PACKAGECONFIG', 'forbit-multiple-compositors', '1', '', d)}" ]; then
         install -m 0644 ${WORKDIR}/prefs/single-compositor.js ${D}${libdir}/${PN}/defaults/pref/


### PR DESCRIPTION
This preference isn't available as of firefox-68.
Use environment variable MOZ_FORCE_DISABLE_E10S=1 instead.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1548941

Signed-off-by: Takuro Ashie <ashie@clear-code.com>