### PR TITLE
Document meta-python2 dependency in README.

### DIFF
--- a/README
+++ b/README
@@ -18,6 +18,10 @@ URI: git://github.com/kraj/meta-clang
 branch: master
 revision: HEAD
 
+URI: git://git.openembedded.org/meta-python2
+branch: master
+revision: HEAD
+
 For Firefox, meta-rust is also necessary:
 
 URI: git://github.com/meta-rust/meta-rust


### PR DESCRIPTION
This layer has dependend on the meta-python2 layer since commit
4eb1ab946 ("conf/layer.conf: Add meta-python2 to LAYERDEPENDS"), but this
was not documented in the README.