### PR TITLE
chromium-x11: Add RDEPENDS on libx11-xcb.

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-x11_109.0.5414.74.bb
+++ b/meta-chromium/recipes-browser/chromium/chromium-x11_109.0.5414.74.bb
@@ -16,6 +16,10 @@ DEPENDS += "\
         libxtst \
 "
 
+# Loaded at runtime.
+# https://source.chromium.org/chromium/chromium/src/+/main:ui/gfx/x/xlib_support.cc
+RDEPENDS:${PN} += "libx11-xcb"
+
 # Ozone is default path on Linux since M95.
 # Disable all backends except x11 to ensure this is
 # x11 only recipe.


### PR DESCRIPTION
libX11-xcb.so.1 is loaded at runtime by the X11 backend, but we had no
explicit dependency on the package that provides it (libx11-xcb).

It ended up being installed most of the time anyway, but make sure it is
listed as a runtime dependency to avoid the issue described in #683.

Fixes #683.

Signed-off-by: Raphael Kubo da Costa <raphael.kubo.da.costa@intel.com>
