### PR TITLE
Add meta-python2 to LAYERDEPENDS and shorten layer index

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -112,4 +112,4 @@ BBFILE_PRIORITY_browser-layer = "7"
 LAYERVERSION_browser-layer = "1"
 LAYERSERIES_COMPAT_browser-layer = "warrior zeus dunfell gatesgarth"
 
-LAYERDEPENDS_browser-layer = "clang-layer core openembedded-layer"
+LAYERDEPENDS_browser-layer = "clang-layer core openembedded-layer meta-python2"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -110,6 +110,6 @@ BBFILE_PATTERN_browser-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_browser-layer = "7"
 
 LAYERVERSION_browser-layer = "1"
-LAYERSERIES_COMPAT_browser-layer = "warrior zeus dunfell gatesgarth"
+LAYERSERIES_COMPAT_browser-layer = "dunfell gatesgarth"
 
 LAYERDEPENDS_browser-layer = "clang-layer core openembedded-layer meta-python2"


### PR DESCRIPTION
Chromium requires pythonnative which is in meta-python2, so we need to add this to the bowser layer dependencies. Also, layerindex only supports 25 characters so LAYERSERIES_COMPACT should be made shorter. 