### PR TITLE
chromium: Add PACKAGECONFIG settings to switch between GTK 3/4

### DIFF
--- a/meta-chromium/README.md
+++ b/meta-chromium/README.md
@@ -90,6 +90,10 @@ PACKAGECONFIG knobs
 * cups: (off by default)
   Enables CUPS support in Chromium, and adds a dependency on the "cups" recipe.
 
+* gtk4: (off by default)
+  Enables GTK4 runtime support in Chromium by adding --gtk-version=4
+  to the command line. Chromium is still built against GTK3.
+
 * kiosk-mode: (off by default)
   Enable this option if you want your browser to start up full-screen, without
   any menu bars, without any clutter, and without any initial start-up

--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -2,6 +2,8 @@ require chromium.inc
 require chromium-unbundle.inc
 require gn-utils.inc
 
+GTKIC_VERSION = "${@bb.utils.contains('PACKAGECONFIG', 'gtk4', '4', '3',d)}"
+
 inherit features_check gtk-icon-cache qemu
 
 # The actual directory name in out/ is irrelevant for GN.
@@ -117,6 +119,7 @@ PACKAGECONFIG[use-egl] = ",,virtual/egl virtual/libgles2"
 # be necessary but are OK to add).
 PACKAGECONFIG[component-build] = ""
 PACKAGECONFIG[cups] = "use_cups=true,use_cups=false,cups"
+PACKAGECONFIG[gtk4] = ""
 PACKAGECONFIG[kiosk-mode] = ""
 PACKAGECONFIG[proprietary-codecs] = ' \
         ffmpeg_branding="Chrome" proprietary_codecs=true, \
@@ -332,6 +335,7 @@ GN_ARGS:append:libc-musl = ' use_allocator_shim=false use_allocator="none"'
 CHROMIUM_EXTRA_ARGS ?= " \
         ${@bb.utils.contains('PACKAGECONFIG', 'use-egl', '--use-gl=egl', '', d)} \
         ${@bb.utils.contains('PACKAGECONFIG', 'kiosk-mode', '--kiosk --no-first-run --incognito', '', d)} \
+        ${@bb.utils.contains('PACKAGECONFIG', 'gtk4', '--gtk-version=4', '', d)} \
 "
 
 # V8's JIT infrastructure requires binaries such as mksnapshot and


### PR DESCRIPTION
Kirkstone provides gtk4 4.4.0, Chromium 97 has a configuration
setting to build with GTK version 3 or 4. Expose this choice in
PACKAGECONFIG.

Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>