### PR TITLE
chromium: Update mallinfo patch for aarch64

### DIFF
--- a/meta-chromium/recipes-browser/chromium/files/musl/0001-mallinfo-implementation-is-glibc-specific.patch
+++ b/meta-chromium/recipes-browser/chromium/files/musl/0001-mallinfo-implementation-is-glibc-specific.patch
@@ -12,11 +12,9 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  third_party/tcmalloc/chromium/src/config_linux.h                | 2 +-
  4 files changed, 4 insertions(+), 4 deletions(-)
 
-diff --git a/base/process/process_metrics_posix.cc b/base/process/process_metrics_posix.cc
-index 9d12c427bb..7984c733c8 100644
 --- a/base/process/process_metrics_posix.cc
 +++ b/base/process/process_metrics_posix.cc
-@@ -119,7 +119,7 @@ size_t ProcessMetrics::GetMallocUsage() {
+@@ -119,7 +119,7 @@ size_t ProcessMetrics::GetMallocUsage()
    malloc_statistics_t stats = {0};
    malloc_zone_statistics(nullptr, &stats);
    return stats.size_in_use;
@@ -25,11 +23,9 @@ index 9d12c427bb..7984c733c8 100644
    struct mallinfo minfo = mallinfo();
  #if BUILDFLAG(USE_TCMALLOC)
    return minfo.uordblks;
-diff --git a/base/trace_event/malloc_dump_provider.cc b/base/trace_event/malloc_dump_provider.cc
-index 9bf8376988..e6cb89ebed 100644
 --- a/base/trace_event/malloc_dump_provider.cc
 +++ b/base/trace_event/malloc_dump_provider.cc
-@@ -184,7 +184,7 @@ bool MallocDumpProvider::OnMemoryDump(const MemoryDumpArgs& args,
+@@ -184,7 +184,7 @@ bool MallocDumpProvider::OnMemoryDump(co
    }
  #elif defined(OS_FUCHSIA)
  // TODO(fuchsia): Port, see https://crbug.com/706592.
@@ -38,8 +34,6 @@ index 9bf8376988..e6cb89ebed 100644
    struct mallinfo info = mallinfo();
    // In case of Android's jemalloc |arena| is 0 and the outer pages size is
    // reported by |hblkhd|. In case of dlmalloc the total is given by
-diff --git a/third_party/swiftshader/third_party/llvm-subzero/build/Linux/include/llvm/Config/config.h b/third_party/swiftshader/third_party/llvm-subzero/build/Linux/include/llvm/Config/config.h
-index 2f860e1286..d99a22ad1b 100644
 --- a/third_party/swiftshader/third_party/llvm-subzero/build/Linux/include/llvm/Config/config.h
 +++ b/third_party/swiftshader/third_party/llvm-subzero/build/Linux/include/llvm/Config/config.h
 @@ -130,7 +130,7 @@
@@ -47,12 +41,10 @@ index 2f860e1286..d99a22ad1b 100644
  
  /* Define to 1 if you have the `mallinfo' function. */
 -#define HAVE_MALLINFO 1
-+/* #define HAVE_MALLINFO 1 */
++/* #undef HAVE_MALLINFO */
  
  /* Define to 1 if you have the <malloc.h> header file. */
  #define HAVE_MALLOC_H 1
-diff --git a/third_party/tcmalloc/chromium/src/config_linux.h b/third_party/tcmalloc/chromium/src/config_linux.h
-index 4e8e3989eb..93a62a2d82 100644
 --- a/third_party/tcmalloc/chromium/src/config_linux.h
 +++ b/third_party/tcmalloc/chromium/src/config_linux.h
 @@ -152,7 +152,7 @@
@@ -64,3 +56,14 @@ index 4e8e3989eb..93a62a2d82 100644
  
  /* Define to 1 if you have the <sys/cdefs.h> header file. */
  #define HAVE_SYS_CDEFS_H 1
+--- a/third_party/swiftshader/third_party/llvm-10.0/configs/linux/include/llvm/Config/config.h
++++ b/third_party/swiftshader/third_party/llvm-10.0/configs/linux/include/llvm/Config/config.h
+@@ -125,7 +125,7 @@
+ /* #undef HAVE_MALLCTL */
+ 
+ /* Define to 1 if you have the `mallinfo' function. */
+-#define HAVE_MALLINFO 1
++/* #undef HAVE_MALLINFO */
+ 
+ /* Define to 1 if you have the <malloc/malloc.h> header file. */
+ /* #undef HAVE_MALLOC_MALLOC_H */


### PR DESCRIPTION
while building for aarch64 ran into a case where HAVE_MALLINFO was
hardcoded, undefine it for musl like other places as well.

Signed-off-by: Khem Raj <raj.khem@gmail.com>