### PR TITLE
cbindgen: add explicit branch parameter

### DIFF
--- a/meta-firefox/recipes-devtools/cbindgen/cbindgen_0.8.7.bb
+++ b/meta-firefox/recipes-devtools/cbindgen/cbindgen_0.8.7.bb
@@ -7,7 +7,7 @@ inherit cargo
 
 # how to get cbindgen could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/cbindgen/0.8.7"
-SRC_URI += "git://github.com/eqrion/cbindgen.git;protocol=https"
+SRC_URI += "git://github.com/eqrion/cbindgen.git;protocol=https;branch=master"
 SRCREV = "7b9ea991bdabb442093014d21fde6a192f574f21"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR=""


### PR DESCRIPTION
* fixes:
  WARNING: cbindgen-native-0.8.7-r0 do_unpack: URL:
  git://github.com/eqrion/cbindgen.git;protocol=https does not set any
  branch parameter. The future default branch used by tools and
  repositories is uncertain and we will therefore soon require this is
  set in all git urls.

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>