### PR TITLE
Revert "chromium: Set LIBCPLUSPLUS to use libc++"

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium.inc
@@ -24,16 +24,6 @@ TOOLCHAIN:class-native = "clang"
 # https://github.com/kraj/meta-clang/issues/449).
 RUNTIME = "llvm"
 
-# meta-clang uses RUNTIME variable to add build dependencies on libcxx/compiler-rt
-# but does not add compiler options to commandline. It expects compiler's own
-# defaults to be used and compiler's buildtime defaults are chosen based on
-# global RUNTIME variable setting when building clang compiler, which defaults to 'gnu'.
-# For chromium libc++ is expected to be used therefore ensure that
-# right build flags are set for chromium irrespective of
-# distro defaults (which could be 'gnu' or 'llvm').
-# This also ensures that it does not rely too much on meta-clang's defaults.
-LIBCPLUSPLUS = "-stdlib=libc++"
-
 inherit mime-xdg pythonnative
 DEPENDS += "python-setuptools-native"
 


### PR DESCRIPTION
This reverts commit e109eb76fe2983a0e0c038d974a62eec70a23c24.

This change broke the hardknott build by preventing the libc++ headers from
being installed into the sysroot:

    x86_64-poky-linux-clang++ -target x86_64-poky-linux  -m64 -march=nehalem -mtune=generic -mfpmath=sse -msse4.2 -rtlib=compiler-rt --unwindlib=libgcc -stdlib=libc++ -mlittle-endian -Qunused-arguments -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/data/src/yocto/poky/build-hardknott-intel-corei7-64/tmp/work/corei7-64-poky-linux/chromium-x11/92.0.4515.159-r0/recipe-sysroot -MMD -MF obj/v8/cppgc_base/sweeper.o.d -DUSE_UDEV -DUSE_AURA=1 -DUSE_GLIB=1 -DUSE_NSS_CERTS=1 -DUSE_X11=1 -DOFFICIAL_BUILD -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DNO_UNWIND_TABLES -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DV8_TYPED_ARRAY_MAX_SIZE_IN_HEAP=64 -DENABLE_MINOR_MC -DV8_INTL_SUPPORT -DV8_USE_EXTERNAL_STARTUP_DATA -DV8_ATOMIC_OBJECT_FIELD_WRITES -DV8_ATOMIC_MARKING_STATE -DV8_ENABLE_LAZY_SOURCE_POSITIONS -DV8_SHARED_RO_HEAP -DV8_WIN64_UNWINDING_INFO -DV8_ENABLE_REGEXP_INTERPRETER_THREADED_DISPATCH -DV8_SNAPSHOT_COMPRESSION -DV8_SHORT_BUILTIN_CALLS -DV8_ENABLE_WEBASSEMBLY -DV8_COMPRESS_POINTERS -DV8_COMPRESS_POINTERS_IN_SHARED_CAGE -DV8_31BIT_SMIS_ON_64BIT_ARCH -DV8_DEPRECATION_WARNINGS -DCPPGC_CAGED_HEAP -DV8_TARGET_ARCH_X64 -DV8_HAVE_TARGET_OS -DV8_TARGET_OS_LINUX -DV8_RUNTIME_CALL_STATS -DDISABLE_UNTRUSTED_CODE_MITIGATIONS -DV8_COMPRESS_POINTERS -DV8_COMPRESS_POINTERS_IN_SHARED_CAGE -DV8_31BIT_SMIS_ON_64BIT_ARCH -DV8_DEPRECATION_WARNINGS -DCPPGC_CAGED_HEAP -DV8_COMPRESS_POINTERS -DV8_COMPRESS_POINTERS_IN_SHARED_CAGE -DV8_31BIT_SMIS_ON_64BIT_ARCH -DV8_DEPRECATION_WARNINGS -DCPPGC_CAGED_HEAP -I../.. -Igen -I../../v8 -I../../v8/include -Igen/v8 -Igen/v8/include -Igen/v8/include -I../../v8/include -fno-delete-null-pointer-checks -fno-ident -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -pthread -fcolor-diagnostics -fmerge-all-constants -fcrash-diagnostics-dir=../../tools/clang/crashreports -mllvm -instcombine-lower-dbg-declare=0 -flto=thin -fsplit-lto-unit -fwhole-program-vtables -m64 -march=x86-64 -msse3 -Xclang -fdebug-compilation-dir -Xclang . -Wall -Wextra -Wimplicit-fallthrough -Wunreachable-code -Wthread-safety -Wextra-semi -Wno-missing-field-initializers -Wno-unused-parameter -Wno-c++11-narrowing -Wno-unneeded-internal-declaration -Wno-undefined-var-template -Wno-unknown-warning-option -Wno-psabi -Wno-ignored-pragma-optimize -Wno-implicit-int-float-conversion -Wno-final-dtor-non-final-class -Wno-builtin-assume-aligned-alignment -Wno-deprecated-copy -Wno-non-c-typedef-for-linkage -Wno-max-tokens -fno-omit-frame-pointer -g0 -fvisibility=hidden -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wmissing-field-initializers -Wunreachable-code -Wshorten-64-to-32 -O3 -fdata-sections -ffunction-sections -Wexit-time-destructors -std=c++14 -fno-trigraphs -Wno-trigraphs -fno-exceptions -fno-rtti -fvisibility-inlines-hidden  -O2 -pipe  -feliminate-unused-debug-types -fmacro-prefix-map=/data/src/yocto/poky/build-hardknott-intel-corei7-64/tmp/work/corei7-64-poky-linux/chromium-x11/92.0.4515.159-r0=/usr/src/debug/chromium-x11/92.0.4515.159-r0                      -fdebug-prefix-map=/data/src/yocto/poky/build-hardknott-intel-corei7-64/tmp/work/corei7-64-poky-linux/chromium-x11/92.0.4515.159-r0=/usr/src/debug/chromium-x11/92.0.4515.159-r0                      -fdebug-prefix-map=/data/src/yocto/poky/build-hardknott-intel-corei7-64/tmp/work/corei7-64-poky-linux/chromium-x11/92.0.4515.159-r0/recipe-sysroot=                      -fdebug-prefix-map=/data/src/yocto/poky/build-hardknott-intel-corei7-64/tmp/work/corei7-64-poky-linux/chromium-x11/92.0.4515.159-r0/recipe-sysroot-native= -g1 -stdlib=libc++ -fvisibility-inlines-hidden -c ../../v8/src/heap/cppgc/sweeper.cc -o obj/v8/cppgc_base/sweeper.o
    In file included from ../../v8/src/heap/cppgc/sweeper.cc:5:
    ../../v8/src/heap/cppgc/sweeper.h:8:10: fatal error: 'memory' file not found
    #include <memory>
             ^~~~~~~~