### PR TITLE
chromium-x11: install ANGLE so files (libEGL.so, libGLESv2.so)

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -426,6 +426,14 @@ do_install() {
 	# modifying the dummy "CHROME_EXTRA_ARGS" line
 	sed -i "s/^CHROME_EXTRA_ARGS=\"\"/CHROME_EXTRA_ARGS=\"${CHROMIUM_EXTRA_ARGS}\"/" ${D}${libdir}/chromium/chromium-wrapper
 
+	# This is ANGLE, not to be confused with the similarly named files under swiftshader/
+	if [ -e libEGL.so ]; then
+		install -m 0755 libEGL.so ${D}${libdir}/chromium/
+	fi
+	if [ -e libGLESv2.so ]; then
+		install -m 0755 libGLESv2.so ${D}${libdir}/chromium/
+	fi
+
 	if [ -n "${@bb.utils.contains('PACKAGECONFIG', 'component-build', 'component-build', '', d)}" ]; then
 		install -m 0755 *.so ${D}${libdir}/chromium/
 	fi


### PR DESCRIPTION
Refer what fedora [1] did, install libEGL.so, libGLESv2.so which
avoid failed to load libGLESv2.so.2 on bcm-2xxx-rpi4 when launch
chromium with cmd line

...
sh-5.0# chromium --no-sandbox
|[3503:3503:1209/005940.666757:ERROR:gl_implementation.cc(286)]
Failed to load libGLESv2.so.2: libGLESv2.so.2: cannot open shared
object file: No such file or directory
|[3503:3503:1209/005940.676576:ERROR:viz_main_impl.cc(229)] Exiting
GPU process due to errors during initialization
...

[1] https://src.fedoraproject.org/rpms/chromium/c/bbb6fbf8e77f620502fc655619b867f0aeb18f03.patch

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>