### PR TITLE
chromium: Add opengl to REQUIRED_DISTRO_FEATURES

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -45,6 +45,8 @@ SRC_URI_append_libc-musl = "\
     file://musl/0020-Fix-tab-crashes-on-musl.patch \
 "
 
+ANY_OF_DISTRO_FEATURES = "opengl vulkan"
+
 # Append instead of assigning; the gtk-icon-cache class inherited above also
 # adds packages to DEPENDS.
 DEPENDS += " \


### PR DESCRIPTION
Chromium depends on virtual/libgl,
which oe-core provides by default in mesa.

opengl or vulkan is a REQUIRED_DISTRO_FEATURES for mesa.

In a minimal build of oe-core + meta-oe + meta-python2,
bitbake would complain that nothing provides
virtual/libgl, virtual/libgles2.

Also makes meta-chromium pass yocto-check-layer.

Signed-off-by: Yi Fan Yu <yifan.yu@windriver.com>