### PR TITLE
Run firefox without X11

### DIFF
--- a/meta-firefox/classes/mozilla.bbclass
+++ b/meta-firefox/classes/mozilla.bbclass
@@ -1,5 +1,9 @@
 SECTION = "x11/utils"
-DEPENDS:append = " gnu-config-native virtual/libintl libxt libxi zip-native gtk+ "
+DEPENDS:append = " gnu-config-native virtual/libintl \
+	${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'libxt libxi', '', d)} \
+	zip-native \
+"
+
 
 inherit pkgconfig cargo
 


### PR DESCRIPTION
This commit should remove the dependencies on needing X11 to build. So far I haven't had trouble building a wayland only system where I can compile and run a firefox browser.

Related to #821 