### PR TITLE
chromium: Backport missing dependency in NewTabPage

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -13,6 +13,7 @@ B = "${S}/${OUTPUT_DIR}"
 # Backported patches.
 SRC_URI += "\
     file://backport/Add-missing-components-enterprise-buildflag.patch \
+    file://backport/NewTabPage-Add-missing-dep-to-cr_components.patch \
 "
 
 # Non-specific patches.

--- a/meta-chromium/recipes-browser/chromium/files/backport/NewTabPage-Add-missing-dep-to-cr_components.patch
+++ b/meta-chromium/recipes-browser/chromium/files/backport/NewTabPage-Add-missing-dep-to-cr_components.patch
@@ -1,0 +1,27 @@
+From bd53e2fcd2ff2ab5f9726753b827e7f958ad1041 Mon Sep 17 00:00:00 2001
+From: dpapad <dpapad@chromium.org>
+Date: Wed, 27 Mar 2024 23:05:52 +0000
+Subject: [PATCH] Backport "NewTabPage: Add missing dep to
+ cr_components/history_clusters/."
+
+This fixes transient build error caused by missing dependency.
+The patch will be included in upstream's 125 release.
+
+Upstream-Status: Backport [https://crrev.com/c/5402989]
+Signed-off-by: Daniel Semkowicz <dse@thaumatec.com>
+---
+ chrome/browser/resources/new_tab_page/BUILD.gn | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/chrome/browser/resources/new_tab_page/BUILD.gn b/chrome/browser/resources/new_tab_page/BUILD.gn
+index 83736b4..64b5a0b 100644
+--- a/chrome/browser/resources/new_tab_page/BUILD.gn
++++ b/chrome/browser/resources/new_tab_page/BUILD.gn
+@@ -104,6 +104,7 @@ build_webui("build") {
+     "//ui/webui/resources/cr_components/color_change_listener:build_ts",
+     "//ui/webui/resources/cr_components/customize_themes:build_ts",
+     "//ui/webui/resources/cr_components/help_bubble:build_ts",
++    "//ui/webui/resources/cr_components/history_clusters:build_ts",
+     "//ui/webui/resources/cr_components/most_visited:build_ts",
+     "//ui/webui/resources/cr_components/omnibox:build_ts",
+     "//ui/webui/resources/cr_components/page_image_service:build_ts",


### PR DESCRIPTION
Cherry-pick of #815.

Build and patch changes:
------------------------

Add one backported patch to fix a build race condition that would sometimes lead to build errors.

License changes:
----------------

Added licenses: none.

Removed licenses: none.

Updated licenses: none.

Test-built:
-----------

* chromium-x11:
 - scarthgap, clang, MACHINE=qemux86-64