### PR TITLE
chromium: Fix gn build for Yocto master

### DIFF
--- a/meta-chromium/recipes-browser/chromium/gn-native_122.0.6261.128.bb
+++ b/meta-chromium/recipes-browser/chromium/gn-native_122.0.6261.128.bb
@@ -16,6 +16,7 @@ B = "${S}/out_bootstrap"
 
 SRC_URI += " \
         file://0001-Pass-no-static-libstdc-to-gen.py.patch \
+        file://gn-bootstrap-Don-t-pass-removed-dupbuild-ninja-optio.patch \
 "
 
 # The build system expects the linker to be invoked via the compiler. If we use

--- a/meta-chromium/recipes-browser/chromium/gn/gn-bootstrap-Don-t-pass-removed-dupbuild-ninja-optio.patch
+++ b/meta-chromium/recipes-browser/chromium/gn/gn-bootstrap-Don-t-pass-removed-dupbuild-ninja-optio.patch
@@ -1,0 +1,27 @@
+From 3fbc984a8c73cb8245ea0c3783cb88c558996f7d Mon Sep 17 00:00:00 2001
+From: Max Ihlenfeldt <max@igalia.com>
+Date: Tue, 7 May 2024 17:38:25 +0200
+Subject: [PATCH] Backport "gn bootstrap: Don't pass removed dupbuild ninja option"
+
+This backports a patch to GN's bootstrap script to fix a build error
+when using ninja >= 1.12.0. It will be included in upstream's 126
+release.
+
+Upstream-Status: Backport [https://crrev.com/c/5522398]
+---
+ tools/gn/bootstrap/bootstrap.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/gn/bootstrap/bootstrap.py b/tools/gn/bootstrap/bootstrap.py
+index caf736b28946d..b721e79a205ed 100755
+--- a/tools/gn/bootstrap/bootstrap.py
++++ b/tools/gn/bootstrap/bootstrap.py
+@@ -122,7 +122,7 @@ def main(argv):
+
+   shutil.copy2(
+       os.path.join(BOOTSTRAP_DIR, 'last_commit_position.h'), gn_build_dir)
+-  cmd = [ninja_binary, '-C', gn_build_dir, '-w', 'dupbuild=err', 'gn']
++  cmd = [ninja_binary, '-C', gn_build_dir, 'gn']
+   if options.jobs:
+     cmd += ['-j', str(options.jobs)]
+   subprocess.check_call(cmd)


### PR DESCRIPTION
Build and patch changes:
------------------------

Add one backported patch to fix a build error on Yocto master.

License changes:
----------------

Added licenses: none.

Removed licenses: none.

Updated licenses: none.

Test-built:
-----------

* chromium-x11:
 - master, clang, MACHINE=qemuarm