### PR TITLE
chromium: Indicate that x86-32 is not a supported machine

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -94,7 +94,6 @@ COMPATIBLE_MACHINE:aarch64 = "(.*)"
 COMPATIBLE_MACHINE:armv6 = "(.*)"
 COMPATIBLE_MACHINE:armv7a = "(.*)"
 COMPATIBLE_MACHINE:armv7ve = "(.*)"
-COMPATIBLE_MACHINE:x86 = "(.*)"
 COMPATIBLE_MACHINE:x86-64 = "(.*)"
 
 # Also build the parts that are run on the host with clang.


### PR DESCRIPTION
The x86-32 bit target build is not supported for Chromium-x11 so do_configure fails while building x86-32 bit target but, the failure appears quite late in a build.

Removing x86-32 bit target from COMPATIBLE_MACHINE will make it fail much earlier and in clear manner if a user tries to build for an x86-32 bit target.

References:
https://groups.google.com/a/chromium.org/g/chromium-packagers/c/Q7jI7kI9umM/m/IoPYldUSCwAJ
https://support.google.com/chrome/a/answer/7100626

Error logs while building x86-32 bit target:

> | DEBUG: Python function extend_recipe_sysroot finished
> | DEBUG: Executing shell function do_configure
> | ERROR at //BUILD.gn:1641:1: Assertion failed.
> | assert(
> | ^-----
> | 'target_cpu=x86' is not supported for 'target_os=linux'. Consider omitting 'target_cpu' (default) or using 'target_cpu=x64' instead.
> | See //BUILD.gn:1642:5:
> |     is_valid_x86_target || target_cpu != "x86" || v8_target_cpu == "arm",
> |     ^-------------------------------------------------------------------
> | This is where it was set.
> | WARNING: /buildarea/eng1/chromium/poky/build/tmp/work/core2-32-poky-linux/chromium-x11/111.0.5563.64-r0/temp/run.do_configure.456546:149 exit 1