### PR TITLE
chromium-gn: respect PARALLEL_MAKE when setting max_jobs_per_link

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -275,6 +275,10 @@ GN_ARGS += ' \
         v8_snapshot_toolchain="//build/toolchain/yocto:yocto_target" \
 '
 
+# This parameter is added by limit-number-of-LTO-jobs.patch with the default value of 8,
+# but we can use whatever user configured in PARALLEL_MAKE
+GN_ARGS += 'max_jobs_per_link="${@oe.utils.parallel_make_argument(d, '%d')}"'
+
 # ARM builds need special additional flags (see ${S}/build/config/arm.gni).
 # If we do not pass |arm_arch| and friends to GN, it will deduce a value that
 # will then conflict with TUNE_CCARGS and CC.


### PR DESCRIPTION
* the limit-number-of-LTO-jobs.patch sets the default to be 8, but we can
  set whatever user configured in PARALLEL_MAKE

* with "-j 64" in PARALLEL_MAKE the do_compile task is 3.8 minutes faster
  (from 2701s to 2473s)

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>