### PR TITLE
chromium: rename distro_features_check to features_check

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -2,7 +2,7 @@ require chromium.inc
 require chromium-unbundle.inc
 require gn-utils.inc
 
-inherit distro_features_check gtk-icon-cache qemu
+inherit features_check gtk-icon-cache qemu
 
 # The actual directory name in out/ is irrelevant for GN.
 OUTPUT_DIR = "out/Release"


### PR DESCRIPTION
Avoid warning due to the class rename in OE-Core.

Fixes:

WARNING: distro_features_check.bbclass is deprecated, please use features_check.bbclass instead

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>