### PR TITLE
[scarthgap] chromium: Use correct Rust mixin layer dependency

### DIFF
--- a/meta-chromium/conf/layer.conf
+++ b/meta-chromium/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_chromium-browser-layer = "7"
 LAYERVERSION_chromium-browser-layer = "1"
 LAYERSERIES_COMPAT_chromium-browser-layer = "scarthgap styhead walnascar"
 
-LAYERDEPENDS_chromium-browser-layer = "clang-layer core openembedded-layer lts-rust-mixin"
+LAYERDEPENDS_chromium-browser-layer = "clang-layer core openembedded-layer scarthgap-rust-mixin"


### PR DESCRIPTION
Fixes #862.

Thanks to @darren-etheridge for finding this as well as the right name to use!