### PR TITLE
chromium: Remove impl-side-painting PACKAGECONFIG knob.

### DIFF
--- a/meta-chromium/README.md
+++ b/meta-chromium/README.md
@@ -94,12 +94,6 @@ PACKAGECONFIG knobs
 * cups: (off by default)
   Enables CUPS support in Chromium, and adds a dependency on the "cups" recipe.
 
-* impl-side-painting: (off by default)
-  This is a new painting mechanism. Still in development stages, it can improve
-  performance See
-  http://www.chromium.org/developers/design-documents/impl-side-painting for
-  more.
-
 * kiosk-mode: (off by default)
   Enable this option if you want your browser to start up full-screen, without
   any menu bars, without any clutter, and without any initial start-up

--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -111,7 +111,6 @@ PACKAGECONFIG[use-egl] = ",,virtual/egl virtual/libgles2"
 # be necessary but are OK to add).
 PACKAGECONFIG[component-build] = ""
 PACKAGECONFIG[cups] = "use_cups=true,use_cups=false,cups"
-PACKAGECONFIG[impl-side-painting] = ""
 PACKAGECONFIG[kiosk-mode] = ""
 PACKAGECONFIG[proprietary-codecs] = ' \
         ffmpeg_branding="Chrome" proprietary_codecs=true, \
@@ -312,7 +311,6 @@ GN_ARGS_append_libc-musl = ' use_allocator_shim=false'
 
 CHROMIUM_EXTRA_ARGS ?= " \
         ${@bb.utils.contains('PACKAGECONFIG', 'use-egl', '--use-gl=egl', '', d)} \
-        ${@bb.utils.contains('PACKAGECONFIG', 'impl-side-painting', '--enable-gpu-rasterization --enable-impl-side-painting', '', d)} \
         ${@bb.utils.contains('PACKAGECONFIG', 'kiosk-mode', '--kiosk --no-first-run --incognito', '', d)} \
 "
 


### PR DESCRIPTION
This knob was added back in 2014 in commit fb6df963376c ("chromium: Add
recipe for version 37.0.2062.0"). Multithreaded rasterization was under
development back then, but this hasn't been the case since M39 and M40 (see
https://crbug.com/169282 and https://crbug.com/413479).

Given multithreaded rasterization was enabled by default in 2015, the
--enable-impl-side-painting was removed around that time and that this knob
was off by default, it should be safe to remove it altogether.