### PR TITLE
chromium-ozone-wayland: fix va-api.

### DIFF
--- a/meta-chromium/recipes-browser/chromium/files/chromium-wayland/0001-ozone-add-va-api-support-to-wayland.patch
+++ b/meta-chromium/recipes-browser/chromium/files/chromium-wayland/0001-ozone-add-va-api-support-to-wayland.patch
@@ -23,7 +23,8 @@ Signed-off-by: Maksim Sisov <msisov@igalia.com>
  .../gpu/vaapi/vaapi_video_decode_accelerator.cc |  4 ++--
  .../platform/wayland/gpu/gbm_pixmap_wayland.cc  | 14 ++++++++++++--
  .../platform/wayland/gpu/gbm_pixmap_wayland.h   |  3 +++
- 5 files changed, 34 insertions(+), 6 deletions(-)
+ .../platform/wayland/ozone_platform_wayland.cc  |  3 +++
+ 6 files changed, 37 insertions(+), 6 deletions(-)
 
 diff --git a/media/gpu/vaapi/vaapi_picture_factory.cc b/media/gpu/vaapi/vaapi_picture_factory.cc
 index 9c7d7387d24b2..400ea292e9d6e 100644
@@ -140,3 +141,16 @@ index e2af8c3d3233c..5a54fd7f96aec 100644
  };
  
  }  // namespace ui
+diff --git a/ui/ozone/platform/wayland/ozone_platform_wayland.cc b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+index 7334bf8225e48..2f29dc66d02f6 100644
+--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
++++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+@@ -314,6 +314,9 @@ class OzonePlatformWayland : public OzonePlatform,
+       // coordinates, instead only surface-local ones are supported.
+       properties->supports_global_screen_coordinates = false;
+
++      // Let the media know this platform supports va-api.
++      properties->supports_vaapi = true;
++
+       initialised = true;
+     }


### PR DESCRIPTION
After https://crrev.com/c/3141878, it's required to set
supports_vaapi in properties to make Wayland use va-api.

Fixes #592