### PR TITLE
chromium-gn.inc: rename fieldtrial_testing_like_official_build parameter

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -235,7 +235,7 @@ GN_ARGS += "is_cfi=false"
 # Disable activation of field trial tests that can cause problems in
 # production.
 # See https://groups.google.com/a/chromium.org/d/msg/chromium-packagers/ECWC57W7E0k/9Kc5UAmyDAAJ
-GN_ARGS += "fieldtrial_testing_like_official_build=true"
+GN_ARGS += "disable_fieldtrial_testing_config=true"
 
 # Disable PGO optimization as generated profdata requires the same version of
 # clang that upstream uses. Otherwise, clang-llvm produces the following error:


### PR DESCRIPTION
* it's no longer available as gn warns about in log.do_configure:
  chromium-x11/94.0.4606.61-r0$ . temp/run.do_configure
  WARNING at the command-line "--args":1:592: Build argument has no effect.
            use_cups=false use_system_freetype=false          ffmpeg_branding="Chromium" proprietary_codecs=false  use_vaapi=false         is_component_build=false         use_gnome_keyring=false         use_kerberos=false         use_pulseaudio=true         use_system_libjpeg=true  enable_js_type_check=false host_pkg_config="pkg-config-native" is_debug=false is_official_build=true use_custom_libcxx=false use_lld=true use_gold=false symbol_level=0 enable_remoting=false enable_nacl=false use_sysroot=false treat_warnings_as_errors=false is_cfi=false fieldtrial_testing_like_official_build=true chrome_pgo_phase=0          google_api_key="invalid-api-key"         google_default_client_id="invalid-client-id"         google_default_client_secret="invalid-client-secret"           custom_toolchain="//build/toolchain/yocto:yocto_target"         gold_path=""         host_toolchain="//build/toolchain/yocto:yocto_native"         is_clang=true         clang_base_path="/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/chromium-x11/94.0.4606.61-r0/recipe-sysroot-native/usr/bin"         clang_use_chrome_plugins=false         target_cpu="x64"         v8_snapshot_toolchain="//build/toolchain/yocto:yocto_target"  max_jobs_per_link="64"         ozone_auto_platforms=false         ozone_platform_x11=true
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 ^---
  The variable "fieldtrial_testing_like_official_build" was set as a build argument
  but never appeared in a declare_args() block in any buildfile.

  To view all possible args, run "gn args --list <out_dir>"

  The build continued as if that argument was unspecified.

* it was renamed to disable_fieldtrial_testing_config in:
  https://chromium-review.googlesource.com/c/chromium/src/+/3034966

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>