### PR TITLE
chromium: Always use LLD for linking

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -159,9 +159,8 @@ GN_ARGS += "is_debug=false is_official_build=true"
 # https://groups.google.com/a/chromium.org/d/msg/chromium-packagers/8aYO3me2SCE/SZ8pJXhZAwAJ
 GN_ARGS += "use_custom_libcxx=false"
 
-# When using meta-clang, one can switch to using the lld linker
-# by using the ld-is-lld distro feature otherwise use gold linker
-GN_ARGS += "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-lld', 'use_lld=true use_gold=false', 'use_lld=false use_gold=true', d)}"
+# Use lld linker its quicker see https://lld.llvm.org/#performance
+GN_ARGS += "use_lld=true use_gold=false"
 
 # By default, passing is_official_build=true to GN causes its symbol_level
 # variable to be set to "2". This means the compiler will be passed "-g2" and


### PR DESCRIPTION
Its well supported on arm/x86/aarch64 architectures
and is faster to link see [1]

[1] https://lld.llvm.org/#performance

Signed-off-by: Khem Raj <raj.khem@gmail.com>