### PR TITLE
chromium-ozone-wayland: add build dependency to at-spi2-atk

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland_83.0.4103.116.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_83.0.4103.116.bb
@@ -3,6 +3,7 @@ require chromium-gn.inc
 REQUIRED_DISTRO_FEATURES = "wayland"
 
 DEPENDS += "\
+        at-spi2-atk \
         libxkbcommon \
         virtual/egl \
         wayland \


### PR DESCRIPTION
Fixes configure error with poky master branch:

ERROR at //build/config/linux/pkg_config.gni:103:17: Script returned non-zero exit code.
    pkgresult = exec_script(pkg_config_script, args, "value")
                ^----------
Current dir: /home/builder/src/yocto/poky/build/tmp/work/cortexa57-poky-linux/chromium-ozone-wayland/83.0.4103.116-r0/chromium-83.0.4103.116/out/Release/
Command: python /home/builder/src/yocto/poky/build/tmp/work/cortexa57-poky-linux/chromium-ozone-wayland/83.0.4103.116-r0/chromium-83.0.4103.116/build/config/linux/pkg-config.py atk atk-bridge-2.0
Returned 1.
stderr:

Package atk-bridge-2.0 was not found in the pkg-config search path.
Perhaps you should add the directory containing `atk-bridge-2.0.pc'
to the PKG_CONFIG_PATH environment variable
No package 'atk-bridge-2.0' found
Could not run pkg-config.

See //build/config/linux/atk/BUILD.gn:19:1: whence it was called.
pkg_config("atk_base") {
^-----------------------
See //ui/views/BUILD.gn:821:22: which caused the file to be included.
        configs += [ "//build/config/linux/atk" ]
                     ^-------------------------
WARNING: exit code 1 from a shell command.
ERROR: Execution of '/home/builder/src/yocto/poky/build/tmp/work/cortexa57-poky-linux/chromium-ozone-wayland/83.0.4103.116-r0/temp/run.do_configure.35368' failed with exit code 1:
ERROR at //build/config/linux/pkg_config.gni:103:17: Script returned non-zero exit code.
    pkgresult = exec_script(pkg_config_script, args, "value")
                ^----------

Signed-off-by: Mikko Rapeli <mikko.rapeli@bmw.de>