### PR TITLE
chromium: fix patch context error in build cleanup

### DIFF
--- a/recipes-browser/chromium/files/remove-enable-dse-memoryssa-command-line-flag.patch
+++ b/recipes-browser/chromium/files/remove-enable-dse-memoryssa-command-line-flag.patch
@@ -36,5 +36,8 @@ index 85fbbbe614bf..fba9fd10426e 100644
 -      ]
 -    }
    }
+ 
+   # C11/C++11 compiler flags setup.
 -- 
 2.25.1
+


### PR DESCRIPTION
Building with 87.0.4280.88 and 87.0.4280.141 errors out (on at least
Dunfell) due to a claim of a malformed patch.  Reapplying the changes
by hand and regenerating the patch results in a simple context
adjustment, and when I recreate that adjustment in the original patch
file, the error is resolved.  Original error below:

  Applying patch remove-enable-dse-memoryssa-command-line-flag.patch
  patching file build/config/compiler/BUILD.gn
  patch: **** malformed patch at line 40: 2.25.1

Signed-off-by: Michael van er Westhuizen <r1mikey@gmail.com>