### PR TITLE
chromium: fix do_copy_clang_library failed for multilib

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -457,7 +457,7 @@ do_copy_clang_library () {
     # Chromium needs to link against libclang_rt.builtins.a for both host and
     # target code, and expects to find both libraries in the same directory
     # (thanks to 0008-Use-the-correct-path-to-libclang_rt.builtins.a.patch).
-    cd "${STAGING_LIBDIR}/clang"
+    cd "${STAGING_DIR_HOST}${nonarch_libdir}/clang"
     # lib_file = "./$CLANG_VERSION/lib/linux/libclang_rt.builtins-$ARCH.a"
     lib_file="$(find . -name 'libclang_rt.builtins*')"
     # stripped_lib_file = "lib/linux/libclang_rt.builtins-$ARCH.a"


### PR DESCRIPTION
Due to commit [clang: use nonarch_libdir/clang for all runtime files][1] applied, the clang runtime libraries was installed to ${nonarch_libdir}, no matter the value of libdir

Tweak it for do_copy_clang_library, use ${nonarch_libdir} to instead

[1] https://github.com/kraj/meta-clang/commit/cda1376a97b86d6ae5c92fd931f9583430c73885