### PR TITLE
firefox: backport fix for newer rust and add python and python2.7 to HOSTTOOLS

### DIFF
--- a/meta-firefox/README.md
+++ b/meta-firefox/README.md
@@ -27,6 +27,10 @@ This layer depends on:
   - branch: master
   - revision: HEAD
 
+* python2.7 and python on host for HOSTTOOLS
+  - e.g. on newer ubuntu which doesn't install python2 at all by default
+    you need to install python-is-python2 (which will pull python2-minimal/python2.7-minimal)
+
 Contributing
 ------------
 

--- a/meta-firefox/conf/layer.conf
+++ b/meta-firefox/conf/layer.conf
@@ -4,6 +4,14 @@ BBPATH .= ":${LAYERDIR}"
 # We have a recipes directory, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
+# this is only temporary to allow building firefox on hosts without any python2
+# were it would fail like this:
+# ERROR: firefox-68.9.0esr-r0 do_configure: Execution of '/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/firefox/68.9.0esr-r0/temp/run.do_configure.2697230' failed with exit code 127:
+# ./mach: 9: exec: python: not found
+# this should be removed when firefox is upgraded to 78 ESR or newer which contains:
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1473498
+HOSTTOOLS += "python python2.7"
+
 SIGGEN_EXCLUDERECIPES_ABISAFE += " \
    firefox-addon-webconverger \
    firefox-l10n-ach \

--- a/meta-firefox/recipes-browser/firefox/firefox/fixes/Bug-1640982-SetCARGO_PROFILE_RELEASE_LTO-true-when-e.patch
+++ b/meta-firefox/recipes-browser/firefox/firefox/fixes/Bug-1640982-SetCARGO_PROFILE_RELEASE_LTO-true-when-e.patch
@@ -1,0 +1,36 @@
+
+# HG changeset patch
+# User Mike Hommey <mh+mozilla@glandium.org>
+# Date 1595261136 0
+# Node ID fb557eeb597737455524be7bed3fa6a3ea1b7408
+# Parent  7610647673d28bb487cb2032b72a09a729c86b20
+Bug 1640982 - Set CARGO_PROFILE_RELEASE_LTO=true when enabling rust LTO. r=rstewart, a=RyanVM
+
+Differential Revision: https://phabricator.services.mozilla.com/D84098
+
+diff --git a/config/makefiles/rust.mk b/config/makefiles/rust.mk
+--- a/config/makefiles/rust.mk
++++ b/config/makefiles/rust.mk
+@@ -42,17 +42,21 @@ endif
+ endif
+ 
+ # These flags are passed via `cargo rustc` and only apply to the final rustc
+ # invocation (i.e., only the top-level crate, not its dependencies).
+ cargo_rustc_flags = $(CARGO_RUSTCFLAGS)
+ ifndef DEVELOPER_OPTIONS
+ ifndef MOZ_DEBUG_RUST
+ # Enable link-time optimization for release builds.
++# Pass -Clto for older versions of rust, and CARGO_PROFILE_RELEASE_LTO=true
++# for newer ones that support it. Combining the latter with -Clto works, so
++# set both everywhere.
+ cargo_rustc_flags += -C lto
++export CARGO_PROFILE_RELEASE_LTO=true
+ endif
+ endif
+ 
+ ifdef CARGO_INCREMENTAL
+ export CARGO_INCREMENTAL
+ endif
+ 
+ rustflags_neon =
+

--- a/meta-firefox/recipes-browser/firefox/firefox_68.9.0esr.bb
+++ b/meta-firefox/recipes-browser/firefox/firefox_68.9.0esr.bb
@@ -25,6 +25,7 @@ SRC_URI = "https://ftp.mozilla.org/pub/firefox/releases/${PV}/source/firefox-${P
            file://fixes/Bug-1556197-amend-Bug-1544631-for-fixing-mips32.patch \
            file://fixes/Bug-1560340-Only-add-confvars.sh-as-a-dependency-to-.patch \
            file://fixes/bug1545437-enable-to-specify-rust-target.patch \
+           file://fixes/Bug-1640982-SetCARGO_PROFILE_RELEASE_LTO-true-when-e.patch \
            file://fixes/avoid-running-autoconf2.13.patch \
            file://fixes/pre-generated-old-configure.patch \
            file://fixes/link-with-libpangoft.patch \


### PR DESCRIPTION
Depends on https://github.com/OSSystems/meta-browser/pull/470