### PR TITLE
chromium: Fix tab crashes due to stack overflow on musl

### DIFF
--- a/meta-chromium/recipes-browser/chromium/files/musl/0001-mallinfo-implementation-is-glibc-specific.patch
+++ b/meta-chromium/recipes-browser/chromium/files/musl/0001-mallinfo-implementation-is-glibc-specific.patch
@@ -6,32 +6,48 @@ Subject: [PATCH] mallinfo implementation is glibc specific
 Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 ---
- base/process/process_metrics_posix.cc                           | 2 +-
- base/trace_event/malloc_dump_provider.cc                        | 2 +-
- .../llvm-subzero/build/Linux/include/llvm/Config/config.h       | 2 +-
- third_party/tcmalloc/chromium/src/config_linux.h                | 2 +-
- 4 files changed, 4 insertions(+), 4 deletions(-)
+--- a/third_party/tflite/src/tensorflow/lite/profiling/memory_info.cc
++++ b/third_party/tflite/src/tensorflow/lite/profiling/memory_info.cc
+@@ -35,7 +35,7 @@ bool MemoryUsage::IsSupported() {
 
+ MemoryUsage GetMemoryUsage() {
+   MemoryUsage result;
+-#ifdef __linux__
++#if defined(__linux__) && defined(__GLIBC__)
+   rusage res;
+   if (getrusage(RUSAGE_SELF, &res) == 0) {
+     result.max_rss_kb = res.ru_maxrss;
 --- a/base/process/process_metrics_posix.cc
 +++ b/base/process/process_metrics_posix.cc
 @@ -105,7 +105,7 @@ void IncreaseFdLimitTo(unsigned int max_
- 
+
  #endif  // !defined(OS_FUCHSIA)
- 
+
 -#if defined(OS_LINUX) || defined(OS_CHROMEOS) || defined(OS_ANDROID)
-+#if defined(__GLIBC__) || defined(OS_CHROMEOS) || defined(OS_ANDROID)
++#if (defined(OS_LINUX) && defined(__GLIBC__)) || defined(OS_CHROMEOS) || defined(OS_ANDROID)
  namespace {
- 
+
  size_t GetMallocUsageMallinfo() {
-@@ -134,7 +134,7 @@ size_t ProcessMetrics::GetMallocUsage()
+@@ -127,16 +127,16 @@ size_t GetMallocUsageMallinfo() {
+ }
+
+ }  // namespace
+-#endif  // defined(OS_LINUX) || defined(OS_CHROMEOS) || defined(OS_ANDROID)
++#endif  // (defined(OS_LINUX) && defined(__GLIBC__)) || defined(OS_CHROMEOS) || defined(OS_ANDROID)
+
+ size_t ProcessMetrics::GetMallocUsage() {
+ #if defined(OS_APPLE)
    malloc_statistics_t stats = {0};
    malloc_zone_statistics(nullptr, &stats);
    return stats.size_in_use;
 -#elif defined(OS_LINUX) || defined(OS_CHROMEOS) || defined(OS_ANDROID)
-+#elif defined(__GLIBC__) || defined(OS_CHROMEOS) || defined(OS_ANDROID)
++#elif (defined(OS_LINUX) && defined(__GLIBC__)) || defined(OS_CHROMEOS) || defined(OS_ANDROID)
    return GetMallocUsageMallinfo();
- #elif defined(OS_FUCHSIA)
+-#elif defined(OS_FUCHSIA)
++#else
    // TODO(fuchsia): Not currently exposed. https://crbug.com/735087.
+   return 0;
+ #endif
 --- a/base/trace_event/malloc_dump_provider.cc
 +++ b/base/trace_event/malloc_dump_provider.cc
 @@ -203,7 +203,7 @@ bool MallocDumpProvider::OnMemoryDump(co
@@ -47,61 +63,10 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
 +++ b/third_party/swiftshader/third_party/llvm-subzero/build/Linux/include/llvm/Config/config.h
 @@ -130,7 +130,7 @@
  /* #undef HAVE_MALLCTL */
- 
+
  /* Define to 1 if you have the `mallinfo' function. */
 -#define HAVE_MALLINFO 1
 +/* #undef HAVE_MALLINFO */
- 
+
  /* Define to 1 if you have the <malloc.h> header file. */
  #define HAVE_MALLOC_H 1
---- a/third_party/tcmalloc/chromium/src/config_linux.h
-+++ b/third_party/tcmalloc/chromium/src/config_linux.h
-@@ -152,7 +152,7 @@
- #define HAVE_STRING_H 1
- 
- /* Define to 1 if the system has the type `struct mallinfo'. */
--#define HAVE_STRUCT_MALLINFO 1
-+/* #undef HAVE_STRUCT_MALLINFO */
- 
- /* Define to 1 if you have the <sys/cdefs.h> header file. */
- #define HAVE_SYS_CDEFS_H 1
---- a/third_party/swiftshader/third_party/llvm-10.0/configs/linux/include/llvm/Config/config.h
-+++ b/third_party/swiftshader/third_party/llvm-10.0/configs/linux/include/llvm/Config/config.h
-@@ -125,7 +125,7 @@
- /* #undef HAVE_MALLCTL */
- 
- /* Define to 1 if you have the `mallinfo' function. */
--#define HAVE_MALLINFO 1
-+/* #undef HAVE_MALLINFO */
- 
- /* Define to 1 if you have the <malloc/malloc.h> header file. */
- /* #undef HAVE_MALLOC_MALLOC_H */
---- a/third_party/tflite/src/tensorflow/lite/profiling/memory_info.cc
-+++ b/third_party/tflite/src/tensorflow/lite/profiling/memory_info.cc
-@@ -14,7 +14,7 @@ limitations under the License.
- ==============================================================================*/
- #include "tensorflow/lite/profiling/memory_info.h"
- 
--#ifdef __linux__
-+#ifdef __GLIBC__
- #include <malloc.h>
- #include <sys/resource.h>
- #include <sys/time.h>
-@@ -27,7 +27,7 @@ namespace memory {
- const int MemoryUsage::kValueNotSet = 0;
- 
- bool MemoryUsage::IsSupported() {
--#ifdef __linux__
-+#ifdef __GLIBC__
-   return true;
- #endif
-   return false;
-@@ -35,7 +35,7 @@ bool MemoryUsage::IsSupported() {
- 
- MemoryUsage GetMemoryUsage() {
-   MemoryUsage result;
--#ifdef __linux__
-+#ifdef __GLIBC__
-   rusage res;
-   if (getrusage(RUSAGE_SELF, &res) == 0) {
-     result.max_rss_kb = res.ru_maxrss;

--- a/meta-chromium/recipes-browser/chromium/files/musl/0006-fontconfig-Musl-does-not-have-rand_r-API.patch
+++ b/meta-chromium/recipes-browser/chromium/files/musl/0006-fontconfig-Musl-does-not-have-rand_r-API.patch
@@ -1,7 +1,7 @@
 From da6183c75d9b4f0f77ea0bee460315697302f23c Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 13 Feb 2019 09:51:14 -0800
-Subject: [PATCH] fontconfig: Musl does not have rand_r() API
+Subject: [PATCH] fontconfig: Musl does not have random_r() API
 
 Mark it to be glibc specific
 
@@ -11,24 +11,14 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  third_party/fontconfig/include/config.h | 9 ++++++---
  1 file changed, 6 insertions(+), 3 deletions(-)
 
-diff --git a/third_party/fontconfig/include/config.h b/third_party/fontconfig/include/config.h
-index 9087ca0c15..265e69248f 100644
 --- a/third_party/fontconfig/include/config.h
 +++ b/third_party/fontconfig/include/config.h
-@@ -157,10 +157,13 @@
+@@ -157,7 +157,7 @@
  #define HAVE_RANDOM 1
- 
+
  /* Define to 1 if you have the `random_r' function. */
 -#define HAVE_RANDOM_R 1
--
-+#ifdef __GLIBC__
-+# define HAVE_RANDOM_R 1
-+#endif
++/* #undef HAVE_RANDOM_R */
+
  /* Define to 1 if you have the `rand_r' function. */
--#define HAVE_RAND_R 1
-+#ifdef __GLIBC__
-+# define HAVE_RAND_R 1
-+#endif
- 
- /* Define to 1 if you have the `readlink' function. */
- #define HAVE_READLINK 1
+ #define HAVE_RAND_R 1

--- a/meta-chromium/recipes-browser/chromium/files/musl/0009-provide-res_ninit-and-nclose-APIs-on-non-glibc-linux.patch
+++ b/meta-chromium/recipes-browser/chromium/files/musl/0009-provide-res_ninit-and-nclose-APIs-on-non-glibc-linux.patch
@@ -9,124 +9,63 @@ These APIs are not implemented on musl
 Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 ---
- net/dns/dns_config_service_posix.cc | 30 +++++++++++++++++++++++++++++
- net/dns/dns_reloader.cc             | 30 +++++++++++++++++++++++++++++
- 2 files changed, 60 insertions(+)
-
---- a/net/dns/dns_config_service_posix.cc
-+++ b/net/dns/dns_config_service_posix.cc
-@@ -32,6 +32,36 @@
- #include "net/dns/dns_config_watcher_mac.h"
- #endif
- 
-+#if !defined(__GLIBC__)
-+/***************************************************************************
-+ * resolv_compat.h
-+ *
-+ * Mimick GLIBC's res_ninit() and res_nclose() for musl libc
-+ * Note: res_init() is actually deprecated according to
-+ * http://docs.oracle.com/cd/E36784_01/html/E36875/res-nclose-3resolv.html
-+ **************************************************************************/
-+#include <string.h>
-+
-+static inline int res_ninit(res_state statp)
-+{
-+	int rc = res_init();
-+	if (statp != &_res) {
-+		memcpy(statp, &_res, sizeof(*statp));
-+	}
-+	return rc;
-+}
-+
-+static inline int res_nclose(res_state statp)
-+{
-+	if (!statp)
-+		return -1;
-+	if (statp != &_res) {
-+		memset(statp, 0, sizeof(*statp));
-+	}
-+	return 0;
-+}
-+#endif
-+
- namespace net {
- 
- namespace internal {
 --- a/net/dns/dns_reloader.cc
 +++ b/net/dns/dns_reloader.cc
-@@ -17,6 +17,36 @@
- #include "base/threading/thread_local.h"
- #include "net/base/network_change_notifier.h"
+@@ -4,8 +4,7 @@
  
-+#if !defined(__GLIBC__)
-+/***************************************************************************
-+ * resolv_compat.h
-+ *
-+ * Mimick GLIBC's res_ninit() and res_nclose() for musl libc
-+ * Note: res_init() is actually deprecated according to
-+ * http://docs.oracle.com/cd/E36784_01/html/E36875/res-nclose-3resolv.html
-+ **************************************************************************/
-+#include <string.h>
-+
-+static inline int res_ninit(res_state statp)
-+{
-+	int rc = res_init();
-+	if (statp != &_res) {
-+		memcpy(statp, &_res, sizeof(*statp));
-+	}
-+	return rc;
-+}
-+
-+static inline int res_nclose(res_state statp)
-+{
-+	if (!statp)
-+		return -1;
-+	if (statp != &_res) {
-+		memset(statp, 0, sizeof(*statp));
-+	}
-+	return 0;
-+}
-+#endif
-+
- namespace net {
+ #include "net/dns/dns_reloader.h"
  
- namespace {
+-#if defined(OS_POSIX) && !defined(OS_APPLE) && !defined(OS_OPENBSD) && \
+-    !defined(OS_ANDROID) && !defined(OS_FUCHSIA)
++#if defined(__GLIBC__)
+ 
+ #include <resolv.h>
+ 
+--- a/net/dns/host_resolver_manager.cc
++++ b/net/dns/host_resolver_manager.cc
+@@ -2536,8 +2536,7 @@ HostResolverManager::HostResolverManager
+   NetworkChangeNotifier::AddConnectionTypeObserver(this);
+   if (system_dns_config_notifier_)
+     system_dns_config_notifier_->AddObserver(this);
+-#if defined(OS_POSIX) && !defined(OS_APPLE) && !defined(OS_OPENBSD) && \
+-    !defined(OS_ANDROID)
++#if defined(__GLIBC__)
+   EnsureDnsReloaderInit();
+ #endif
+ 
+--- a/net/dns/host_resolver_proc.cc
++++ b/net/dns/host_resolver_proc.cc
+@@ -176,8 +176,7 @@ int SystemHostResolverCall(const std::st
+   base::ScopedBlockingCall scoped_blocking_call(FROM_HERE,
+                                                 base::BlockingType::WILL_BLOCK);
+ 
+-#if defined(OS_POSIX) && !defined(OS_APPLE) && !defined(OS_OPENBSD) && \
+-    !defined(OS_ANDROID) && !defined(OS_FUCHSIA)
++#if defined(__GLIBC__)
+   DnsReloaderMaybeReload();
+ #endif
+   absl::optional<AddressInfo> ai;
 --- a/net/dns/dns_config_service_linux.cc
 +++ b/net/dns/dns_config_service_linux.cc
-@@ -35,6 +35,36 @@
- #include "net/dns/serial_worker.h"
- #include "third_party/abseil-cpp/absl/types/optional.h"
+@@ -486,20 +486,11 @@ class DnsConfigServiceLinux::ConfigReade
  
-+#if !defined(__GLIBC__)
-+/***************************************************************************
-+ * resolv_compat.h
-+ *
-+ * Mimick GLIBC's res_ninit() and res_nclose() for musl libc
-+ * Note: res_init() is actually deprecated according to
-+ * http://docs.oracle.com/cd/E36784_01/html/E36875/res-nclose-3resolv.html
-+ **************************************************************************/
-+#include <string.h>
-+
-+static inline int res_ninit(res_state statp)
-+{
-+       int rc = res_init();
-+       if (statp != &_res) {
-+               memcpy(statp, &_res, sizeof(*statp));
-+       }
-+       return rc;
-+}
-+
-+static inline int res_nclose(res_state statp)
-+{
-+       if (!statp)
-+               return -1;
-+       if (statp != &_res) {
-+               memset(statp, 0, sizeof(*statp));
-+       }
-+       return 0;
-+}
-+#endif
-+
- namespace net {
+ std::unique_ptr<struct __res_state>
+ DnsConfigServiceLinux::ResolvReader::GetResState() {
+-  auto res = std::make_unique<struct __res_state>();
+-  memset(res.get(), 0, sizeof(struct __res_state));
+-
+-  if (res_ninit(res.get()) != 0) {
+-    CloseResState(res.get());
+-    return nullptr;
+-  }
+-
+-  return res;
++  return nullptr;
+ }
  
- namespace internal {
+ void DnsConfigServiceLinux::ResolvReader::CloseResState(
+     struct __res_state* res) {
+-  res_nclose(res);
+ }
+ 
+ DnsConfigServiceLinux::DnsConfigServiceLinux()


### PR DESCRIPTION
These patches are musl specific and are refreshed to fix mainly the
problem with stack overflow which was happening due to crash in thread
stack from code using mallinfo, we have to disable mallinfo using
codepaths completely.

rand_r() API is available in musl so there is no need to disable it

providing res_ninit/res_nclose using obsolete APIs is not good solution
so do not use these APIs on musl

chromium works like a charm on musl now ( tested on x86_64/qemu )

Signed-off-by: Khem Raj <raj.khem@gmail.com>