### PR TITLE
chromium: Disable Rust for now

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -303,6 +303,9 @@ GN_ARGS += ' \
 # but we can use whatever user configured in PARALLEL_MAKE
 GN_ARGS += 'max_jobs_per_link="${@oe.utils.parallel_make_argument(d, '%d')}"'
 
+# We haven't figured out how to best support Rust yet, so disable it for now.
+GN_ARGS += 'enable_rust=false'
+
 # ARM builds need special additional flags (see ${S}/build/config/arm.gni).
 # If we do not pass |arm_arch| and friends to GN, it will deduce a value that
 # will then conflict with TUNE_CCARGS and CC.

--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -304,6 +304,7 @@ GN_ARGS += ' \
 GN_ARGS += 'max_jobs_per_link="${@oe.utils.parallel_make_argument(d, '%d')}"'
 
 # We haven't figured out how to best support Rust yet, so disable it for now.
+# See the discussion at https://github.com/OSSystems/meta-browser/issues/723.
 GN_ARGS += 'enable_rust=false'
 
 # ARM builds need special additional flags (see ${S}/build/config/arm.gni).


### PR DESCRIPTION
It turns out that Rust might be used in the build in 114 already. As discussed in #723, we need to figure out how to best support Rust builds, and until we've done so we need to disable it.