### PR TITLE
chromium: backport patch that addresses cve-2021-21148 (0day)

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -23,6 +23,7 @@ SRC_URI += " \
         file://0001-Build-fix-for-libstdc.patch \
         file://0001-IWYU-add-missing-include-for-std-vector-and-std-uniq.patch \
         file://0001-ozone-fix-include.patch \
+        file://CVE-2021-21148.patch \
 "
 
 SRC_URI_append_libc-musl = "\

--- a/recipes-browser/chromium/files/CVE-2021-21148.patch
+++ b/recipes-browser/chromium/files/CVE-2021-21148.patch
@@ -1,0 +1,60 @@
+Upstream-Status: Backport
+
+This is a fix for CVE-2021-21148.
+See https://chromereleases.googleblog.com/2021/02/stable-channel-update-for-desktop_4.html
+for more details.
+
+Signed-off-by: Maksim Sisov <msisov@igalia.com>
+---
+From dfcf1e86fac0a7b067caf8fdfc13eaf3e3f445e4 Mon Sep 17 00:00:00 2001
+From: Deepti Gandluri <gdeepti@chromium.org>
+Date: Wed, 27 Jan 2021 22:19:44 -0800
+Subject: [PATCH] [wasm] PostMessage of Memory.buffer should throw
+
+PostMessage of an ArrayBuffer that is not detachable should result
+in a DataCloneError.
+
+Bug: chromium:1170176, chromium:961059
+Change-Id: Ib89bbc10d2b58918067fd1a90365cad10a0db9ec
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2653810
+Reviewed-by: Adam Klein <adamk@chromium.org>
+Reviewed-by: Andreas Haas <ahaas@chromium.org>
+Commit-Queue: Deepti Gandluri <gdeepti@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#72415}
+---
+ src/common/message-template.h   | 2 ++
+ src/objects/value-serializer.cc | 5 +++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/v8/src/common/message-template.h b/v8/src/common/message-template.h
+index f0f4b61..c8ff902 100644
+--- a/v8/src/common/message-template.h
++++ b/v8/src/common/message-template.h
+@@ -580,6 +580,8 @@ namespace internal {
+   T(DataCloneErrorOutOfMemory, "Data cannot be cloned, out of memory.")        \
+   T(DataCloneErrorDetachedArrayBuffer,                                         \
+     "An ArrayBuffer is detached and could not be cloned.")                     \
++  T(DataCloneErrorNonDetachableArrayBuffer,                                    \
++    "ArrayBuffer is not detachable and could not be cloned.")                  \
+   T(DataCloneErrorSharedArrayBufferTransferred,                                \
+     "A SharedArrayBuffer could not be cloned. SharedArrayBuffer must not be "  \
+     "transferred.")                                                            \
+diff --git a/v8/src/objects/value-serializer.cc b/v8/src/objects/value-serializer.cc
+index 3df1bb1..d5f5f05 100644
+--- a/v8/src/objects/value-serializer.cc
++++ b/v8/src/objects/value-serializer.cc
+@@ -864,6 +864,11 @@ Maybe<bool> ValueSerializer::WriteJSArrayBuffer(
+     WriteVarint(index.FromJust());
+     return ThrowIfOutOfMemory();
+   }
++  if (!array_buffer->is_detachable()) {
++    ThrowDataCloneError(
++        MessageTemplate::kDataCloneErrorNonDetachableArrayBuffer);
++    return Nothing<bool>();
++  }
+ 
+   uint32_t* transfer_entry = array_buffer_transfer_map_.Find(array_buffer);
+   if (transfer_entry) {
+-- 
+2.27.0
+


### PR DESCRIPTION
A stable channel has been updated to 88.0.4324.150, but it hasn't
been rolled out yet. Thus, backport the patch and keep it until
the meta-browser chromium recipe is updated to 88.0.4324.150.

Signed-off-by: Maksim Sisov <msisov@igalia.com>