### PR TITLE
chromium: Set LIBCPLUSPLUS to use libc++

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium.inc
@@ -24,6 +24,21 @@ TOOLCHAIN:class-native = "clang"
 # https://github.com/kraj/meta-clang/issues/449).
 RUNTIME = "llvm"
 
+# meta-clang uses RUNTIME variable to add build dependencies on libcxx/compiler-rt
+# but does not add compiler options to commandline. It expects compiler's own
+# defaults to be used and compiler's buildtime defaults are chosen based on
+# global RUNTIME variable setting when building clang compiler, which defaults to 'gnu'.
+# For chromium libc++ is expected to be used therefore ensure that
+# right build flags are set for chromium irrespective of
+# distro defaults (which could be 'gnu' or 'llvm').
+# This also ensures that it does not rely too much on meta-clang's defaults.
+LIBCPLUSPLUS = "-stdlib=libc++"
+
+# Explicitly add dependency on libcxx, because meta-clang/hardknott checks for
+# --stdlib=libc++ in LIBCPLUSPLUS (with extra dash, which was removed in
+# newer meta-clang in https://github.com/kraj/meta-clang/commit/cda2283e4cf3c90ea42b43dbc3a2268be6655670)
+DEPENDS += "libcxx"
+
 inherit mime-xdg pythonnative
 DEPENDS += "python-setuptools-native"
 


### PR DESCRIPTION
This should fix issue seen with
https://github.com/OSSystems/meta-browser/pull/551

Explicitly add dependency on libcxx to fix:
https://github.com/OSSystems/meta-browser/pull/556
https://github.com/OSSystems/meta-browser/pull/554
for hardknott and older.

Signed-off-by: Khem Raj <raj.khem@gmail.com>
Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>