### PR TITLE
chromium: Backport missing dependency in NewTabPage

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -21,6 +21,7 @@ SRC_URI += "\
     file://backport/IWYU-for-content-browser-generic_sensor-fra.patch \
     file://backport/IWYU-for-g-c-service-shared_image-ozone_ima.patch \
     file://backport/Make-toolchain_supports_rust_thin_lto-configurable.patch \
+    file://backport/NewTabPage-Add-missing-dep-to-cr_components.patch \
 "
 # Non-specific patches.
 SRC_URI += "\

--- a/meta-chromium/recipes-browser/chromium/files/backport/NewTabPage-Add-missing-dep-to-cr_components.patch
+++ b/meta-chromium/recipes-browser/chromium/files/backport/NewTabPage-Add-missing-dep-to-cr_components.patch
@@ -1,0 +1,27 @@
+From bd53e2fcd2ff2ab5f9726753b827e7f958ad1041 Mon Sep 17 00:00:00 2001
+From: dpapad <dpapad@chromium.org>
+Date: Wed, 27 Mar 2024 23:05:52 +0000
+Subject: [PATCH] Backport "NewTabPage: Add missing dep to
+ cr_components/history_clusters/."
+
+This fixes transient build error caused by missing dependency.
+The patch will be included in upstream's 125 release.
+
+Upstream-Status: Backport [https://crrev.com/c/5402989]
+Signed-off-by: Daniel Semkowicz <dse@thaumatec.com>
+---
+ chrome/browser/resources/new_tab_page/BUILD.gn | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/chrome/browser/resources/new_tab_page/BUILD.gn b/chrome/browser/resources/new_tab_page/BUILD.gn
+index db4708a51c522..96612c978bcb6 100644
+--- a/chrome/browser/resources/new_tab_page/BUILD.gn
++++ b/chrome/browser/resources/new_tab_page/BUILD.gn
+@@ -97,6 +97,7 @@ build_webui("build") {
+     "//ui/webui/resources/cr_components/color_change_listener:build_ts",
+     "//ui/webui/resources/cr_components/customize_themes:build_ts",
+     "//ui/webui/resources/cr_components/help_bubble:build_ts",
++    "//ui/webui/resources/cr_components/history_clusters:build_ts",
+     "//ui/webui/resources/cr_components/most_visited:build_ts",
+     "//ui/webui/resources/cr_components/omnibox:build_ts",
+     "//ui/webui/resources/cr_components/page_image_service:build_ts",


### PR DESCRIPTION
Dependency is missing in NewTabPage module. This can cause random build errors. Error occurrence depends on the order in which packages were build. It seems to occur more frequently with lower BB_NUMBER_THREADS values.

Build failed in my case usually with following error:
```
Error: Could not load gen/ui/webui/resources/tsc/cr_components/history_clusters/history_clusters_shared_style.css.js (imported by gen/chrome/browser/resources/new_tab_page/tsc/modules/history_clusters/suggest_tile.js): ENOENT: no such file or directory, open 'gen/ui/webui/resources/tsc/cr_components/history_clusters/history_clusters_shared_style.css.js'
```

This issue most likely occurs also on master (Chromium 122 at the moment of writing), because fix was merged in version 125. I experienced this problem only on kirkstone branch and didn't test the master. If you think this fix is also beneficial on master, I can do a rebase on 122 and push the second MR.