### PR TITLE
kirkstone: chromium: Don't require profiler_builtins.rlib

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -42,6 +42,7 @@ SRC_URI += "\
     file://0016-Use-base-ranges-instead-of-std-ranges.patch \
     file://0017-Use-the-correct-path-to-libclang_rt.builtins.a.patch \
     file://0018-Adjust-the-Rust-build-to-our-needs.patch \
+    file://0019-Don-t-require-profiler_builtins.rlib.patch \
 "
 # ARM/AArch64-specific patches.
 SRC_URI:append:arm = "\

--- a/meta-chromium/recipes-browser/chromium/files/0019-Don-t-require-profiler_builtins.rlib.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0019-Don-t-require-profiler_builtins.rlib.patch
@@ -1,0 +1,27 @@
+From 7f9a0877029aa3492fd381313886d9c80efbb752 Mon Sep 17 00:00:00 2001
+From: Max Ihlenfeldt <max@igalia.com>
+Date: Wed, 7 Feb 2024 11:58:30 +0000
+Subject: [PATCH] Don't require profiler_builtins.rlib
+
+This library is only needed for profiling builds, which we don't do.
+Including it leads to compile errors on with OE's current master branch
+because they disabled building the library, so just skip it.
+
+Upstream-Status: Inappropriate [specific to our build setup]
+Signed-off-by: Max Ihlenfeldt <max@igalia.com>
+---
+ build/rust/std/BUILD.gn | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/build/rust/std/BUILD.gn b/build/rust/std/BUILD.gn
+index 77f4b8c..3078de8 100644
+--- a/build/rust/std/BUILD.gn
++++ b/build/rust/std/BUILD.gn
+@@ -100,7 +100,6 @@ if (toolchain_has_rust) {
+   # don't need to pass to the C++ linker because they're used for specialized
+   # purposes.
+   skip_stdlib_files = [
+-    "profiler_builtins",
+     "rustc_std_workspace_alloc",
+     "rustc_std_workspace_core",
+     "rustc_std_workspace_std",


### PR DESCRIPTION
Backport `0019-Don-t-require-profiler_builtins.rlib.patch` from master branch.

This fixes Chromium compilation errors, when using `meta-lts-mixins` layer with latest revision from `kirkstone/rust` branch (Rust 1.75).