### PR TITLE
chromium: Create packageconfig to control libc++ to use

### DIFF
--- a/meta-chromium/README.md
+++ b/meta-chromium/README.md
@@ -90,6 +90,12 @@ PACKAGECONFIG knobs
 * cups: (off by default)
   Enables CUPS support in Chromium, and adds a dependency on the "cups" recipe.
 
+* custom-libcxx (off by default)
+  Enable vendored version of C++ runtime ( libc++ ) instead of using this from
+  meta-clang provided libc++, this could be useful in some cases, where the
+  binary is to be run on foreign systems which are not built using OE/Yocto
+  base
+
 * gtk4: (off by default)
   Enables GTK4 runtime support in Chromium by adding --gtk-version=4
   to the command line. Chromium is still built against GTK3.

--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -118,6 +118,12 @@ PACKAGECONFIG[use-egl] = ",,virtual/egl virtual/libgles2"
 # and command-line switches (extra dependencies should not
 # be necessary but are OK to add).
 PACKAGECONFIG[component-build] = ""
+
+# Starting with M61, Chromium defaults to building with its own copy of libc++
+# instead of the system's libstdc++. Add a knob to control this behavior
+# https://groups.google.com/a/chromium.org/d/msg/chromium-packagers/8aYO3me2SCE/SZ8pJXhZAwAJ
+PACKAGECONFIG[custom-libcxx] = "use_custom_libcxx=true,use_custom_libcxx=false,,"
+
 PACKAGECONFIG[cups] = "use_cups=true,use_cups=false,cups"
 PACKAGECONFIG[gtk4] = ""
 PACKAGECONFIG[kiosk-mode] = ""
@@ -168,11 +174,6 @@ GN_ARGS += 'host_pkg_config="pkg-config-native"'
 # separate flags.
 # See also: https://groups.google.com/a/chromium.org/d/msg/chromium-dev/hkcb6AOX5gE/PPT1ukWoBwAJ
 GN_ARGS += "is_debug=false is_official_build=true"
-
-# Starting with M61, Chromium defaults to building with its own copy of libc++
-# instead of the system's libstdc++. Explicitly disable this behavior.
-# https://groups.google.com/a/chromium.org/d/msg/chromium-packagers/8aYO3me2SCE/SZ8pJXhZAwAJ
-GN_ARGS += "use_custom_libcxx=false"
 
 # Use lld linker its quicker see https://lld.llvm.org/#performance
 GN_ARGS += "use_lld=true use_gold=false"


### PR DESCRIPTION
This helps to use either system provided libc++ or bundled libc++ with
chromium. Defaults in chromium is to use bundled version, however in OE
we have used the system provided so far, therefore the default are not
changed here, just an option offered to enable custom libc++ if someone
desires so. Should we default to use the custom copy by default, perhaps
yes but thats a separate discussion

Signed-off-by: Khem Raj <raj.khem@gmail.com>