### PR TITLE
chromium: Remove the "jumbo-build" PACKAGECONFIG knob.

### DIFF
--- a/recipes-browser/chromium/README
+++ b/recipes-browser/chromium/README
@@ -50,14 +50,6 @@ PACKAGECONFIG knobs
   http://www.chromium.org/developers/design-documents/impl-side-painting for
   more.
 
-* jumbo-build: (off by default)
-  Enables what's also known as "unity builds": several source files are merged
-  together and compiled only once in order to reduce build times, but may end
-  up requiring more memory at certain points.
-
-  Jumbo builds are documented here:
-  https://chromium.googlesource.com/chromium/src/+/master/docs/jumbo.md
-
 * kiosk-mode: (off by default)
   Enable this option if you want your browser to start up full-screen, without
   any menu bars, without any clutter, and without any initial start-up

--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -110,7 +110,6 @@ PACKAGECONFIG[use-egl] = ",,virtual/egl virtual/libgles2"
 PACKAGECONFIG[component-build] = ""
 PACKAGECONFIG[cups] = "use_cups=true,use_cups=false,cups"
 PACKAGECONFIG[impl-side-painting] = ""
-PACKAGECONFIG[jumbo-build] = ""
 PACKAGECONFIG[kiosk-mode] = ""
 PACKAGECONFIG[proprietary-codecs] = ' \
         ffmpeg_branding="Chrome" proprietary_codecs=true, \
@@ -122,7 +121,6 @@ GN_ARGS = " \
         ${PACKAGECONFIG_CONFARGS} \
         is_component_build=${@bb.utils.contains('PACKAGECONFIG', 'component-build', 'true', 'false', d)} \
         use_gnome_keyring=false \
-        use_jumbo_build=${@bb.utils.contains('PACKAGECONFIG', 'jumbo-build', 'true', 'false', d)} \
         use_kerberos=false \
         use_pulseaudio=${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'true', 'false', d)} \
         use_system_freetype=true \


### PR DESCRIPTION
Support for Jumbo builds was removed upstream, and M87 does not have any
code handling the argument we were passing.