### PR TITLE
Switch to python3 and remove dependency on meta-python2

### DIFF
--- a/meta-chromium/README.md
+++ b/meta-chromium/README.md
@@ -19,10 +19,6 @@ This layer depends on:
   - branch: master
   - revision: HEAD
 
-* URI: git://git.openembedded.org/meta-python2
-  - branch: master
-  - revision: HEAD
-
 Contributing
 ------------
 

--- a/meta-chromium/conf/layer.conf
+++ b/meta-chromium/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_chromium-browser-layer = "7"
 LAYERVERSION_chromium-browser-layer = "1"
 LAYERSERIES_COMPAT_chromium-browser-layer = "dunfell gatesgarth hardknott honister"
 
-LAYERDEPENDS_chromium-browser-layer = "clang-layer core openembedded-layer meta-python2"
+LAYERDEPENDS_chromium-browser-layer = "clang-layer core openembedded-layer"

--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -22,6 +22,7 @@ SRC_URI += " \
     file://0011-exception_handler.cc-Match-the-types-for-SIGSTKSZ.patch \
     file://0013-Revert-Use-ffile-compilation-dir-instead-of-fdebug-c.patch \
     file://0014-ozone-wayland-don-t-build-xcb-for-pure-wayland-build.patch \
+    file://0015-build-use-python3.patch \
 "
 
 SRC_URI:append:libc-musl = "\
@@ -386,7 +387,7 @@ addtask add_nodejs_symlink after do_configure before do_compile
 
 do_configure() {
 	cd ${S}
-	./build/linux/unbundle/replace_gn_files.py --system-libraries ${GN_UNBUNDLE_LIBS}
+	python3 ./build/linux/unbundle/replace_gn_files.py --system-libraries ${GN_UNBUNDLE_LIBS}
 	gn gen --args='${GN_ARGS}' "${OUTPUT_DIR}"
 }
 

--- a/meta-chromium/recipes-browser/chromium/chromium.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium.inc
@@ -39,8 +39,8 @@ LIBCPLUSPLUS = "-stdlib=libc++"
 # newer meta-clang in https://github.com/kraj/meta-clang/commit/cda2283e4cf3c90ea42b43dbc3a2268be6655670)
 DEPENDS += "libcxx"
 
-inherit mime-xdg pythonnative
-DEPENDS += "python-setuptools-native"
+inherit mime-xdg python3native
+DEPENDS += "python3-setuptools-native"
 
 # Chromium itself is licensed under the 3-clause BSD license. However, it
 # depends upon several other projects whose copyright files are listed in

--- a/meta-chromium/recipes-browser/chromium/files/0015-build-use-python3.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0015-build-use-python3.patch
@@ -1,0 +1,51 @@
+From 5defc3d0745fd40635c730acb8e694c6402f0d2d Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Tue, 28 Sep 2021 16:26:45 +0200
+Subject: [PATCH] build: use python3
+
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ build/linux/unbundle/replace_gn_files.py | 2 +-
+ buildtools/linux64/clang-format          | 8 ++++----
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/build/linux/unbundle/replace_gn_files.py b/build/linux/unbundle/replace_gn_files.py
+index eba4bd1fb3..53cb4b0296 100755
+--- a/build/linux/unbundle/replace_gn_files.py
++++ b/build/linux/unbundle/replace_gn_files.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ # Copyright 2016 The Chromium Authors. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+diff --git a/buildtools/linux64/clang-format b/buildtools/linux64/clang-format
+index 1a25a2b520..806b620bc4 100755
+--- a/buildtools/linux64/clang-format
++++ b/buildtools/linux64/clang-format
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python2
++#!/usr/bin/env python3
+ # Copyright 2020 The Chromium Authors. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+@@ -12,7 +12,7 @@ inputfiles = [a for a in args if not a.startswith('-')]
+ 
+ contents = ''
+ if '-' in args or not inputfiles:
+-    contents = sys.stdin.read()
++    contents = sys.stdin.read().encode('utf-8')
+ 
+ # Tarball builds may or may not have depot_tools in $PATH. In the former case,
+ # running 'clang-format' will call back into this script infinitely. Strip off
+@@ -34,8 +34,8 @@ try:
+     stdout, stderr = proc.communicate(input=contents)
+     # Ignore if clang-format fails. Eg: it may be too old to support C++14.
+     if proc.returncode == 0:
+-        sys.stdout.write(stdout)
+-        sys.stderr.write(stderr)
++        sys.stdout.write(stdout.decode('utf-8'))
++        sys.stderr.write(stderr.decode('utf-8'))
+         sys.exit(0)
+ except OSError:
+     # Ignore if clang-format is not installed.

--- a/meta-chromium/recipes-browser/chromium/gn-native_94.0.4606.61.bb
+++ b/meta-chromium/recipes-browser/chromium/gn-native_94.0.4606.61.bb
@@ -37,7 +37,7 @@ LDFLAGS:append:runtime-llvm = " -rtlib=libgcc -unwindlib=libgcc -stdlib=libc++ -
 do_configure[noexec] = "1"
 
 do_compile() {
-	python ${S}/tools/gn/bootstrap/bootstrap.py --skip-generate-buildfiles
+	python3 ${S}/tools/gn/bootstrap/bootstrap.py --skip-generate-buildfiles
 }
 
 do_install() {


### PR DESCRIPTION
Fixes https://github.com/OSSystems/meta-browser/issues/496

If someone can run some runtime test on this PR, then it would be great, I've only build tested chromium-ozone-wayland and chromium-x11 on honister with qemux86-64.