### PR TITLE
chromium: don't pass is_official_build=true when doing a component-build

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -165,7 +165,8 @@ GN_ARGS += 'host_pkg_config="pkg-config-native"'
 # (debug, release, official) but for historical reasons there are two
 # separate flags.
 # See also: https://groups.google.com/a/chromium.org/d/msg/chromium-dev/hkcb6AOX5gE/PPT1ukWoBwAJ
-GN_ARGS += "is_debug=false is_official_build=true"
+GN_ARGS += "is_debug=false"
+GN_ARGS += "is_official_build=${@bb.utils.contains('PACKAGECONFIG', 'component-build', 'false', 'true', d)}"
 
 # Starting with M61, Chromium defaults to building with its own copy of libc++
 # instead of the system's libstdc++. Explicitly disable this behavior.


### PR DESCRIPTION
When setting the PACKAGECONFIG component-build, the build breaks
immediately due to this from the toplevel BUILD.gn:

if (is_official_build) {
  # An official (maximally optimized!) component (optimized for build times)
  # build doesn't make sense and usually doesn't work.
  assert(!is_component_build)
}

So we must make is_official_build the negative of component-build.