### PR TITLE
chromium: Fix build race condition

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -13,6 +13,7 @@ B = "${S}/${OUTPUT_DIR}"
 # Backported patches.
 SRC_URI += "\
     file://backport/Make-toolchain_supports_rust_thin_lto-configurable.patch \
+    file://backport/Add-missing-components-enterprise-buildflag.patch \
 "
 # Non-specific patches.
 SRC_URI += "\

--- a/meta-chromium/recipes-browser/chromium/files/backport/Add-missing-components-enterprise-buildflag.patch
+++ b/meta-chromium/recipes-browser/chromium/files/backport/Add-missing-components-enterprise-buildflag.patch
@@ -1,0 +1,54 @@
+From d695f5ed165f88b157dcc9d150a05ce756405fa7 Mon Sep 17 00:00:00 2001
+From: Takuto Ikuta <tikuta@chromium.org>
+Date: Thu, 25 Apr 2024 07:25:32 +0000
+Subject: [PATCH] Backport "Add missing components/enterprise/buildflags
+ dependency"
+
+This is a backport of two CLs that add missing dependencies to fix a
+build race condition that would sometimes lead to build errors. Both CLs
+will be included in upstream's 126 release.
+
+Upstream-Status: Backport [https://crrev.com/c/5487538, https://crrev.com/c/5526618]
+Signed-off-by: Max Ihlenfeldt <max@igalia.com>
+---
+ chrome/browser/devtools/BUILD.gn      | 1 +
+ chrome/browser/extensions/BUILD.gn    | 1 +
+ chrome/browser/safe_browsing/BUILD.gn | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/chrome/browser/devtools/BUILD.gn b/chrome/browser/devtools/BUILD.gn
+index 159ee09..fee4c31 100644
+--- a/chrome/browser/devtools/BUILD.gn
++++ b/chrome/browser/devtools/BUILD.gn
+@@ -113,6 +113,7 @@ static_library("devtools") {
+     "//chrome/browser/autofill:autofill",
+     "//components/autofill/content/browser:browser",
+     "//components/autofill/core/browser:browser",
++    "//components/enterprise/buildflags",
+     "//components/paint_preview/buildflags:buildflags",
+     "//content/public/browser",
+     "//net",
+diff --git a/chrome/browser/extensions/BUILD.gn b/chrome/browser/extensions/BUILD.gn
+index 0ca4995..554cc16 100644
+--- a/chrome/browser/extensions/BUILD.gn
++++ b/chrome/browser/extensions/BUILD.gn
+@@ -853,6 +853,7 @@ static_library("extensions") {
+     "//components/embedder_support",
+     "//components/embedder_support:browser_util",
+     "//components/enterprise",
++    "//components/enterprise/buildflags",
+     "//components/favicon/content",
+     "//components/feedback",
+     "//components/gcm_driver",
+diff --git a/chrome/browser/safe_browsing/BUILD.gn b/chrome/browser/safe_browsing/BUILD.gn
+index 4a67fbf..031e76b 100644
+--- a/chrome/browser/safe_browsing/BUILD.gn
++++ b/chrome/browser/safe_browsing/BUILD.gn
+@@ -31,6 +31,7 @@ static_library("safe_browsing") {
+     "//chrome/common:constants",
+     "//components/browser_sync",
+     "//components/enterprise:enterprise",
++    "//components/enterprise/buildflags",
+     "//components/enterprise/common:strings",
+     "//components/keyed_service/content",
+     "//components/language/core/browser",


### PR DESCRIPTION
Fixes #811.

Build and patch changes:
------------------------

Add one backported patch to fix a build race condition that would sometimes lead to build errors.

License changes:
----------------

Added licenses: none.

Removed licenses: none.

Updated licenses: none.

Test-built:
-----------

* chromium-wayland:
 - nanbield, clang, MACHINE=qemuarm64

* chromium-x11:
 - master, clang,   MACHINE=qemuarm