### PR TITLE
chromium: Depend on libstd-rs instead of rust

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -72,6 +72,7 @@ DEPENDS += " \
     jpeg \
     libdrm \
     libffi \
+    libstd-rs \
     libwebp \
     libxkbcommon \
     libxslt \
@@ -86,7 +87,6 @@ DEPENDS += " \
     pkgconfig-native \
     ${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'pulseaudio', '', d)} \
     qemu-native \
-    rust \
     rust-native \
     virtual/libgl \
 "

--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -4,7 +4,7 @@ require gn-utils.inc
 
 GTKIC_VERSION = "${@bb.utils.contains('PACKAGECONFIG', 'gtk4', '4', '3',d)}"
 
-inherit features_check gtk-icon-cache qemu
+inherit features_check gtk-icon-cache qemu rust-common
 
 # The actual directory name in out/ is irrelevant for GN.
 OUTPUT_DIR = "out/Release"

--- a/meta-chromium/recipes-browser/chromium/files/0009-Adjust-the-Rust-build-to-our-needs.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0009-Adjust-the-Rust-build-to-our-needs.patch
@@ -19,8 +19,8 @@ Signed-off-by: Max Ihlenfeldt <max@igalia.com>
  build/config/rust.gni            | 24 +++++++++++++++++------
  build/rust/rustc_wrapper.py      |  1 +
  build/rust/std/BUILD.gn          | 33 ++++++++++++++++++++++++--------
- build/rust/std/find_std_rlibs.py | 13 ++++++++++---
- 4 files changed, 54 insertions(+), 17 deletions(-)
+ build/rust/std/find_std_rlibs.py | 17 +++++++++++-----
+ 4 files changed, 56 insertions(+), 19 deletions(-)
 
 diff --git a/build/config/rust.gni b/build/config/rust.gni
 index e98d913..6213b72 100644
@@ -166,9 +166,18 @@ index 77f4b8c..8a25798 100644
        # The host builds tools toolchain supports Rust only and does not use
        # the allocator remapping to point it to PartitionAlloc.
 diff --git a/build/rust/std/find_std_rlibs.py b/build/rust/std/find_std_rlibs.py
-index 386258f..25fdedc 100755
+index 386258f..3bb6a41 100755
 --- a/build/rust/std/find_std_rlibs.py
 +++ b/build/rust/std/find_std_rlibs.py
+@@ -17,7 +17,7 @@ import re
+ from collections import defaultdict
+
+ EXPECTED_STDLIB_INPUT_REGEX = re.compile(r"([0-9a-z_]+)(?:-([0-9]+))?$")
+-RLIB_NAME_REGEX = re.compile(r"lib([0-9a-z_]+)-([0-9a-f]+)\.rlib$")
++RLIB_NAME_REGEX = re.compile(r"lib([0-9a-z_]+)(-([0-9a-f]+))?\.rlib$")
+
+
+ def main():
 @@ -52,6 +52,8 @@ def main():
      rustc_args.extend(["--target", args.target])
    rustlib_dir = subprocess.check_output(rustc_args).rstrip().decode()
@@ -187,6 +196,15 @@ index 386258f..25fdedc 100755
 
      def copy_file(infile, outfile):
        depfile.write(f" {infile}")
+@@ -99,7 +101,7 @@ def main():
+       # the correct file path to our linker invocations, we don't need
+       # that, and it would prevent us having the predictable filenames
+       # which we need for statically computable gn dependency rules.
+-      (crate_name, metadata) = RLIB_NAME_REGEX.match(f).group(1, 2)
++      (crate_name, metadata) = RLIB_NAME_REGEX.match(f).group(1, 3)
+
+       # Use the number of times we've seen this name to disambiguate the output
+       # filenames. Since we sort the input filenames including the metadata,
 @@ -117,14 +119,19 @@ def main():
        output_filename = f"lib{concise_name}.rlib"
 

--- a/meta-chromium/recipes-browser/chromium/files/0009-Adjust-the-Rust-build-to-our-needs.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0009-Adjust-the-Rust-build-to-our-needs.patch
@@ -19,8 +19,8 @@ Signed-off-by: Max Ihlenfeldt <max@igalia.com>
  build/config/rust.gni            | 24 +++++++++++++++++------
  build/rust/rustc_wrapper.py      |  1 +
  build/rust/std/BUILD.gn          | 33 ++++++++++++++++++++++++--------
- build/rust/std/find_std_rlibs.py | 17 +++++++++++-----
- 4 files changed, 56 insertions(+), 19 deletions(-)
+ build/rust/std/find_std_rlibs.py | 16 +++++++++++-----
+ 4 files changed, 55 insertions(+), 19 deletions(-)
 
 diff --git a/build/config/rust.gni b/build/config/rust.gni
 index e98d913..6213b72 100644
@@ -205,7 +205,7 @@ index 386258f..3bb6a41 100755
 
        # Use the number of times we've seen this name to disambiguate the output
        # filenames. Since we sort the input filenames including the metadata,
-@@ -117,14 +119,19 @@ def main():
+@@ -117,14 +119,18 @@ def main():
        output_filename = f"lib{concise_name}.rlib"
 
        infile = os.path.join(rustlib_dir, f)
@@ -219,9 +219,8 @@ index 386258f..3bb6a41 100755
 +      outfile = os.path.join(lib_output_dir, f)
        copy_file(infile, outfile)
 
-+    f = 'target.json'
-+    infile = os.path.join(rustlib_dir, '..', f)
-+    outfile = os.path.join(args.output, f)
++    infile = os.path.join(os.environ['RUST_TARGET_PATH'], f'{args.target}.json')
++    outfile = os.path.join(args.output, 'target.json')
 +    copy_file(infile, outfile)
 +
      depfile.write("\n")

--- a/meta-chromium/recipes-browser/chromium/libstd-rs_%.bbappend
+++ b/meta-chromium/recipes-browser/chromium/libstd-rs_%.bbappend
@@ -1,9 +1,0 @@
-FILES:${PN} += "${libdir}/rustlib/*/target.json"
-
-# Without this, rustc fails with "could not find specification for target ...".
-do_install:append() {
-    target_dir=`realpath "${D}${rustlibdir}"/..`
-    target_triple=`basename "${target_dir}"`
-    target_json="${target_dir}/target.json"
-    RUSTC_BOOTSTRAP=1 rustc -Z unstable-options --print target-spec-json --target "${target_triple}" > "${target_json}"
-}

--- a/meta-chromium/recipes-browser/chromium/libstd-rs_%.bbappend
+++ b/meta-chromium/recipes-browser/chromium/libstd-rs_%.bbappend
@@ -1,0 +1,9 @@
+FILES:${PN} += "${libdir}/rustlib/*/target.json"
+
+# Without this, rustc fails with "could not find specification for target ...".
+do_install:append() {
+    target_dir=`realpath "${D}${rustlibdir}"/..`
+    target_triple=`basename "${target_dir}"`
+    target_json="${target_dir}/target.json"
+    RUSTC_BOOTSTRAP=1 rustc -Z unstable-options --print target-spec-json --target "${target_triple}" > "${target_json}"
+}

--- a/meta-chromium/recipes-browser/chromium/rust_%.bbappend
+++ b/meta-chromium/recipes-browser/chromium/rust_%.bbappend
@@ -5,22 +5,3 @@
 rust_do_install:append() {
     install -m 0644 ${WORKDIR}/rust-targets/${RUST_TARGET_SYS}.json ${D}${libdir}/rustlib/${RUST_TARGET_SYS}/target.json
 }
-
-# This makes sure that all .rlib files that Chromium needs get installed. The
-# libraries installed by libstd-rs don't include e.g. libprofiler_builtins.
-# Additionally, libstd and libtest installed by libstd-rs don't follow the usual
-# naming scheme, which would trip up Chromium.
-rust_do_install:class-target:append() {
-    mkdir -p _dist
-    rlib_path="rust-std-${PV}-${RUST_TARGET_SYS}/rust-std-${RUST_TARGET_SYS}/lib/rustlib"
-    tar -C _dist -xf build/dist/rust-std-${PV}-${RUST_TARGET_SYS}.tar.xz $rlib_path
-
-    target_dir=${D}${libdir}/rustlib
-    install -d $target_dir
-    cp -r _dist/$rlib_path/${RUST_TARGET_SYS} $target_dir
-    rm -rf _dist
-}
-
-# Override the default dependency on libstd-rs, as we copy the libraries
-# manually above.
-RUSTLIB_DEP = ""

--- a/meta-chromium/recipes-browser/chromium/rust_%.bbappend
+++ b/meta-chromium/recipes-browser/chromium/rust_%.bbappend
@@ -1,7 +1,0 @@
-# Chromium copies this file to a local sysroot. For class-target, it already
-# gets installed, but for the native build we need to append this.
-# Note: this isn't strictly needed for the compilation to work, but it's easier
-# than making Chromium only copy it for the target and not the host.
-rust_do_install:append() {
-    install -m 0644 ${WORKDIR}/rust-targets/${RUST_TARGET_SYS}.json ${D}${libdir}/rustlib/${RUST_TARGET_SYS}/target.json
-}


### PR DESCRIPTION
Fixes #792.

Build and patch changes:
------------------------

In #782, we decided to depend on rust instead of libstd-rs, because the latter didn't include libprofiler_builtins and also used a naming scheme that trips up Chromium.

However, in #791 we decided to patch Chromium so that it doesn't need libprofiler_builtins any more, because the master version of the rust recipe also doesn't include it.

Finally, while investigating #792 it turned out that our approach breaks as soon as we have something that depends on libstd-rs in our dependency graph. In that scenario, both libstd-rs and rust (the latter due to our bbappend file) install Rust libraries to /usr/lib/rustlib. This first leads to Chromium build system errors (due to libstd-rs's naming scheme), and after fixing these to Rust compiler errors due to multiple versions being present.

The conclusion is now that we can depend on libstd-rs we should do so. This only requires a small change to Chromium's Rust build scripts to adapt them to the slightly different naming scheme.

License changes:
----------------

Added licenses: none.

Removed licenses: none.

Updated licenses: none.

Test-built:
-----------

* chromium-wayland:
 - nanbield, clang, MACHINE=qemuarm64

* chromium-x11:
 - master, clang,   MACHINE=qemuarm