### PR TITLE
chromium: add PACKAGECONFIG for gtk

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -68,7 +68,6 @@ DEPENDS += " \
     glib-2.0 \
     gn-native \
     gperf-native \
-    gtk+3 \
     jpeg \
     libdrm \
     libwebp \
@@ -105,8 +104,6 @@ BUILD_CC:toolchain-clang = "clang"
 BUILD_CXX:toolchain-clang = "clang++"
 BUILD_LD:toolchain-clang = "clang"
 
-PACKAGECONFIG ??= "upower use-egl"
-
 # this makes sure the dependencies for the EGL mode are present; otherwise, the configure scripts
 # automatically and silently fall back to GLX
 PACKAGECONFIG[use-egl] = ",,virtual/egl virtual/libgles2"
@@ -117,6 +114,7 @@ PACKAGECONFIG[use-egl] = ",,virtual/egl virtual/libgles2"
 # be necessary but are OK to add).
 PACKAGECONFIG[component-build] = ""
 PACKAGECONFIG[cups] = "use_cups=true,use_cups=false,cups"
+PACKAGECONFIG[gtk] = "use_gtk=true,use_gtk=false,gtk+3"
 PACKAGECONFIG[kiosk-mode] = ""
 PACKAGECONFIG[proprietary-codecs] = ' \
         ffmpeg_branding="Chrome" proprietary_codecs=true, \

--- a/meta-chromium/recipes-browser/chromium/chromium-ozone-wayland_94.0.4606.71.bb
+++ b/meta-chromium/recipes-browser/chromium/chromium-ozone-wayland_94.0.4606.71.bb
@@ -27,7 +27,6 @@ GN_ARGS += "\
         use_system_libwayland=true \
         use_system_minigbm=true \
         use_system_libdrm=true \
-        use_gtk=false \
 "
 
 # Ozone is default via finch since M94 and default via compile time
@@ -41,3 +40,4 @@ GN_ARGS += "use_x11=false"
 # The chromium binary must always be started with those arguments.
 CHROMIUM_EXTRA_ARGS:append = " --ozone-platform=wayland"
 
+PACKAGECONFIG ??= "upower use-egl"

--- a/meta-chromium/recipes-browser/chromium/chromium-x11_94.0.4606.71.bb
+++ b/meta-chromium/recipes-browser/chromium/chromium-x11_94.0.4606.71.bb
@@ -33,3 +33,5 @@ GN_ARGS += "\
 # chromium-ozone-wayland recipes, and the former used to be called just
 # "chromium".
 PROVIDES = "chromium"
+
+PACKAGECONFIG ??= "gtk upower use-egl"


### PR DESCRIPTION
Recently i found out, that chromium needs to be built with use_gtk=true if you want it to respect the gtk cursor theme.
This seems to be related to a change in use flags in chromium. There has been a use_gtk3 option that was true by
default. In addition we had use_gtk to enable builds with gtk+2.

Now it looks like we only have use_gtk to enable build with gtk+
https://github.com/chromium/chromium/blob/72ceeed2ebcd505b8d8205ed7354e862b871995e/build/config/linux/gtk/gtk.gni#L9

We have this disabled by default so i guess all current builds are without using gtk:
https://github.com/OSSystems/meta-browser/blob/8df26e66c28b43f1630fcd2cb952a1e69b6e6558/meta-chromium/recipes-browser/chromium/chromium-ozone-wayland_94.0.4606.71.bb#L30

Make gtk a PACKAGECONFIG to have an option.

Signed-off-by: MarkusVolk <f_l_k@t-online.de>