### PR TITLE
chromium: specify the current supported architectures

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -478,3 +478,6 @@ PACKAGE_DEBUG_SPLIT_STYLE = "debug-without-src"
 
 # There is no need to ship empty -dev packages.
 ALLOW_EMPTY_${PN}-dev = "0"
+
+# tested successfully on these architectures
+COMPATIBLE_HOST = "(x86_64|arm|aarch64).*-linux"


### PR DESCRIPTION
These following architectures have been successfully
tested.

* arm64
* arm32
* x86-64

Signed-off-by: Yi Fan Yu <yifan.yu@windriver.com>