### PR TITLE
chromium: fix spontaneous crash in ManifestManagerHost

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -30,6 +30,7 @@ SRC_URI += " \
         file://0001-IWYU-include-cstring-for-memset-and-memcpy-calls-in-.patch \
         file://0001-Add-xcbproto-to-third_party.patch \
         file://0002-Build-with-third-party-xcbproto.patch \
+        file://0001-content-Avoid-calling-DeleteForCurrentDocument-from-.patch \
 "
 
 SRC_URI_append_libc-musl = "\

--- a/recipes-browser/chromium/files/0001-content-Avoid-calling-DeleteForCurrentDocument-from-.patch
+++ b/recipes-browser/chromium/files/0001-content-Avoid-calling-DeleteForCurrentDocument-from-.patch
@@ -1,0 +1,80 @@
+Upstream-Status: Backport
+
+Backported from https://crrev.com/c/2224737
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From 039d21d1ed7fe2cf828127b1e6ee60b3db74c25c Mon Sep 17 00:00:00 2001
+From: Yuzu Saijo <yuzus@chromium.org>
+Date: Tue, 2 Jun 2020 04:51:11 +0000
+Subject: [PATCH] [content] Avoid calling DeleteForCurrentDocument from
+ destructor
+
+This CL removes the call to DeleteForCurrentDocument from the destructor
+of ManifestManagerHost.
+
+This intends to fix a crash which happens from time to time using
+RenderDocumentHostUserData.
+
+Change-Id: I1336fb62328dcb0cf9991499f399bf3665d29b75
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2224737
+Reviewed-by: Rakina Zata Amni <rakina@chromium.org>
+Reviewed-by: Alexander Timin <altimin@chromium.org>
+Reviewed-by: Sreeja Kamishetty <sreejakshetty@chromium.org>
+Reviewed-by: Kinuko Yasuda <kinuko@chromium.org>
+Commit-Queue: Yuzu Saijo <yuzus@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#774006}
+---
+ content/browser/manifest/manifest_manager_host.cc | 7 +++++--
+ content/browser/manifest/manifest_manager_host.h  | 2 ++
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/content/browser/manifest/manifest_manager_host.cc b/content/browser/manifest/manifest_manager_host.cc
+index 68ea016c62eb..501ba2b276ae 100644
+--- a/content/browser/manifest/manifest_manager_host.cc
++++ b/content/browser/manifest/manifest_manager_host.cc
+@@ -22,7 +22,7 @@ ManifestManagerHost::ManifestManagerHost(RenderFrameHost* render_frame_host)
+ }
+ 
+ ManifestManagerHost::~ManifestManagerHost() {
+-  OnConnectionError();
++  DispatchPendingCallbacks();
+ }
+ 
+ void ManifestManagerHost::BindObserver(
+@@ -63,7 +63,7 @@ blink::mojom::ManifestManager& ManifestManagerHost::GetManifestManager() {
+   return *manifest_manager_;
+ }
+ 
+-void ManifestManagerHost::OnConnectionError() {
++void ManifestManagerHost::DispatchPendingCallbacks() {
+   std::vector<GetManifestCallback> callbacks;
+   for (CallbackMap::iterator it(&callbacks_); !it.IsAtEnd(); it.Advance()) {
+     callbacks.push_back(std::move(*it.GetCurrentValue()));
+@@ -71,7 +71,10 @@ void ManifestManagerHost::OnConnectionError() {
+   callbacks_.Clear();
+   for (auto& callback : callbacks)
+     std::move(callback).Run(GURL(), blink::Manifest());
++}
+ 
++void ManifestManagerHost::OnConnectionError() {
++  DispatchPendingCallbacks();
+   if (GetForCurrentDocument(manifest_manager_frame_)) {
+     DeleteForCurrentDocument(manifest_manager_frame_);
+   }
+diff --git a/content/browser/manifest/manifest_manager_host.h b/content/browser/manifest/manifest_manager_host.h
+index 57f51dc9fad7..bdd4ffaf511b 100644
+--- a/content/browser/manifest/manifest_manager_host.h
++++ b/content/browser/manifest/manifest_manager_host.h
+@@ -59,6 +59,8 @@ class ManifestManagerHost
+   using CallbackMap = base::IDMap<std::unique_ptr<GetManifestCallback>>;
+ 
+   blink::mojom::ManifestManager& GetManifestManager();
++
++  void DispatchPendingCallbacks();
+   void OnConnectionError();
+ 
+   void OnRequestManifestResponse(int request_id,
+-- 
+2.25.1
+


### PR DESCRIPTION
Some clients can experience crash that happens in
ManifestManagerHost that may result in a stack with
over 99k frames!

Signed-off-by: Maksim Sisov <msisov@igalia.com>