### PR TITLE
Remove "thud" from LAYERSERIES_COMPAT.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -110,6 +110,6 @@ BBFILE_PATTERN_browser-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_browser-layer = "7"
 
 LAYERVERSION_browser-layer = "1"
-LAYERSERIES_COMPAT_browser-layer = "thud warrior zeus dunfell"
+LAYERSERIES_COMPAT_browser-layer = "warrior zeus dunfell"
 
 LAYERDEPENDS_browser-layer = "clang-layer core openembedded-layer"


### PR DESCRIPTION
The thud branch is no longer officially supported, and the latest updates to
the Chromium recipe have not even been tested in it.

Fixes #324.