### PR TITLE
chromium: Backport upstream patch to fix the build with LLVM 12 and later

### DIFF
--- a/recipes-browser/chromium/chromium-gn.inc
+++ b/recipes-browser/chromium/chromium-gn.inc
@@ -23,6 +23,7 @@ SRC_URI += " \
         file://0001-Build-fix-for-libstdc.patch \
         file://0001-IWYU-add-missing-include-for-std-vector-and-std-uniq.patch \
         file://0001-ozone-fix-include.patch \
+        file://0001-Fix-ill-formed-C-code.patch \
 "
 
 SRC_URI_append_libc-musl = "\

--- a/recipes-browser/chromium/files/0001-Fix-ill-formed-C-code.patch
+++ b/recipes-browser/chromium/files/0001-Fix-ill-formed-C-code.patch
@@ -1,0 +1,44 @@
+Upstream-Status: Backport
+
+This allows the recipe to build with LLVM 12+.
+
+Signed-off-by: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
+---
+From d62de64e2fd20a4811593cb2248bb476aebfadf5 Mon Sep 17 00:00:00 2001
+From: Arthur Eubanks <aeubanks@google.com>
+Date: Sat, 2 Jan 2021 08:11:55 +0000
+Subject: [PATCH] Fix ill-formed C++ code
+
+See https://reviews.llvm.org/D92936.
+
+Bug: 1162717
+Change-Id: Ia44176774dbb4b1d90db08afbe95994c57f8387d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2608756
+Reviewed-by: Kentaro Hara <haraken@chromium.org>
+Commit-Queue: Arthur Eubanks <aeubanks@google.com>
+Cr-Commit-Position: refs/heads/master@{#839931}
+---
+ third_party/blink/renderer/platform/disk_data_metadata.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/third_party/blink/renderer/platform/disk_data_metadata.h b/third_party/blink/renderer/platform/disk_data_metadata.h
+index 7c66cff4773c..94d62b3f7a58 100644
+--- a/third_party/blink/renderer/platform/disk_data_metadata.h
++++ b/third_party/blink/renderer/platform/disk_data_metadata.h
+@@ -14,12 +14,12 @@ class DiskDataMetadata {
+  public:
+   int64_t start_offset() const { return start_offset_; }
+   size_t size() const { return size_; }
+-  DiskDataMetadata(DiskDataMetadata&& other) = delete;
+ 
+  private:
+   DiskDataMetadata(int64_t start_offset, size_t size)
+       : start_offset_(start_offset), size_(size) {}
+   DiskDataMetadata(const DiskDataMetadata& other) = default;
++  DiskDataMetadata(DiskDataMetadata&& other) = default;
+   DiskDataMetadata& operator=(const DiskDataMetadata& other) = default;
+ 
+   int64_t start_offset_;
+-- 
+2.29.2
+


### PR DESCRIPTION
Thanks to Zoltán Böszörményi for pointing to the upstream fix.

Fixes #461.