### PR TITLE
firefox: remove test reporting from the workflow

### DIFF
--- a/.github/workflows/yocto_matrix.yml
+++ b/.github/workflows/yocto_matrix.yml
@@ -75,11 +75,3 @@ jobs:
       - run: |
          cd /yocto/${{ matrix.yocto_version }}
          ./meta-firefox-test/scripts/test.sh ${{ matrix.yocto_version}} ${{ matrix.arch }} ${{ matrix.ff_version }} ${{ matrix.libc_flavour}}
-      - uses: dorny/test-reporter@v1
-        if: always()
-        with:
-          path: meta-firefox/test-results/*.xml
-          reporter: java-junit
-          name: Test Results - ${{ matrix.yocto_version}} ${{ matrix.arch }} ${{ matrix.ff_version }} ${{ matrix.libc_flavour}}
-          working-directory: /yocto/${{ matrix.yocto_version }}/meta-browser
-          fail-on-empty: false


### PR DESCRIPTION
The test reporting github action fails to upload the test results with the following error:
`HttpError: Resource not accessible by integration`

I am not really sure why it started this - I have used exactly the same permissions in my repository for months. Based on some issues I have found in the repository of the action, it requires write permission to some new properties of the repository. However considering that it used to work with the current permissions for a long time, this makes uncomfortable granting anything new - hence I'd rather bid farewell to this, and maybe look for an alternative in the future.

The tests are still executed though, and their overall status is still reported as the status of the job. This is only about the test report artifact.