### PR TITLE
chromium: Add mime-xdg to get rid of build warning

### DIFF
--- a/recipes-browser/chromium/chromium.inc
+++ b/recipes-browser/chromium/chromium.inc
@@ -18,7 +18,7 @@ TOOLCHAIN = "clang"
 # to build the native recipes (e.g. GN) with clang too.
 TOOLCHAIN_class-native = "clang"
 
-inherit pythonnative setuptools
+inherit mime-xdg pythonnative setuptools
 
 # Chromium itself is licensed under the 3-clause BSD license. However, it
 # depends upon several other projects whose copyright files are listed in


### PR DESCRIPTION
When building chromium without including mime-xdg, bitbake throws the
following warning:

WARNING: chromium-x11-86.0.4240.111-r0 do_package_qa:
QA Issue: package contains desktop file with key 'MimeType' but does not inhert mime

In order to deal with this warning, have the chromium recipe inherit
the mime-xdg recipe.

Signed-off-by: Stacy Gaikovaia <stacygaikovaia@gmail.com>