### PR TITLE
chromium: Ignore textrels on x86 build

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -521,3 +521,7 @@ PACKAGE_DEBUG_SPLIT_STYLE = "debug-without-src"
 
 # There is no need to ship empty -dev packages.
 ALLOW_EMPTY:${PN}-dev = "0"
+
+# ERROR: QA Issue: lib32-chromium-ozone-wayland: ELF binary /usr/bin/chromium has relocations in .text [textrel]
+INSANE_SKIP:${PN}:append:x86 = "textrel"
+


### PR DESCRIPTION
building 32bit x86 results in textrels which I guess should be fixed
so here is a workaround until they are root caused and fixed.

Signed-off-by: Khem Raj <raj.khem@gmail.com>