### PR TITLE
chromium: Backport patch to stop including <sys/random.h>

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -22,6 +22,7 @@ SRC_URI += " \
         file://0001-drop-dep-on-ui-ozone-for-building-without-ozone.patch \
         file://0001-Fix-local-build.patch \
         file://0001-IWYU-ui-CursorFactory-is-required-without-Ozone.patch \
+        file://0001-RandBytes-Stop-including-sys-random.h-on-Linux.patch \
 "
 
 SRC_URI_append_libc-musl = "\

--- a/recipes-browser/chromium/files/0001-RandBytes-Stop-including-sys-random.h-on-Linux.patch
+++ b/recipes-browser/chromium/files/0001-RandBytes-Stop-including-sys-random.h-on-Linux.patch
@@ -1,0 +1,49 @@
+Upstream-Status: Backport
+
+Signed-off-by: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
+---
+From 80fb001240ed0c30f06eabc75a7899bf1067f515 Mon Sep 17 00:00:00 2001
+From: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
+Date: Wed, 27 Jan 2021 00:09:41 +0000
+Subject: [PATCH] RandBytes: Stop including sys/random.h on Linux.
+
+We use the getrandom() syscall via LSS, so the header is not necessary.
+Additionally, this file might be built on host toolchains with very old
+packages (e.g. CentOS 7 cross-compiling to a more recent target) where the
+header might not exist (due to glibc and/or the Linux kernel version being
+too old), but where reading from /dev/urandom should still work.
+
+Replicate the #ifdef checks from RandBytes() itself in the includes to make
+the file build in more systems.
+
+Bug: 995996
+Change-Id: If75d706f51bed2f0239ec15ca82d2f58d1055b05
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2644955
+Reviewed-by: Chris Palmer <palmer@chromium.org>
+Commit-Queue: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
+Cr-Commit-Position: refs/heads/master@{#847397}
+---
+ base/rand_util_posix.cc | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/base/rand_util_posix.cc b/base/rand_util_posix.cc
+index f121db7fcbdf..b58c37406214 100644
+--- a/base/rand_util_posix.cc
++++ b/base/rand_util_posix.cc
+@@ -17,11 +17,9 @@
+ #include "base/posix/eintr_wrapper.h"
+ #include "build/build_config.h"
+ 
+-#if defined(OS_LINUX) || defined(OS_CHROMEOS)
++#if (defined(OS_LINUX) || defined(OS_CHROMEOS)) && !defined(OS_NACL)
+ #include "third_party/lss/linux_syscall_support.h"
+-#endif
+-
+-#if !defined(OS_IOS) && !defined(OS_NACL)
++#elif defined(OS_MAC)
+ // TODO(crbug.com/995996): Waiting for this header to appear in the iOS SDK.
+ // (See below.)
+ #include <sys/random.h>
+-- 
+2.29.2
+


### PR DESCRIPTION
This header might not exist on systems with very old glibc packages (e.g.
CentOS 7) when building some host binaries that we need to run as part of
the build. It turns out the header is not necessary at all, as Chromium uses
LSS (Linux Syscall Support) to call the syscall and falls back to reading
from /dev/urandom when that fails.

Fixes #445.