### PR TITLE
Revert "firefox: Provide symbolic link for python2.7 when firefox 68esr is built"

### DIFF
--- a/meta-firefox/classes/mozilla.bbclass
+++ b/meta-firefox/classes/mozilla.bbclass
@@ -3,7 +3,7 @@ DEPENDS += "gnu-config-native virtual/libintl libxt libxi zip-native gtk+"
 
 SRC_URI += "file://mozconfig"
 
-inherit pkgconfig pythonnative
+inherit pkgconfig
 
 EXTRA_OECONF = "--target=${TARGET_SYS} --host=${BUILD_SYS} \
                 --with-toolchain-prefix=${TARGET_SYS}- \
@@ -62,15 +62,6 @@ mozilla_do_configure() {
 }
 
 mozilla_do_compile() {
-
-	# This is a hack/workaround necessary for building firefox 68esr on
-	# Centos 7.6/Fedora
-	# It doesn't do any harm on other distros - like Ubuntu 18.04 or Debian 10
-	# Moreover, it mimics 'include pythonnative', which cannot be used as it
-	# causes errors during firefox 68esr configuration stage
-	ln -snf python-native/python2.7 ${STAGING_BINDIR_NATIVE}/python2.7
-	ln -snf python-native/python2.7 ${STAGING_BINDIR_NATIVE}/python
-
 	mozilla_run_mach build
 }
 

--- a/meta-firefox/conf/layer.conf
+++ b/meta-firefox/conf/layer.conf
@@ -4,6 +4,14 @@ BBPATH .= ":${LAYERDIR}"
 # We have a recipes directory, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
+# this is only temporary to allow building firefox on hosts without any python2
+# were it would fail like this:
+# ERROR: firefox-68.9.0esr-r0 do_configure: Execution of '/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/firefox/68.9.0esr-r0/temp/run.do_configure.2697230' failed with exit code 127:
+# ./mach: 9: exec: python: not found
+# this should be removed when firefox is upgraded to 78 ESR or newer which contains:
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1473498
+HOSTTOOLS += "python python2.7"
+
 SIGGEN_EXCLUDERECIPES_ABISAFE += " \
    firefox-addon-webconverger \
    firefox-l10n-ach \


### PR DESCRIPTION
Reverts OSSystems/meta-browser#399

It was merged by accident, I've rebased the PR and tested it locally and it definitely doesn't work for me on Ubuntu 21.04, the errors seem the same as what I've documented in https://github.com/OSSystems/meta-browser/commit/92eee5b7f42db21e9fe460fdc92c5fcce6660e6c so it looks like this symlink doesn't really help. At this point I believe it would be better for someone interested in firefox to spend time on upgrade to newer ESR 78 where python3 should work OOTB, instead of spending even more time trying to get pythonnative working here (the python/python2.7 in HOSTTOOLS works for me for long time and now with separate layer it's not so terrible temporary work around - as only people really interested in firefox will ever include meta-firefox in bblayers).