### PR TITLE
chromium: Fix patch fuzz

### DIFF
--- a/recipes-browser/chromium/files/musl/musl_no_mallinfo.patch
+++ b/recipes-browser/chromium/files/musl/musl_no_mallinfo.patch
@@ -22,8 +22,8 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
 -#else
 +#elif defined(__GLIBC__)
    struct mallinfo info = mallinfo();
-   DCHECK_GE(info.arena + info.hblkhd, info.uordblks);
- 
+ #if !defined(ADDRESS_SANITIZER) && !defined(THREAD_SANITIZER)
+   // Sanitizers override mallinfo.
 --- a/third_party/swiftshader/third_party/llvm-7.0/configs/linux/include/llvm/Config/config.h
 +++ b/third_party/swiftshader/third_party/llvm-7.0/configs/linux/include/llvm/Config/config.h
 @@ -122,8 +122,9 @@


### PR DESCRIPTION
Fixes musl patches after recemnt chromium updates
no code chanhes per se

Fixes
Applying patch musl_no_mallinfo.patch
patching file base/process/process_metrics_posix.cc
patching file base/trace_event/malloc_dump_provider.cc
Hunk #1 succeeded at 132 with fuzz 2.
patching file third_party/swiftshader/third_party/llvm-7.0/configs/linux/include/llvm/Config/config.h
patching file third_party/swiftshader/third_party/llvm-subzero/build/Linux/include/llvm/Config/config.h
patching file third_party/tcmalloc/chromium/src/config_linux.h

Signed-off-by: Khem Raj <raj.khem@gmail.com>