### PR TITLE
chromium: Add UPower to RDPENDS

### DIFF
--- a/meta-chromium/README.md
+++ b/meta-chromium/README.md
@@ -117,6 +117,10 @@ PACKAGECONFIG knobs
   also be enabled. Please note that not all the possible hardware configs are
   tested and supported.
 
+* upower: (on by default)
+  Chromium expects the presence of `org.freedesktop.UPower` via D-Bus to
+  query battery status. If disabled, there will be warning messages seen on
+  stderr and Battery Status Web API will not work.
 
 Google API keys
 ---------------

--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -106,7 +106,7 @@ BUILD_CC:toolchain-clang = "clang"
 BUILD_CXX:toolchain-clang = "clang++"
 BUILD_LD:toolchain-clang = "clang"
 
-PACKAGECONFIG ??= "use-egl"
+PACKAGECONFIG ??= "upower use-egl"
 
 # this makes sure the dependencies for the EGL mode are present; otherwise, the configure scripts
 # automatically and silently fall back to GLX
@@ -123,6 +123,9 @@ PACKAGECONFIG[proprietary-codecs] = ' \
         ffmpeg_branding="Chrome" proprietary_codecs=true, \
         ffmpeg_branding="Chromium" proprietary_codecs=false \
 '
+# Enable UPower by default.
+# Chromium expects to be able to query battery status through D-Bus.
+PACKAGECONFIG[upower] = ",,,upower"
 
 # Disable VA-API by default. It is compile time enabled since M88, but it's not
 # desired to make all the users of the Chromium meta-browser recipe depend on


### PR DESCRIPTION
Chromium uses D-Bus to communicate with UPower.
It uses it to query battery among many things.
see:
    services/device/battery/battery_status_manager_linux.cc

Fixes error/warning messages related to UPower:
```
Failed to call method: org.freedesktop.UPower.GetDisplayDevice
The name org.freedesktop.UPower was not provided by any .service files
```

Signed-off-by: Yi Fan Yu <yifan.yu@windriver.com>