### PR TITLE
chromium-x11: avoid link latomic failure on CentOS 8 host

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -426,6 +426,9 @@ do_install() {
 	# modifying the dummy "CHROME_EXTRA_ARGS" line
 	sed -i "s/^CHROME_EXTRA_ARGS=\"\"/CHROME_EXTRA_ARGS=\"${CHROMIUM_EXTRA_ARGS}\"/" ${D}${libdir}/chromium/chromium-wrapper
 
+	# This is ANGLE, not to be confused with the similarly named files under swiftshader/
+	cp -a libEGL.so* libGLESv2.so* ${D}${libdir}/chromium/
+
 	if [ -n "${@bb.utils.contains('PACKAGECONFIG', 'component-build', 'component-build', '', d)}" ]; then
 		install -m 0755 *.so ${D}${libdir}/chromium/
 	fi

--- a/recipes-browser/chromium/chromium-x11_87.0.4280.141.bb
+++ b/recipes-browser/chromium/chromium-x11_87.0.4280.141.bb
@@ -2,6 +2,10 @@ require chromium-gn.inc
 
 REQUIRED_DISTRO_FEATURES = "x11"
 
+SRC_URI += " \
+    file://0001-remove-link-to-libatomic-from-BUILD.gn.patch \
+"
+
 DEPENDS += "\
         libx11 \
         libxcomposite \
@@ -27,3 +31,9 @@ GN_ARGS += "use_ozone=false"
 # chromium-ozone-wayland recipes, and the former used to be called just
 # "chromium".
 PROVIDES = "chromium"
+
+# Since chromium use clang as toolchain and clang delegates atomics to
+# runtime library instead of builtins, Link with latomic in TARGET_LDFLAGS
+# rather than in BUILD.gn, to avoid build failure due to no libatomic on host
+# (such as CentOS 8)
+TARGET_LDFLAGS_append_toolchain-clang = " -latomic"

--- a/recipes-browser/chromium/files/0001-remove-link-to-libatomic-from-BUILD.gn.patch
+++ b/recipes-browser/chromium/files/0001-remove-link-to-libatomic-from-BUILD.gn.patch
@@ -1,0 +1,60 @@
+From 01c899455bff7ab0322542c832d4f7c3359e9139 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Thu, 21 Jan 2021 17:07:28 +0800
+Subject: [PATCH] remove link to libatomic from BUILD.gn
+
+In BUILD.gn, the compile option does not distinguish target and native, such as
+-latomic works for both of target and native, if no libatomic on host (such as
+CentOS 8), there will be a link failure on native tool, even though the native
+tool does not require -latomic.
+
+Remove -latomic from BUILD.gn, and we will set it for target from recipe
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ base/BUILD.gn               | 9 ---------
+ build/config/linux/BUILD.gn | 6 ------
+ 2 files changed, 15 deletions(-)
+
+diff --git a/base/BUILD.gn b/base/BUILD.gn
+index 1d97f72..ba755fb 100644
+--- a/base/BUILD.gn
++++ b/base/BUILD.gn
+@@ -1291,15 +1291,6 @@ component("base") {
+     "//third_party/abseil-cpp:absl",
+   ]
+ 
+-  # Needed for <atomic> if using newer C++ library than sysroot, except if
+-  # building inside the cros_sdk environment - use host_toolchain as a
+-  # more robust check for this.
+-  if (!use_sysroot &&
+-      (is_android || ((is_linux || is_chromeos) && !is_chromecast)) &&
+-      host_toolchain != "//build/toolchain/cros:host") {
+-    libs += [ "atomic" ]
+-  }
+-
+   if (use_allocator_shim) {
+     sources += [
+       "allocator/allocator_shim.cc",
+diff --git a/build/config/linux/BUILD.gn b/build/config/linux/BUILD.gn
+index 80c5318..8a51542 100644
+--- a/build/config/linux/BUILD.gn
++++ b/build/config/linux/BUILD.gn
+@@ -27,12 +27,6 @@ config("runtime_library") {
+   if (is_chromeos) {
+     defines = [ "OS_CHROMEOS" ]
+   }
+-
+-  if ((!(is_chromeos || chromeos_is_browser_only) ||
+-       default_toolchain != "//build/toolchain/cros:target") &&
+-      (!use_custom_libcxx || current_cpu == "mipsel")) {
+-    libs = [ "atomic" ]
+-  }
+ }
+ 
+ config("x11") {
+-- 
+2.18.2
+


### PR DESCRIPTION
Since chromium use clang as toolchain and clang delegates atomics to
runtime library instead of builtins, Link with latomic in TARGET_LDFLAGS
rather than in BUILD.gn, to avoid build failure due to no libatomic on
host (such as CentOS 8)

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>