### PR TITLE
chromium: fix unintended throttling of TouchMoves.

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -20,6 +20,7 @@ SRC_URI += " \
         file://0001-IWYU-int8_t-used-in-nearby-share-encrypted-metadata-.patch \
         file://0001-IWYU-missing-include-for-std-vector-usage-in-ozone-p.patch \
         file://0001-Revert-ui-gfx-linux-Remove-2-unnecessary-preprocesso.patch \
+        file://0001-Turn-TouchMove-to-async-after-the-first-GestureScrol.patch \
 "
 
 SRC_URI_append_libc-musl = "\

--- a/recipes-browser/chromium/files/0001-Turn-TouchMove-to-async-after-the-first-GestureScrol.patch
+++ b/recipes-browser/chromium/files/0001-Turn-TouchMove-to-async-after-the-first-GestureScrol.patch
@@ -1,0 +1,424 @@
+Upstream-Status: Backport
+
+Fixes unintended throttling of TouchMoves.
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+BACKPORT: Turn TouchMove to async after the first GestureScroll has been consumed
+
+This is a reland of http://crrev/c/2182426 which was reverted in
+http://crrev/c/2413491. This was due to unintended side effect of
+non-blocking overscrolls causing throttled TouchMoves where
+developers were relying on them. See http://crbug/1123304 for details.
+
+This avoids turning a touch stream to passive until a scroll has been
+consumed in the renderer (i.e. scrolling has actually begun). Thus,
+this avoids the problem in the initial CL since a touch stream that
+starts by overscrolling will remain blocking and thus won't throttle
+touchmove notifications to the page.
+
+Bug: 1123304,1072364
+Change-Id: I84ada1754c80f6c5254b21beabb8980c6043094e
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2410531
+Reviewed-by: David Bokan <bokan@chromium.org>
+Reviewed-by: Sadrul Chowdhury <sadrul@chromium.org>
+Commit-Queue: Sadrul Chowdhury <sadrul@chromium.org>
+Auto-Submit: Stephen Nusko <nuskos@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#809827}
+---
+ .../renderer_host/input/input_router_impl.cc  |  1 -
+ .../input/passthrough_touch_event_queue.cc    | 12 +---
+ .../input/passthrough_touch_event_queue.h     |  1 -
+ .../passthrough_touch_event_queue_unittest.cc | 60 +++++--------------
+ .../render_widget_host_browsertest.cc         | 33 +++++-----
+ .../render_widget_host_view_mac_unittest.mm   |  3 +-
+ 6 files changed, 37 insertions(+), 73 deletions(-)
+
+diff --git a/content/browser/renderer_host/input/input_router_impl.cc b/content/browser/renderer_host/input/input_router_impl.cc
+index fffec86cf973..4041d69d4690 100644
+--- a/content/browser/renderer_host/input/input_router_impl.cc
++++ b/content/browser/renderer_host/input/input_router_impl.cc
+@@ -200,7 +200,6 @@ void InputRouterImpl::SendGestureEventWithoutQueueing(
+       touch_scroll_started_sent_ = true;
+       touch_event_queue_.PrependTouchScrollNotification();
+     }
+-    touch_event_queue_.OnGestureScrollEvent(gesture_event);
+   }
+ 
+   if (gesture_event.event.IsTouchpadZoomEvent() &&
+diff --git a/content/browser/renderer_host/input/passthrough_touch_event_queue.cc b/content/browser/renderer_host/input/passthrough_touch_event_queue.cc
+index 558fc1872de6..97e518d4bdc8 100644
+--- a/content/browser/renderer_host/input/passthrough_touch_event_queue.cc
++++ b/content/browser/renderer_host/input/passthrough_touch_event_queue.cc
+@@ -154,15 +154,6 @@ void PassthroughTouchEventQueue::ProcessTouchAck(
+   AckCompletedEvents();
+ }
+ 
+-void PassthroughTouchEventQueue::OnGestureScrollEvent(
+-    const GestureEventWithLatencyInfo& gesture_event) {
+-  // Turn events sent during gesture scrolls to be async.
+-  if (gesture_event.event.GetType() ==
+-      blink::WebInputEvent::Type::kGestureScrollUpdate) {
+-    send_touch_events_async_ = true;
+-  }
+-}
+-
+ void PassthroughTouchEventQueue::OnGestureEventAck(
+     const GestureEventWithLatencyInfo& event,
+     blink::mojom::InputEventResultState ack_result) {
+@@ -170,7 +161,8 @@ void PassthroughTouchEventQueue::OnGestureEventAck(
+   if (event.event.GetType() == blink::WebInputEvent::Type::kGestureScrollEnd) {
+     send_touch_events_async_ = false;
+   } else if (event.event.GetType() ==
+-             blink::WebInputEvent::Type::kGestureScrollUpdate) {
++                 blink::WebInputEvent::Type::kGestureScrollUpdate &&
++             ack_result == blink::mojom::InputEventResultState::kConsumed) {
+     send_touch_events_async_ = true;
+   }
+ }
+diff --git a/content/browser/renderer_host/input/passthrough_touch_event_queue.h b/content/browser/renderer_host/input/passthrough_touch_event_queue.h
+index 024bea927d45..82ddc301dc8c 100644
+--- a/content/browser/renderer_host/input/passthrough_touch_event_queue.h
++++ b/content/browser/renderer_host/input/passthrough_touch_event_queue.h
+@@ -102,7 +102,6 @@ class CONTENT_EXPORT PassthroughTouchEventQueue {
+                        const ui::LatencyInfo& latency_info,
+                        const uint32_t unique_touch_event_id,
+                        bool should_stop_timeout_monitor);
+-  void OnGestureScrollEvent(const GestureEventWithLatencyInfo& gesture_event);
+ 
+   void OnGestureEventAck(const GestureEventWithLatencyInfo& event,
+                          blink::mojom::InputEventResultState ack_result);
+diff --git a/content/browser/renderer_host/input/passthrough_touch_event_queue_unittest.cc b/content/browser/renderer_host/input/passthrough_touch_event_queue_unittest.cc
+index 7f67166e2bfc..a3457beddb93 100644
+--- a/content/browser/renderer_host/input/passthrough_touch_event_queue_unittest.cc
++++ b/content/browser/renderer_host/input/passthrough_touch_event_queue_unittest.cc
+@@ -86,12 +86,6 @@ class PassthroughTouchEventQueueTest : public testing::Test,
+           std::move(followup_touch_event_);
+       SendTouchEvent(*followup_touch_event);
+     }
+-    if (followup_gesture_event_) {
+-      std::unique_ptr<WebGestureEvent> followup_gesture_event =
+-          std::move(followup_gesture_event_);
+-      queue_->OnGestureScrollEvent(GestureEventWithLatencyInfo(
+-          *followup_gesture_event, ui::LatencyInfo()));
+-    }
+     last_acked_event_ = event.event;
+     last_acked_event_state_ = ack_result;
+   }
+@@ -146,13 +140,6 @@ class PassthroughTouchEventQueueTest : public testing::Test,
+     queue_->QueueEvent(TouchEventWithLatencyInfo(event, ui::LatencyInfo()));
+   }
+ 
+-  void SendGestureEvent(WebInputEvent::Type type) {
+-    WebGestureEvent event(type, WebInputEvent::kNoModifiers,
+-                          ui::EventTimeForNow());
+-    queue_->OnGestureScrollEvent(
+-        GestureEventWithLatencyInfo(event, ui::LatencyInfo()));
+-  }
+-
+   void SendTouchEventAck(blink::mojom::InputEventResultState ack_result) {
+     DCHECK(!sent_events_ids_.empty());
+     queue_->ProcessTouchAck(
+@@ -188,10 +175,6 @@ class PassthroughTouchEventQueueTest : public testing::Test,
+     followup_touch_event_.reset(new WebTouchEvent(event));
+   }
+ 
+-  void SetFollowupEvent(const WebGestureEvent& event) {
+-    followup_gesture_event_.reset(new WebGestureEvent(event));
+-  }
+-
+   void SetSyncAckResult(blink::mojom::InputEventResultState sync_ack_result) {
+     sync_ack_result_.reset(
+         new blink::mojom::InputEventResultState(sync_ack_result));
+@@ -355,7 +338,6 @@ class PassthroughTouchEventQueueTest : public testing::Test,
+   blink::mojom::InputEventResultState last_acked_event_state_;
+   SyntheticWebTouchEvent touch_event_;
+   std::unique_ptr<WebTouchEvent> followup_touch_event_;
+-  std::unique_ptr<WebGestureEvent> followup_gesture_event_;
+   std::unique_ptr<blink::mojom::InputEventResultState> sync_ack_result_;
+   double slop_length_dips_;
+   gfx::PointF anchor_;
+@@ -1161,11 +1143,8 @@ TEST_F(PassthroughTouchEventQueueTest, TouchTimeoutWithFollowupGesture) {
+   EXPECT_TRUE(IsTimeoutRunning());
+   EXPECT_EQ(1U, GetAndResetSentEventCount());
+ 
+-  // The cancelled sequence may turn into a scroll gesture.
+-  WebGestureEvent followup_scroll(WebInputEvent::Type::kGestureScrollBegin,
+-                                  WebInputEvent::kNoModifiers,
+-                                  ui::EventTimeForNow());
+-  SetFollowupEvent(followup_scroll);
++  // The cancelled sequence may turn into a scroll gesture, but this code but
++  // these GestureScrollBegin events are generated elsewhere.
+ 
+   // Delay the ack.
+   RunTasksAndWait(DefaultTouchTimeoutDelay() * 2);
+@@ -1198,8 +1177,7 @@ TEST_F(PassthroughTouchEventQueueTest, TouchTimeoutWithFollowupGesture) {
+   EXPECT_EQ(1U, GetAndResetSentEventCount());
+   EXPECT_EQ(1U, GetAndResetAckedEventCount());
+ 
+-  // Now end the scroll sequence.
+-  SendGestureEvent(blink::WebInputEvent::Type::kGestureScrollEnd);
++  // Now end the scroll sequence (A GestureScrollEnd).
+   PressTouchPoint(0, 1);
+   EXPECT_TRUE(IsTimeoutRunning());
+   EXPECT_EQ(1U, GetAndResetSentEventCount());
+@@ -1218,11 +1196,8 @@ TEST_F(PassthroughTouchEventQueueTest,
+   EXPECT_TRUE(IsTimeoutRunning());
+   EXPECT_EQ(1U, GetAndResetSentEventCount());
+ 
+-  // The cancelled sequence may turn into a scroll gesture.
+-  WebGestureEvent followup_scroll(WebInputEvent::Type::kGestureScrollBegin,
+-                                  WebInputEvent::kNoModifiers,
+-                                  ui::EventTimeForNow());
+-  SetFollowupEvent(followup_scroll);
++  // The cancelled sequence may turn into a scroll gesture, but this code but
++  // these GestureScrollBegin events are generated elsewhere.
+ 
+   // Delay the ack.
+   RunTasksAndWait(DefaultTouchTimeoutDelay() * 2);
+@@ -1243,7 +1218,6 @@ TEST_F(PassthroughTouchEventQueueTest,
+ 
+   // Now end the scroll sequence.  Events will not be forwarded until the two
+   // outstanding touch acks are received.
+-  SendGestureEvent(blink::WebInputEvent::Type::kGestureScrollEnd);
+   MoveTouchPoint(0, 2, 2);
+   ReleaseTouchPoint(0);
+   EXPECT_FALSE(IsTimeoutRunning());
+@@ -1425,10 +1399,6 @@ TEST_F(PassthroughTouchEventQueueTest,
+   ASSERT_EQ(1U, GetAndResetSentEventCount());
+   ASSERT_EQ(1U, GetAndResetAckedEventCount());
+ 
+-  WebGestureEvent followup_scroll(WebInputEvent::Type::kGestureScrollBegin,
+-                                  WebInputEvent::kNoModifiers,
+-                                  WebInputEvent::GetStaticTimeStampForTests());
+-  SetFollowupEvent(followup_scroll);
+   MoveTouchPoint(0, 20, 5);
+   EXPECT_EQ(0U, GetAndResetSentEventCount());
+   EXPECT_EQ(1U, GetAndResetAckedEventCount());
+@@ -1457,7 +1427,6 @@ TEST_F(PassthroughTouchEventQueueTest, TouchAbsorptionWithConsumedFirstMove) {
+   EXPECT_EQ(1U, GetAndResetAckedEventCount());
+ 
+   MoveTouchPoint(0, 20, 5);
+-  SendGestureEvent(blink::WebInputEvent::Type::kGestureScrollBegin);
+   SendTouchEventAck(blink::mojom::InputEventResultState::kConsumed);
+   EXPECT_EQ(0U, queued_event_count());
+   EXPECT_EQ(2U, GetAndResetSentEventCount());
+@@ -1471,10 +1440,8 @@ TEST_F(PassthroughTouchEventQueueTest, TouchAbsorptionWithConsumedFirstMove) {
+   EXPECT_EQ(1U, GetAndResetSentEventCount());
+ 
+   MoveTouchPoint(0, 20, 5);
+-  WebGestureEvent followup_scroll(WebInputEvent::Type::kGestureScrollUpdate,
+-                                  WebInputEvent::kNoModifiers,
+-                                  WebInputEvent::GetStaticTimeStampForTests());
+-  SetFollowupEvent(followup_scroll);
++  // A GestureScrollUpdate would be sent here so simulate the ACK of the
++  // TouchMove AND the GestureScrollUpdate
+   SendTouchEventAck(blink::mojom::InputEventResultState::kNotConsumed);
+   SendGestureEventAck(WebInputEvent::Type::kGestureScrollUpdate,
+                       blink::mojom::InputEventResultState::kConsumed);
+@@ -1498,9 +1465,10 @@ TEST_F(PassthroughTouchEventQueueTest, TouchStartCancelableDuringScroll) {
+ 
+   MoveTouchPoint(0, 20, 5);
+   EXPECT_EQ(WebInputEvent::DispatchType::kBlocking, sent_event().dispatch_type);
+-  SendGestureEvent(blink::WebInputEvent::Type::kGestureScrollBegin);
+-  SendGestureEvent(blink::WebInputEvent::Type::kGestureScrollUpdate);
+   SendTouchEventAck(blink::mojom::InputEventResultState::kNotConsumed);
++  // Consume the GestureScrollUpdate to move TouchMoves to async behaviour.
++  SendGestureEventAck(WebInputEvent::Type::kGestureScrollUpdate,
++                      blink::mojom::InputEventResultState::kConsumed);
+   EXPECT_EQ(WebInputEvent::DispatchType::kBlocking, sent_event().dispatch_type);
+   ASSERT_EQ(1U, GetAndResetSentEventCount());
+ 
+@@ -1529,15 +1497,19 @@ TEST_F(PassthroughTouchEventQueueTest, TouchStartCancelableDuringScroll) {
+   ASSERT_EQ(1U, GetAndResetSentEventCount());
+ 
+   // If subsequent touchmoves aren't consumed, the generated scroll events
+-  // will restore async touch dispatch.
++  // will restore async touch dispatch if the GestureScrollUpdate's are
++  // consumed.
+   MoveTouchPoint(0, 25, 5);
+   SendTouchEventAck(blink::mojom::InputEventResultState::kNotConsumed);
+-  SendGestureEvent(blink::WebInputEvent::Type::kGestureScrollUpdate);
++  SendGestureEventAck(WebInputEvent::Type::kGestureScrollUpdate,
++                      blink::mojom::InputEventResultState::kConsumed);
+   EXPECT_EQ(WebInputEvent::DispatchType::kBlocking, sent_event().dispatch_type);
+   ASSERT_EQ(1U, GetAndResetSentEventCount());
+   AdvanceTouchTime(kMinSecondsBetweenThrottledTouchmoves + 0.1);
+   MoveTouchPoint(0, 30, 5);
+   SendTouchEventAck(blink::mojom::InputEventResultState::kNotConsumed);
++  SendGestureEventAck(WebInputEvent::Type::kGestureScrollUpdate,
++                      blink::mojom::InputEventResultState::kConsumed);
+   EXPECT_NE(WebInputEvent::DispatchType::kBlocking, sent_event().dispatch_type);
+   ASSERT_EQ(1U, GetAndResetSentEventCount());
+ 
+diff --git a/content/browser/renderer_host/render_widget_host_browsertest.cc b/content/browser/renderer_host/render_widget_host_browsertest.cc
+index 37bef5f7e140..365861745ec5 100644
+--- a/content/browser/renderer_host/render_widget_host_browsertest.cc
++++ b/content/browser/renderer_host/render_widget_host_browsertest.cc
+@@ -267,14 +267,14 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+ 
+   // Simulate a mouse move without any pressed buttons. This should not
+   // generate any touch events.
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 10, 0,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 120, 0,
+                            false);
+   TestInputEventObserver::EventTypeVector dispatched_events =
+       observer.GetAndResetDispatchedEventTypes();
+   EXPECT_EQ(0u, dispatched_events.size());
+ 
+   // Mouse press becomes touch start which in turn becomes tap.
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseDown, 10, 10, 0,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseDown, 10, 120, 0,
+                            true);
+   WaitForAckWith(blink::WebInputEvent::Type::kTouchStart);
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchStart,
+@@ -285,7 +285,7 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+   EXPECT_EQ(blink::WebInputEvent::Type::kGestureTapDown, dispatched_events[1]);
+ 
+   // Mouse drag generates touch move, cancels tap and starts scroll.
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 30, 0,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 100, 0,
+                            true);
+   dispatched_events = observer.GetAndResetDispatchedEventTypes();
+   ASSERT_EQ(4u, dispatched_events.size());
+@@ -301,7 +301,7 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+   EXPECT_EQ(0u, observer.GetAndResetDispatchedEventTypes().size());
+ 
+   // Mouse drag with shift becomes pinch.
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 35,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 95,
+                            blink::WebInputEvent::kShiftKey, true);
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchMove,
+             observer.acked_touch_event_type());
+@@ -312,7 +312,7 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+   EXPECT_EQ(blink::WebInputEvent::Type::kGesturePinchBegin,
+             dispatched_events[1]);
+ 
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 50,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 80,
+                            blink::WebInputEvent::kShiftKey, true);
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchMove,
+             observer.acked_touch_event_type());
+@@ -324,7 +324,7 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+             dispatched_events[1]);
+ 
+   // Mouse drag without shift becomes scroll again.
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 60, 0,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 70, 0,
+                            true);
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchMove,
+             observer.acked_touch_event_type());
+@@ -336,7 +336,7 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+   EXPECT_EQ(blink::WebInputEvent::Type::kGestureScrollUpdate,
+             dispatched_events[2]);
+ 
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 70, 0,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 60, 0,
+                            true);
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchMove,
+             observer.acked_touch_event_type());
+@@ -346,8 +346,9 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+   EXPECT_EQ(blink::WebInputEvent::Type::kGestureScrollUpdate,
+             dispatched_events[1]);
+ 
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseUp, 10, 70, 0,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseUp, 10, 60, 0,
+                            true);
++  WaitForAckWith(blink::WebInputEvent::Type::kTouchEnd);
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchEnd,
+             observer.acked_touch_event_type());
+   dispatched_events = observer.GetAndResetDispatchedEventTypes();
+@@ -357,13 +358,13 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+             dispatched_events[1]);
+ 
+   // Mouse move does nothing.
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 80, 0,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 50, 0,
+                            false);
+   dispatched_events = observer.GetAndResetDispatchedEventTypes();
+   EXPECT_EQ(0u, dispatched_events.size());
+ 
+   // Another mouse down continues scroll.
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseDown, 10, 80, 0,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseDown, 10, 50, 0,
+                            true);
+   WaitForAckWith(blink::WebInputEvent::Type::kTouchStart);
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchStart,
+@@ -372,7 +373,7 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+   ASSERT_EQ(2u, dispatched_events.size());
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchStart, dispatched_events[0]);
+   EXPECT_EQ(blink::WebInputEvent::Type::kGestureTapDown, dispatched_events[1]);
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 100, 0,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 30, 0,
+                            true);
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchMove,
+             observer.acked_touch_event_type());
+@@ -388,7 +389,7 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+   EXPECT_EQ(0u, observer.GetAndResetDispatchedEventTypes().size());
+ 
+   // Another pinch.
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 110,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 20,
+                            blink::WebInputEvent::kShiftKey, true);
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchMove,
+             observer.acked_touch_event_type());
+@@ -397,7 +398,7 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchMove, dispatched_events[0]);
+   EXPECT_EQ(blink::WebInputEvent::Type::kGesturePinchBegin,
+             dispatched_events[1]);
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 120,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 10,
+                            blink::WebInputEvent::kShiftKey, true);
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchMove,
+             observer.acked_touch_event_type());
+@@ -419,7 +420,7 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+             dispatched_events[2]);
+ 
+   // Mouse event should pass untouched.
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 10,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 120,
+                            blink::WebInputEvent::kShiftKey, true);
+   dispatched_events = observer.GetAndResetDispatchedEventTypes();
+   ASSERT_EQ(1u, dispatched_events.size());
+@@ -431,7 +432,7 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+       ui::GestureProviderConfigType::GENERIC_MOBILE);
+ 
+   // Another touch.
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseDown, 10, 10, 0,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseDown, 10, 120, 0,
+                            true);
+   WaitForAckWith(blink::WebInputEvent::Type::kTouchStart);
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchStart,
+@@ -442,7 +443,7 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostTouchEmulatorBrowserTest,
+   EXPECT_EQ(blink::WebInputEvent::Type::kGestureTapDown, dispatched_events[1]);
+ 
+   // Scroll.
+-  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 30, 0,
++  SimulateRoutedMouseEvent(blink::WebInputEvent::Type::kMouseMove, 10, 100, 0,
+                            true);
+   EXPECT_EQ(blink::WebInputEvent::Type::kTouchMove,
+             observer.acked_touch_event_type());
+diff --git a/content/browser/renderer_host/render_widget_host_view_mac_unittest.mm b/content/browser/renderer_host/render_widget_host_view_mac_unittest.mm
+index b6f3c58d6955..a2acfd2e48ba 100644
+--- a/content/browser/renderer_host/render_widget_host_view_mac_unittest.mm
++++ b/content/browser/renderer_host/render_widget_host_view_mac_unittest.mm
+@@ -1122,7 +1122,7 @@ TEST_F(RenderWidgetHostViewMacTest, PointerEventWithPenTypeSendAsTouch) {
+   [rwhv_mac_->GetInProcessNSView() mouseEvent:event];
+   base::RunLoop().RunUntilIdle();
+   events = host_->GetAndResetDispatchedMessages();
+-  ASSERT_EQ("TouchEnd GestureScrollEnd", GetMessageNames(events));
++  ASSERT_EQ("TouchEnd", GetMessageNames(events));
+   EXPECT_EQ(blink::WebPointerProperties::PointerType::kPen,
+             static_cast<const blink::WebTouchEvent&>(
+                 events[0]->ToEvent()->Event()->Event())
+@@ -1132,6 +1132,7 @@ TEST_F(RenderWidgetHostViewMacTest, PointerEventWithPenTypeSendAsTouch) {
+   events.clear();
+   base::RunLoop().RunUntilIdle();
+   events = host_->GetAndResetDispatchedMessages();
++  ASSERT_EQ("GestureScrollEnd", GetMessageNames(events));
+ 
+   event =
+       MockMouseEventWithParams(kCGEventLeftMouseDown, {6, 9},
+-- 
+2.25.1
+


### PR DESCRIPTION
Some users may experience input lag with touch events.
This backport fixes this issue.

See https://crbug.com/1072364 for more details.