### PR TITLE
layers: Bump to use kirkstone

### DIFF
--- a/meta-chromium/conf/layer.conf
+++ b/meta-chromium/conf/layer.conf
@@ -9,6 +9,6 @@ BBFILE_PATTERN_chromium-browser-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_chromium-browser-layer = "7"
 
 LAYERVERSION_chromium-browser-layer = "1"
-LAYERSERIES_COMPAT_chromium-browser-layer = "dunfell gatesgarth hardknott honister"
+LAYERSERIES_COMPAT_chromium-browser-layer = "dunfell gatesgarth hardknott honister kirkstone"
 
 LAYERDEPENDS_chromium-browser-layer = "clang-layer core openembedded-layer"

--- a/meta-firefox/conf/layer.conf
+++ b/meta-firefox/conf/layer.conf
@@ -113,6 +113,6 @@ BBFILE_PATTERN_firefox-browser-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_firefox-browser-layer = "7"
 
 LAYERVERSION_firefox-browser-layer = "1"
-LAYERSERIES_COMPAT_firefox-browser-layer = "dunfell gatesgarth hardknott honister"
+LAYERSERIES_COMPAT_firefox-browser-layer = "dunfell gatesgarth hardknott honister kirkstone"
 
 LAYERDEPENDS_firefox-browser-layer = "clang-layer core openembedded-layer"


### PR DESCRIPTION
its not going to be backward ABI compatible with honister due to variable renaming.

Signed-off-by: Khem Raj <raj.khem@gmail.com>