### PR TITLE
chromium: fix various build errors

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -20,6 +20,9 @@ SRC_URI += " \
     file://0012-Fix-font-rendering-with-glibc-2.33.patch \
     file://0001-nomerge-attribute-on-declaration-is-only-available-s.patch \
     file://0001-Fixed-build-with-use_ozone-false.patch \
+    file://fix-harfbuzz-supp-size-error.patch \
+    file://fix-ruy-numeric-limits-error.patch \
+    file://fix-sql-virtualcursor-error.patch \
 "
 
 SRC_URI_append_libc-musl = "\

--- a/meta-chromium/recipes-browser/chromium/files/fix-harfbuzz-supp-size-error.patch
+++ b/meta-chromium/recipes-browser/chromium/files/fix-harfbuzz-supp-size-error.patch
@@ -1,0 +1,49 @@
+From 243d056ff1c2af583ceb67e5dfbfaac51dc96e63 Mon Sep 17 00:00:00 2001
+From: Andi-Bogdan Postelnicu <abpostelnicu@me.com>
+Date: Wed, 2 Jun 2021 14:08:11 +0300
+Subject: [PATCH] Removed unused variable `supp_size` from
+ plan_subset_encoding(...).
+
+Builds with the latest layers fail as a result of stricter compiler
+checks. This patch backports a fix upstream to remove an unused variable
+which casues the build error. 
+
+Upstream-Status: Backport [https://github.com/harfbuzz/harfbuzz/commit/243d056ff1c2af583ceb67e5dfbfaac51dc96e63]
+
+Signed-off-by: Tony Tascioglu <tony.tascioglu@windriver.com>
+---
+ third_patry/harfbuzz-ng/src/src/hb-subset-cff1.cc | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/third_party/harfbuzz-ng/src/src/hb-subset-cff1.cc b/third_party/harfbuzz-ng/src/src/hb-subset-cff1.cc
+index df322f845..35dae7b1f 100644
+--- a/third_party/harfbuzz-ng/src/src/hb-subset-cff1.cc
++++ b/third_party/harfbuzz-ng/src/src/hb-subset-cff1.cc
+@@ -402,7 +402,7 @@ struct cff_subset_plan {
+   void plan_subset_encoding (const OT::cff1::accelerator_subset_t &acc, hb_subset_plan_t *plan)
+   {
+     const Encoding *encoding = acc.encoding;
+-    unsigned int  size0, size1, supp_size;
++    unsigned int  size0, size1;
+     hb_codepoint_t  code, last_code = CFF_UNDEF_CODE;
+     hb_vector_t<hb_codepoint_t> supp_codes;
+ 
+@@ -412,7 +412,6 @@ struct cff_subset_plan {
+       return;
+     }
+ 
+-    supp_size = 0;
+     supp_codes.init ();
+ 
+     subset_enc_num_codes = plan->num_output_glyphs () - 1;
+@@ -448,7 +447,6 @@ struct cff_subset_plan {
+ 	  code_pair_t pair = { supp_codes[i], sid };
+ 	  subset_enc_supp_codes.push (pair);
+ 	}
+-	supp_size += SuppEncoding::static_size * supp_codes.length;
+       }
+     }
+     supp_codes.fini ();
+-- 
+2.32.0
+

--- a/meta-chromium/recipes-browser/chromium/files/fix-ruy-numeric-limits-error.patch
+++ b/meta-chromium/recipes-browser/chromium/files/fix-ruy-numeric-limits-error.patch
@@ -1,0 +1,31 @@
+From 3c93cda8211efa01128d48950f0d6ee5233c5b9b Mon Sep 17 00:00:00 2001
+From: stha09 <51720730+stha09@users.noreply.github.com>
+Date: Thu, 6 May 2021 18:31:30 +0200
+Subject: [PATCH] IWYU: include limits for std::numeric_limits (#253)
+
+Builds with the latest layers fail as a result of stricter compiler
+checks. This patch backports a fix for a missing include statement in
+the third party dependency on ruy.
+
+Upstream-Status: Backport [https://github.com/google/ruy/commit/3c93cda8211efa01128d48950f0d6ee5233c5b9b]
+
+Signed-off-by: Tony Tascioglu <tony.tascioglu@windriver.com>
+---
+ third_party/ruy/src/ruy/block_map.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/third_party/ruy/src/ruy/block_map.cc b/third_party/ruy/src/ruy/block_map.cc
+index 6c01e52..e04e7af 100644
+--- a/third_party/ruy/src/ruy/block_map.cc
++++ b/third_party/ruy/src/ruy/block_map.cc
+@@ -17,6 +17,7 @@ limitations under the License.
+ 
+ #include <algorithm>
+ #include <cstdint>
++#include <limits>
+ 
+ #ifdef RUY_MAKEBLOCKMAP_DEBUG
+ #include <cstdio>
+-- 
+2.31.1
+

--- a/meta-chromium/recipes-browser/chromium/files/fix-sql-virtualcursor-error.patch
+++ b/meta-chromium/recipes-browser/chromium/files/fix-sql-virtualcursor-error.patch
@@ -1,0 +1,238 @@
+From 80368f8ba7a8bab13440463a254888311efe3986 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Tue, 04 May 2021 15:00:19 +0000
+Subject: [PATCH] sql: make VirtualCursor standard layout type
+
+sql::recover::VirtualCursor needs to be a standard layout type, but
+has members of type std::unique_ptr. However, std::unique_ptr is not
+guaranteed to be standard layout. Compiling with clang combined with
+gcc-11 libstdc++ fails because of this. Replace std::unique_ptr with
+raw pointers.
+
+Bug: 1189788
+Change-Id: Ia6dc388cc5ef1c0f2afc75f8ca45b9f12687ca9c
+
+This patch from ungoogled-chromium addresses a build error with
+cursor.cc in sql/recover/module.
+
+Upstream-Status: Pending [https://github.com/ungoogled-software/ungoogled-chromium-archlinux/blob/master/sql-VirtualCursor-standard-layout.patch]
+
+Signed-off-by: Tony Tascioglu <tony.tascioglu@windriver.com>
+---
+
+diff --git a/sql/recover_module/btree.cc b/sql/recover_module/btree.cc
+index 9ecaafe..839318a 100644
+--- a/sql/recover_module/btree.cc
++++ b/sql/recover_module/btree.cc
+@@ -135,16 +135,25 @@
+               "Move the destructor to the .cc file if it's non-trival");
+ #endif  // !DCHECK_IS_ON()
+ 
+-LeafPageDecoder::LeafPageDecoder(DatabasePageReader* db_reader) noexcept
+-    : page_id_(db_reader->page_id()),
+-      db_reader_(db_reader),
+-      cell_count_(ComputeCellCount(db_reader)),
+-      next_read_index_(0),
+-      last_record_size_(0) {
++void LeafPageDecoder::Initialize(DatabasePageReader* db_reader) {
++  DCHECK(db_reader);
+   DCHECK(IsOnValidPage(db_reader));
++  page_id_ = db_reader->page_id();
++  db_reader_ = db_reader;
++  cell_count_ = ComputeCellCount(db_reader);
++  next_read_index_ = 0;
++  last_record_size_ = 0;
+   DCHECK(DatabasePageReader::IsValidPageId(page_id_));
+ }
+ 
++void LeafPageDecoder::Reset() {
++  db_reader_ = nullptr;
++  page_id_ = 0;
++  cell_count_ = 0;
++  next_read_index_ = 0;
++  last_record_size_ = 0;
++}
++
+ bool LeafPageDecoder::TryAdvance() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   DCHECK(CanAdvance());
+diff --git a/sql/recover_module/btree.h b/sql/recover_module/btree.h
+index d76d076..33114b0 100644
+--- a/sql/recover_module/btree.h
++++ b/sql/recover_module/btree.h
+@@ -102,7 +102,7 @@
+   //
+   // |db_reader| must have been used to read an inner page of a table B-tree.
+   // |db_reader| must outlive this instance.
+-  explicit LeafPageDecoder(DatabasePageReader* db_reader) noexcept;
++  explicit LeafPageDecoder() noexcept = default;
+   ~LeafPageDecoder() noexcept = default;
+ 
+   LeafPageDecoder(const LeafPageDecoder&) = delete;
+@@ -150,6 +150,15 @@
+   // read as long as CanAdvance() returns true.
+   bool TryAdvance();
+ 
++  // Initialize with DatabasePageReader
++  void Initialize(DatabasePageReader* db_reader);
++
++  // Reset internal DatabasePageReader
++  void Reset();
++
++  // True if DatabasePageReader is valid
++  bool IsValid() { return (db_reader_ != nullptr); }
++
+   // True if the given reader may point to an inner page in a table B-tree.
+   //
+   // The last ReadPage() call on |db_reader| must have succeeded.
+@@ -163,14 +172,14 @@
+   static int ComputeCellCount(DatabasePageReader* db_reader);
+ 
+   // The number of the B-tree page this reader is reading.
+-  const int64_t page_id_;
++  int64_t page_id_;
+   // Used to read the tree page.
+   //
+   // Raw pointer usage is acceptable because this instance's owner is expected
+   // to ensure that the DatabasePageReader outlives this.
+-  DatabasePageReader* const db_reader_;
++  DatabasePageReader* db_reader_;
+   // Caches the ComputeCellCount() value for this reader's page.
+-  const int cell_count_ = ComputeCellCount(db_reader_);
++  int cell_count_;
+ 
+   // The reader's cursor state.
+   //
+diff --git a/sql/recover_module/cursor.cc b/sql/recover_module/cursor.cc
+index 0029ff9..42548bc 100644
+--- a/sql/recover_module/cursor.cc
++++ b/sql/recover_module/cursor.cc
+@@ -26,7 +26,7 @@
+ int VirtualCursor::First() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   inner_decoders_.clear();
+-  leaf_decoder_ = nullptr;
++  leaf_decoder_.Reset();
+ 
+   AppendPageDecoder(table_->root_page_id());
+   return Next();
+@@ -36,18 +36,18 @@
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   record_reader_.Reset();
+ 
+-  while (!inner_decoders_.empty() || leaf_decoder_.get()) {
+-    if (leaf_decoder_.get()) {
+-      if (!leaf_decoder_->CanAdvance()) {
++  while (!inner_decoders_.empty() || leaf_decoder_.IsValid()) {
++    if (leaf_decoder_.IsValid()) {
++      if (!leaf_decoder_.CanAdvance()) {
+         // The leaf has been exhausted. Remove it from the DFS stack.
+-        leaf_decoder_ = nullptr;
++        leaf_decoder_.Reset();
+         continue;
+       }
+-      if (!leaf_decoder_->TryAdvance())
++      if (!leaf_decoder_.TryAdvance())
+         continue;
+ 
+-      if (!payload_reader_.Initialize(leaf_decoder_->last_record_size(),
+-                                      leaf_decoder_->last_record_offset())) {
++      if (!payload_reader_.Initialize(leaf_decoder_.last_record_size(),
++                                      leaf_decoder_.last_record_offset())) {
+         continue;
+       }
+       if (!record_reader_.Initialize())
+@@ -99,13 +99,13 @@
+ int64_t VirtualCursor::RowId() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   DCHECK(record_reader_.IsInitialized());
+-  DCHECK(leaf_decoder_.get());
+-  return leaf_decoder_->last_record_rowid();
++  DCHECK(leaf_decoder_.IsValid());
++  return leaf_decoder_.last_record_rowid();
+ }
+ 
+ void VirtualCursor::AppendPageDecoder(int page_id) {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+-  DCHECK(leaf_decoder_.get() == nullptr)
++  DCHECK(!leaf_decoder_.IsValid())
+       << __func__
+       << " must only be called when the current path has no leaf decoder";
+ 
+@@ -113,7 +113,7 @@
+     return;
+ 
+   if (LeafPageDecoder::IsOnValidPage(&db_reader_)) {
+-    leaf_decoder_ = std::make_unique<LeafPageDecoder>(&db_reader_);
++    leaf_decoder_.Initialize(&db_reader_);
+     return;
+   }
+ 
+diff --git a/sql/recover_module/cursor.h b/sql/recover_module/cursor.h
+index afcd690..b15c31d 100644
+--- a/sql/recover_module/cursor.h
++++ b/sql/recover_module/cursor.h
+@@ -129,7 +129,7 @@
+   std::vector<std::unique_ptr<InnerPageDecoder>> inner_decoders_;
+ 
+   // Decodes the leaf page containing records.
+-  std::unique_ptr<LeafPageDecoder> leaf_decoder_;
++  LeafPageDecoder leaf_decoder_;
+ 
+   SEQUENCE_CHECKER(sequence_checker_);
+ };
+diff --git a/sql/recover_module/pager.cc b/sql/recover_module/pager.cc
+index 58e75de..5fe9620 100644
+--- a/sql/recover_module/pager.cc
++++ b/sql/recover_module/pager.cc
+@@ -23,8 +23,7 @@
+               "ints are not appropriate for representing page IDs");
+ 
+ DatabasePageReader::DatabasePageReader(VirtualTable* table)
+-    : page_data_(std::make_unique<uint8_t[]>(table->page_size())),
+-      table_(table) {
++    : page_data_(), table_(table) {
+   DCHECK(table != nullptr);
+   DCHECK(IsValidPageSize(table->page_size()));
+ }
+@@ -57,8 +56,8 @@
+                     std::numeric_limits<int64_t>::max(),
+                 "The |read_offset| computation above may overflow");
+ 
+-  int sqlite_status =
+-      RawRead(sqlite_file, read_size, read_offset, page_data_.get());
++  int sqlite_status = RawRead(sqlite_file, read_size, read_offset,
++                              const_cast<uint8_t*>(page_data_.data()));
+ 
+   // |page_id_| needs to be set to kInvalidPageId if the read failed.
+   // Otherwise, future ReadPage() calls with the previous |page_id_| value
+diff --git a/sql/recover_module/pager.h b/sql/recover_module/pager.h
+index 0e388ddc..99314e3 100644
+--- a/sql/recover_module/pager.h
++++ b/sql/recover_module/pager.h
+@@ -5,6 +5,7 @@
+ #ifndef SQL_RECOVER_MODULE_PAGER_H_
+ #define SQL_RECOVER_MODULE_PAGER_H_
+ 
++#include <array>
+ #include <cstdint>
+ #include <memory>
+ 
+@@ -70,7 +71,7 @@
+     DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+     DCHECK_NE(page_id_, kInvalidPageId)
+         << "Successful ReadPage() required before accessing pager state";
+-    return page_data_.get();
++    return page_data_.data();
+   }
+ 
+   // The number of bytes in the page read by the last ReadPage() call.
+@@ -137,7 +138,7 @@
+   int page_id_ = kInvalidPageId;
+   // Stores the bytes of the last page successfully read by ReadPage().
+   // The content is undefined if the last call to ReadPage() did not succeed.
+-  const std::unique_ptr<uint8_t[]> page_data_;
++  const std::array<uint8_t, kMaxPageSize> page_data_;
+   // Raw pointer usage is acceptable because this instance's owner is expected
+   // to ensure that the VirtualTable outlives this.
+   VirtualTable* const table_;


### PR DESCRIPTION
Fix several errors during build due to stricter clang builds.
  - unused variable error in harfbuzz third party dependency
  - missing include in ruy third party dependency
  - virtualcursor error in sql/recover_module/cursor.cc

The third party fixes are back-ported from upstream.
The virtualcursor patch is from ungoogled-chromium.

Fixes #517

Signed-off-by: Tony Tascioglu <tony.tascioglu@windriver.com>