### PR TITLE
chromium-x11: Add missing DEPENDS on libxkbcommon

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -72,6 +72,7 @@ DEPENDS += " \
     jpeg \
     libdrm \
     libwebp \
+    libxkbcommon \
     libxslt \
     ninja-native \
     nodejs-native \

--- a/meta-chromium/recipes-browser/chromium/chromium-ozone-wayland_96.0.4664.110.bb
+++ b/meta-chromium/recipes-browser/chromium/chromium-ozone-wayland_96.0.4664.110.bb
@@ -4,7 +4,6 @@ REQUIRED_DISTRO_FEATURES = "wayland"
 
 DEPENDS += "\
         at-spi2-atk \
-        libxkbcommon \
         virtual/egl \
         wayland \
         wayland-native \


### PR DESCRIPTION
When using a distro without "wayland" in DISTRO_FEATURES, the build
fails due to libxkbcommon being missing. Add the missing libxkbcommon
dependency, since it's required for x11 only builds too.

Signed-off-by: Robert Joslyn <robert.joslyn@redrectangle.org>