### PR TITLE
chromium: Make yocto-check-layer pass

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-ozone-wayland_112.0.5615.165.bb
+++ b/meta-chromium/recipes-browser/chromium/chromium-ozone-wayland_112.0.5615.165.bb
@@ -21,6 +21,7 @@ GN_ARGS += "\
         use_xkbcommon=true \
         use_system_minigbm=true \
         use_system_libdrm=true \
+        use_system_libffi=true \
         use_gtk=false \
 "
 

--- a/meta-chromium/recipes-browser/chromium/files/0009-nomerge-attribute-on-declaration-is-only-available-s.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0009-nomerge-attribute-on-declaration-is-only-available-s.patch
@@ -20,6 +20,8 @@ build error: 'nomerge' attribute cannot be applied to a declaration
 See https://reviews.llvm.org/D92800
 
 Change-Id: I32e1f7dc9049737d54d8a16de5308aa5aae1ced1
+
+Upstream-Status: Inappropriate
 ---
  base/compiler_specific.h | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

--- a/meta-chromium/recipes-browser/chromium/files/0017-Revert-Fix-std-span-autodetection-7805.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0017-Revert-Fix-std-span-autodetection-7805.patch
@@ -4,6 +4,8 @@ Date: Tue, 11 Apr 2023 15:37:58 +0200
 Subject: [PATCH] Revert "Fix std::span autodetection (#7805)"
 
 This reverts commit a6f41944899e65b38ec45ee82f6840248f06b471.
+
+Upstream-Status: Inappropriate
 ---
  .../src/include/flatbuffers/stl_emulation.h | 19 ++++++++-----------
  1 file changed, 8 insertions(+), 11 deletions(-)

--- a/meta-chromium/recipes-browser/chromium/files/0018-Only-default-operator-on-declaration.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0018-Only-default-operator-on-declaration.patch
@@ -8,7 +8,8 @@ the first declaration was removed in P2085R0, which clang only supports
 in versions 14 and above. Because dunfell still uses clang 12, we need
 to fix the few occurrences where this requirement isn't met.
 
-Upstream-Status: Unknown
+Upstream-Status: Inappropriate
+
 Signed-off-by: Max Ihlenfeldt <max@igalia.com>
 ---
  .../core/browser/affiliation/affiliation_fetcher_base.cc     | 3 ---

--- a/meta-chromium/recipes-browser/chromium/files/musl/no-res-ninit-nclose.patch
+++ b/meta-chromium/recipes-browser/chromium/files/musl/no-res-ninit-nclose.patch
@@ -1,6 +1,8 @@
 Source: https://git.alpinelinux.org/aports/plain/community/chromium/no-res-ninit-nclose.patch
 similar to dns-resolver.patch, musl doesn't have res_ninit and so on
 
+Upstream-Status: Pending
+
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 --- a/net/dns/public/scoped_res_state.cc
 +++ b/net/dns/public/scoped_res_state.cc

--- a/meta-chromium/recipes-browser/chromium/libffi_%.bbappend
+++ b/meta-chromium/recipes-browser/chromium/libffi_%.bbappend
@@ -1,6 +1,0 @@
-# Also copy the PIC version of libffi.a to the sysroot, as Chromium needs it.
-# This is the same approach that Debian takes, which Chromium uses for its
-# sysroot: https://sources.debian.org/src/libffi/3.4.4-1/debian/rules/#L103
-do_install:append() {
-	install -m 0644 ${B}/.libs/libffi_convenience.a ${D}/${libdir}/libffi_pic.a
-}


### PR DESCRIPTION
As explained in:
https://github.com/OSSystems/meta-browser/commit/2f5fe79935e1f5350f9e487625343a8f27b165d3 
Chromium doesn't allow building with system libwayland anymore, and needs (a static version of) libffi to build its own libwayland. Therefore, libffi_%.bbappend was added to make libffi_pic.a (static library) available while building chromium-ozone-wayland.

This libffi_%.bbappend is causing yocto-check-layer to give compliance error for meta-chromium layer.

By adding "use_system_libffi=true" to GN_ARGS in chromium-ozone-wayland recipe and removing the libffi_%.bbappend, we can make chromium-ozone-wayland to build with libffi.so (shared library). With these changes, we can avoid using libffi_pic.a (static library) for chromium-ozone-wayland build and also resolve yocto-check-layer compliance error for meta-chromium layer.

Added Upstream-Status to required patches to fix test_patches_upstream_status failure in yocto-check-layer.

Fixes: #714 

Signed-off-by: Narpat Mali <narpat.mali@windriver.com>