### PR TITLE
chromium: Fix build with clang 12

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -21,6 +21,7 @@ SRC_URI += " \
         file://0001-link-atomic-for-target-only.patch \
         file://0001-Fix-use-of-DCHECK-with-std-unique_ptr.patch \
         file://0001-IWYU-add-ctime-for-std-time.patch \
+        file://0001-mojo-Include-string.h-for-strncpy-declaration.patch \
 "
 
 SRC_URI_append_libc-musl = "\

--- a/meta-chromium/recipes-browser/chromium/files/0001-mojo-Include-string.h-for-strncpy-declaration.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0001-mojo-Include-string.h-for-strncpy-declaration.patch
@@ -1,0 +1,27 @@
+From 6e37708d7e219cf53b3c2b5d3835d48c00b4ed63 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 10 Mar 2021 10:57:35 -0800
+Subject: [PATCH] mojo: Include string.h for strncpy declaration
+
+Fixes
+named_platform_channel_posix.cc:53:3: error: use of undeclared identifier 'strncpy'
+---
+Upstream-Status: Submitted [https://chromium-review.googlesource.com/c/chromium/src/+/2749538]
+ mojo/public/cpp/platform/named_platform_channel_posix.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/mojo/public/cpp/platform/named_platform_channel_posix.cc b/mojo/public/cpp/platform/named_platform_channel_posix.cc
+index 9082ac4da597..cbedae6c3c61 100644
+--- a/mojo/public/cpp/platform/named_platform_channel_posix.cc
++++ b/mojo/public/cpp/platform/named_platform_channel_posix.cc
+@@ -5,6 +5,7 @@
+ #include "mojo/public/cpp/platform/named_platform_channel.h"
+ 
+ #include <errno.h>
++#include <string.h>
+ #include <sys/socket.h>
+ #include <sys/un.h>
+ #include <unistd.h>
+-- 
+2.30.2
+


### PR DESCRIPTION
Replaces https://github.com/OSSystems/meta-browser/pull/466