### PR TITLE
chromium 136.0.7103.113: Re-add patch fixing bindgen build issue

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -33,6 +33,7 @@ SRC_URI += "\
     file://0016-Disable-crabbyavif-to-fix-build-errors.patch \
     file://0017-rust-Use-adler-instead-of-adler2.patch \
     file://0018-third_party-node-update_node_binaries-Update-nodejs-.patch \
+    file://0019-Revert-Connect-the-Rust-log-crate-to-the-base-loggin.patch \
 "
 
 # Missing third_party sources.

--- a/meta-chromium/recipes-browser/chromium/files/0019-Revert-Connect-the-Rust-log-crate-to-the-base-loggin.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0019-Revert-Connect-the-Rust-log-crate-to-the-base-loggin.patch
@@ -1,0 +1,566 @@
+From a8d282ffd65a8de353a446485d730b27ccd5cd67 Mon Sep 17 00:00:00 2001
+From: Ariel D'Alessandro <ariel.dalessandro@collabora.com>
+Date: Fri, 1 Nov 2024 08:48:02 -0300
+Subject: [PATCH] Revert "Connect the Rust log crate to the //base logging
+ implementation"
+
+This reverts chromium commit 7ea0a5e831dd5 ("Connect the Rust log crate
+to the //base logging implementation".
+
+The above commit enabled bindgen for the Rust logger. Similar to patch
+0011-Disable-crabbyavif-to-fix-build-errors.patch added in commit [0],
+this fixes a build error that's most likely because the way upstream
+configures bindgen makes it incompatible with our cross-architecture
+builds.
+
+```
+| FAILED: gen/base/logging_rust_log_integration_bindgen_generator/bindings.rs
+| [...]
+| panicked at bindgen-cli/main.rs:52:36:
+| Unable to generate bindings: ClangDiagnostic("error: unsupported option '-mbranch-protection=' for target 'x86_64-unknown-linux-gnu'\n")
+```
+
+[0] meta-browser commit fd347dc ("chromium: Update to 127.0.6533.99")
+
+Upstream-Status: Inappropriate [specific to our build setup]
+Signed-off-by: Ariel D'Alessandro <ariel.dalessandro@collabora.com>
+---
+ base/BUILD.gn                                 |  47 --------
+ base/logging.cc                               |   9 --
+ base/logging/rust_log_integration.cc          |  36 ------
+ base/logging/rust_log_integration.h           |  52 --------
+ base/logging/rust_log_integration_unittest.cc |  76 ------------
+ base/logging/rust_logger.rs                   | 112 ------------------
+ base/test/BUILD.gn                            |  13 --
+ .../test/logging/test_rust_logger_consumer.rs |  41 -------
+ .../rust/chromium_crates_io/gnrt_config.toml  |   1 +
+ third_party/rust/log/v0_4/BUILD.gn            |   2 +
+ 10 files changed, 3 insertions(+), 386 deletions(-)
+ delete mode 100644 base/logging/rust_log_integration.cc
+ delete mode 100644 base/logging/rust_log_integration.h
+ delete mode 100644 base/logging/rust_log_integration_unittest.cc
+ delete mode 100644 base/logging/rust_logger.rs
+ delete mode 100644 base/test/logging/test_rust_logger_consumer.rs
+
+diff --git a/base/BUILD.gn b/base/BUILD.gn
+index 2703e81421..bf7ee56c2a 100644
+--- a/base/BUILD.gn
++++ b/base/BUILD.gn
+@@ -36,8 +36,6 @@ import("//build/config/sanitizers/sanitizers.gni")
+ import("//build/config/sysroot.gni")
+ import("//build/config/ui.gni")
+ import("//build/nocompile.gni")
+-import("//build/rust/rust_bindgen.gni")
+-import("//build/rust/rust_static_library.gni")
+ import("//build/timestamp.gni")
+ import("//build/util/process_version.gni")
+ import("//build_overrides/build.gni")
+@@ -1046,9 +1044,7 @@ component("base") {
+     # Used by metrics/crc32, except on NaCl builds.
+     deps += [ "//third_party/zlib" ]
+ 
+-    # NaCl does not support Rust.
+     deps += [
+-      ":rust_logger",
+       "//third_party/rust/serde_json_lenient/v0_2/wrapper",
+     ]
+   }
+@@ -1582,8 +1578,6 @@ component("base") {
+       "files/scoped_temp_file.h",
+       "json/json_file_value_serializer.cc",
+       "json/json_file_value_serializer.h",
+-      "logging/rust_log_integration.cc",
+-      "logging/rust_log_integration.h",
+       "memory/discardable_memory.cc",
+       "memory/discardable_memory.h",
+       "memory/discardable_memory_allocator.cc",
+@@ -2516,46 +2510,6 @@ component("base") {
+   }
+ }
+ 
+-rust_bindgen("logging_log_severity_bindgen") {
+-  # TODO(danakj): Maybe combine all base bindgen targets, or all base/logging
+-  # ones even) into a single GN target? But the GN rule needs to handle multiple
+-  # headers then.
+-  header = "logging/log_severity.h"
+-  cpp = true
+-  visibility = [ ":*" ]
+-
+-  # Transitive generated header dependency.
+-  deps = [ ":debugging_buildflags" ]
+-}
+-
+-rust_static_library("rust_logger") {
+-  allow_unsafe = true  # Unsafe needed for FFI.
+-  deps = [
+-    ":debugging_buildflags",
+-    ":logging_log_severity_bindgen",
+-    ":tracing_buildflags",
+-    "//build:chromeos_buildflags",
+-    "//third_party/rust/log/v0_4:lib",
+-
+-    # Needed because of circular dependency: base depends on this target and by
+-    # extension the cxx-generated C++ code, but the cxx-generated code includes
+-    # base headers and calls base code. This seems to generally not cause
+-    # issues, except for partition_alloc which applies configs when depended on.
+-    #
+-    # This allows the generated C++ code to transitively include partition alloc
+-    # headers without issue.
+-    #
+-    # TODO(collinbaker): determine how to handle these cxx bindings-induced
+-    # circular dependencies more robustly.
+-    "//base/allocator/partition_allocator:raw_ptr",
+-  ]
+-  visibility = [ ":base" ]
+-  sources = [ "logging/rust_logger.rs" ]
+-  crate_root = "logging/rust_logger.rs"
+-
+-  cxx_bindings = [ "logging/rust_logger.rs" ]
+-}
+-
+ if (is_linux || is_chromeos) {
+   # Split out as a separate target for two reasons:
+   # - the line number reader is 2x slower in debug builds if not optimized,
+@@ -3371,7 +3325,6 @@ test("base_unittests") {
+     "json/string_escape_unittest.cc",
+     "json/values_util_unittest.cc",
+     "lazy_instance_unittest.cc",
+-    "logging/rust_log_integration_unittest.cc",
+     "logging_unittest.cc",
+     "macros/is_empty_unittest.cc",
+     "memory/aligned_memory_unittest.cc",
+diff --git a/base/logging.cc b/base/logging.cc
+index 26ba1a286e..7bde37bb77 100644
+--- a/base/logging.cc
++++ b/base/logging.cc
+@@ -118,10 +118,6 @@ typedef FILE* FileHandle;
+ #include "base/fuchsia/scoped_fx_logger.h"
+ #endif
+ 
+-#if !BUILDFLAG(IS_NACL)
+-#include "base/logging/rust_logger.rs.h"
+-#endif
+-
+ namespace logging {
+ 
+ namespace {
+@@ -530,11 +526,6 @@ bool BaseInitLoggingImpl(const LoggingSettings& settings) {
+   }
+ #endif
+ 
+-#if !BUILDFLAG(IS_NACL)
+-  // Connects Rust logging with the //base logging functionality.
+-  internal::init_rust_log_crate();
+-#endif
+-
+   // Ignore file options unless logging to file is set.
+   if ((g_logging_destination & LOG_TO_FILE) == 0) {
+     return true;
+diff --git a/base/logging/rust_log_integration.cc b/base/logging/rust_log_integration.cc
+deleted file mode 100644
+index ba3b50bc6a..0000000000
+--- a/base/logging/rust_log_integration.cc
++++ /dev/null
+@@ -1,36 +0,0 @@
+-// Copyright 2024 The Chromium Authors
+-// Use of this source code is governed by a BSD-style license that can be
+-// found in the LICENSE file.
+-
+-#include "base/logging/rust_log_integration.h"
+-
+-#include <stdint.h>
+-
+-#include "base/logging.h"
+-#include "base/logging/log_severity.h"
+-#include "base/logging/rust_logger.rs.h"
+-#include "third_party/rust/cxx/v1/cxx.h"
+-
+-namespace logging::internal {
+-
+-LogMessageRustWrapper::LogMessageRustWrapper(const char* file,
+-                                             int line,
+-                                             ::logging::LogSeverity severity)
+-    : log_message(file, line, severity) {}
+-
+-void LogMessageRustWrapper::write_to_stream(rust::Str str) {
+-  log_message.stream().write(str.data(),
+-                             static_cast<std::streamsize>(str.size()));
+-}
+-
+-void print_rust_log(const RustFmtArguments& msg,
+-                    const char* file,
+-                    int32_t line,
+-                    int32_t severity,
+-                    bool verbose) {
+-  // TODO(danakj): If `verbose` make the log equivalent to VLOG instead of LOG.
+-  LogMessageRustWrapper wrapper(file, line, severity);
+-  msg.format(wrapper);
+-}
+-
+-}  // namespace logging::internal
+diff --git a/base/logging/rust_log_integration.h b/base/logging/rust_log_integration.h
+deleted file mode 100644
+index e1f822de66..0000000000
+--- a/base/logging/rust_log_integration.h
++++ /dev/null
+@@ -1,52 +0,0 @@
+-// Copyright 2024 The Chromium Authors
+-// Use of this source code is governed by a BSD-style license that can be
+-// found in the LICENSE file.
+-
+-#ifndef BASE_LOGGING_RUST_LOG_INTEGRATION_H_
+-#define BASE_LOGGING_RUST_LOG_INTEGRATION_H_
+-
+-#include <stddef.h>
+-#include <stdint.h>
+-
+-#include "base/base_export.h"
+-#include "base/logging.h"
+-#include "base/logging/log_severity.h"
+-#include "third_party/rust/cxx/v1/cxx.h"
+-
+-namespace logging {
+-namespace internal {
+-
+-// Opaquely wraps a Rust std::fmt::Arguments object, which can be turned into a
+-// string but must be done so from a Rust stack frame with the help of
+-// LogMessageRustWrapper below.
+-struct RustFmtArguments;
+-
+-// Receives a log line from Rust and forwards it to base logging, because
+-// logging::LogMessage is not accessible from Rust yet with our current interop
+-// tools.
+-//
+-// TODO(danakj): Should this helper function be replaced with C-like apis next
+-// to logging::LogMessage that Rust uses more directly?
+-void print_rust_log(const RustFmtArguments& msg,
+-                    const char* file,
+-                    int32_t line,
+-                    int32_t severity,
+-                    bool verbose);
+-
+-// Wraps a LogMessage object so that Rust code can write to its ostream.
+-class LogMessageRustWrapper {
+- public:
+-  LogMessageRustWrapper(const char* file,
+-                        int line,
+-                        ::logging::LogSeverity severity);
+-
+-  void write_to_stream(rust::Str str);
+-
+- private:
+-  ::logging::LogMessage log_message;
+-};
+-
+-}  // namespace internal
+-}  // namespace logging
+-
+-#endif  // BASE_LOGGING_RUST_LOG_INTEGRATION_H_
+diff --git a/base/logging/rust_log_integration_unittest.cc b/base/logging/rust_log_integration_unittest.cc
+deleted file mode 100644
+index 8fc0fec7e1..0000000000
+--- a/base/logging/rust_log_integration_unittest.cc
++++ /dev/null
+@@ -1,76 +0,0 @@
+-// Copyright 2024 The Chromium Authors
+-// Use of this source code is governed by a BSD-style license that can be
+-// found in the LICENSE file.
+-
+-#include "base/logging.h"
+-#include "base/test/logging/test_rust_logger_consumer.rs.h"
+-#include "base/test/mock_log.h"
+-
+-using testing::_;
+-
+-namespace logging {
+-namespace {
+-
+-class RustLogIntegrationTest : public testing::Test {
+- public:
+-  void SetUp() override { log_.StartCapturingLogs(); }
+-
+-  void TearDown() override { log_.StopCapturingLogs(); }
+-
+-  base::test::MockLog log_;
+-};
+-
+-// TODO(crbug.com/374023535): Logging does not work in component builds.
+-#if defined(COMPONENT_BUILD)
+-#define MAYBE_CheckAllSeverity DISABLED_CheckAllSeverity
+-#else
+-#define MAYBE_CheckAllSeverity CheckAllSeverity
+-#endif
+-TEST_F(RustLogIntegrationTest, MAYBE_CheckAllSeverity) {
+-#if DCHECK_IS_ON()
+-  // Debug and Trace logs from Rust are discarded when DCHECK_IS_ON() is false;
+-  // otherwise, they are logged as info.
+-  EXPECT_CALL(log_,
+-              Log(LOGGING_INFO, _, _, _, testing::HasSubstr("test trace log")))
+-      .WillOnce(testing::Return(true));
+-
+-  EXPECT_CALL(log_,
+-              Log(LOGGING_INFO, _, _, _, testing::HasSubstr("test debug log")))
+-      .WillOnce(testing::Return(true));
+-#endif
+-
+-  EXPECT_CALL(log_,
+-              Log(LOGGING_INFO, _, _, _, testing::HasSubstr("test info log")))
+-      .WillOnce(testing::Return(true));
+-
+-  EXPECT_CALL(log_, Log(LOGGING_WARNING, _, _, _,
+-                        testing::HasSubstr("test warning log")))
+-      .WillOnce(testing::Return(true));
+-
+-  EXPECT_CALL(log_,
+-              Log(LOGGING_ERROR, _, _, _, testing::HasSubstr("test error log")))
+-      .WillOnce(testing::Return(true));
+-
+-  base::test::print_test_trace_log();
+-  base::test::print_test_debug_log();
+-  base::test::print_test_info_log();
+-  base::test::print_test_warning_log();
+-  base::test::print_test_error_log();
+-}
+-
+-// TODO(crbug.com/374023535): Logging does not work in component builds.
+-#if defined(COMPONENT_BUILD)
+-#define MAYBE_Placeholders DISABLED_Placeholders
+-#else
+-#define MAYBE_Placeholders Placeholders
+-#endif
+-TEST_F(RustLogIntegrationTest, MAYBE_Placeholders) {
+-  EXPECT_CALL(log_, Log(LOGGING_ERROR, _, _, _,
+-                        testing::HasSubstr("test log with placeholder 2")))
+-      .WillOnce(testing::Return(true));
+-
+-  base::test::print_test_error_log_with_placeholder(2);
+-}
+-
+-}  // namespace
+-}  // namespace logging
+diff --git a/base/logging/rust_logger.rs b/base/logging/rust_logger.rs
+deleted file mode 100644
+index 0ead11739b..0000000000
+--- a/base/logging/rust_logger.rs
++++ /dev/null
+@@ -1,112 +0,0 @@
+-// Copyright 2024 The Chromium Authors
+-// Use of this source code is governed by a BSD-style license that can be
+-// found in the LICENSE file.
+-
+-chromium::import! {
+-    "//base:logging_log_severity_bindgen" as log_severity;
+-}
+-
+-use log::Level::{Debug, Error, Info, Trace, Warn};
+-use log::{LevelFilter, Metadata, Record};
+-use log_severity::logging::{LOGGING_ERROR, LOGGING_INFO, LOGGING_WARNING};
+-use std::ffi::CString;
+-use std::pin::Pin;
+-
+-struct RustLogger;
+-
+-impl log::Log for RustLogger {
+-    fn enabled(&self, _metadata: &Metadata) -> bool {
+-        // Always enabled, as it's controlled by command line flags managed by the C++
+-        // implementation.
+-        true
+-    }
+-
+-    fn log(&self, record: &Record) {
+-        // TODO(thiruak1024@gmail.com): Rather than using heap allocation to pass |msg|
+-        // and |file|, we should return a pointer and size object to leverage the
+-        // string_view object in C++. https://crbug.com/371112531
+-        let file = CString::new(record.file().unwrap())
+-            .expect("CString::new failed to create the log file name!");
+-        let wrapped_args = RustFmtArguments(*record.args());
+-        unsafe {
+-            ffi::print_rust_log(
+-                &wrapped_args,
+-                file.as_ptr(),
+-                record.line().unwrap() as i32,
+-                match record.metadata().level() {
+-                    Error => LOGGING_ERROR,
+-                    Warn => LOGGING_WARNING,
+-                    Info => LOGGING_INFO,
+-                    // Note that Debug and Trace level logs are dropped at
+-                    // compile time at the macro call-site when DCHECK_IS_ON()
+-                    // is false. This is done through a Cargo feature.
+-                    Debug | Trace => LOGGING_INFO,
+-                },
+-                record.metadata().level() == Trace,
+-            )
+-        }
+-    }
+-    fn flush(&self) {}
+-}
+-
+-static RUST_LOGGER: RustLogger = RustLogger;
+-
+-/// Wrap a `std::fmt::Arguments` to pass to C++ code.
+-struct RustFmtArguments<'a>(std::fmt::Arguments<'a>);
+-
+-impl<'a> RustFmtArguments<'a> {
+-    /// Format `msg` to the C++-provided stream in `wrapper`.
+-    fn format(&self, mut wrapper: Pin<&mut ffi::LogMessageRustWrapper>) {
+-        // No error expected because our `Write` impl below is infallible.
+-        std::fmt::write(&mut wrapper, self.0).unwrap();
+-    }
+-}
+-
+-// Glue impl to use std::fmt tools with `ffi::LogMessageRustWrapper`.
+-impl std::fmt::Write for Pin<&mut ffi::LogMessageRustWrapper> {
+-    fn write_str(&mut self, s: &str) -> Result<(), std::fmt::Error> {
+-        self.as_mut().write_to_stream(s);
+-        Ok(())
+-    }
+-}
+-
+-#[cxx::bridge(namespace = "logging::internal")]
+-mod ffi {
+-    extern "Rust" {
+-        type RustFmtArguments<'a>;
+-
+-        fn format(&self, wrapper: Pin<&mut LogMessageRustWrapper>);
+-
+-        fn init_rust_log_crate();
+-    }
+-
+-    unsafe extern "C++" {
+-        include!("base/logging/rust_log_integration.h");
+-
+-        /// Wraps a C++ LogMessage object so we can write to its ostream.
+-        type LogMessageRustWrapper;
+-
+-        /// Write a block of characters to the stream.
+-        fn write_to_stream(self: Pin<&mut LogMessageRustWrapper>, s: &str);
+-
+-        /// Emit a log message to the C++-managed logger. `msg` is passed back
+-        /// to `format_to_wrapped_message` to be stringified.
+-        unsafe fn print_rust_log(
+-            msg: &RustFmtArguments,
+-            file: *const c_char,
+-            line: i32,
+-            severity: i32,
+-            verbose: bool,
+-        );
+-    }
+-}
+-
+-pub fn init_rust_log_crate() {
+-    // An error may occur if set_logger has already been called, which can happen
+-    // during unit tests. In that case, return from the method without executing the
+-    // subsequent code.
+-    if let Err(_) = log::set_logger(&RUST_LOGGER) {
+-        return;
+-    };
+-    log::set_max_level(LevelFilter::Trace);
+-}
+diff --git a/base/test/BUILD.gn b/base/test/BUILD.gn
+index 5beef03e5f..282354c538 100644
+--- a/base/test/BUILD.gn
++++ b/base/test/BUILD.gn
+@@ -6,7 +6,6 @@ import("//build/compiled_action.gni")
+ import("//build/config/features.gni")
+ import("//build/config/nacl/config.gni")
+ import("//build/config/ui.gni")
+-import("//build/rust/rust_static_library.gni")
+ import("//build_overrides/build.gni")
+ import("//third_party/protobuf/proto_library.gni")
+ 
+@@ -38,17 +37,6 @@ static_library("test_config") {
+   ]
+ }
+ 
+-rust_static_library("test_rust_logger_consumer") {
+-  allow_unsafe = true  # Unsafe needed for FFI
+-  testonly = true
+-  deps = [ "//third_party/rust/log/v0_4:lib" ]
+-  sources = [ "logging/test_rust_logger_consumer.rs" ]
+-
+-  crate_root = "logging/test_rust_logger_consumer.rs"
+-
+-  cxx_bindings = [ "logging/test_rust_logger_consumer.rs" ]
+-}
+-
+ static_library("test_support") {
+   testonly = true
+   sources = [
+@@ -192,7 +180,6 @@ static_library("test_support") {
+ 
+   public_deps = [
+     ":test_config",
+-    ":test_rust_logger_consumer",
+     "//base",
+     "//base:base_static",
+     "//base:i18n",
+diff --git a/base/test/logging/test_rust_logger_consumer.rs b/base/test/logging/test_rust_logger_consumer.rs
+deleted file mode 100644
+index dc8adc6b85..0000000000
+--- a/base/test/logging/test_rust_logger_consumer.rs
++++ /dev/null
+@@ -1,41 +0,0 @@
+-// Copyright 2024 The Chromium Authors
+-// Use of this source code is governed by a BSD-style license that can be
+-// found in the LICENSE file.
+-
+-use log::{debug, error, info, trace, warn};
+-
+-#[cxx::bridge(namespace = "base::test")]
+-mod ffi {
+-    extern "Rust" {
+-        fn print_test_info_log();
+-        fn print_test_warning_log();
+-        fn print_test_error_log();
+-        fn print_test_debug_log();
+-        fn print_test_trace_log();
+-        fn print_test_error_log_with_placeholder(i: i32);
+-    }
+-}
+-
+-pub fn print_test_info_log() {
+-    info!("test info log");
+-}
+-
+-pub fn print_test_warning_log() {
+-    warn!("test warning log");
+-}
+-
+-pub fn print_test_error_log() {
+-    error!("test error log");
+-}
+-
+-pub fn print_test_debug_log() {
+-    debug!("test debug log");
+-}
+-
+-pub fn print_test_trace_log() {
+-    trace!("test trace log");
+-}
+-
+-fn print_test_error_log_with_placeholder(i: i32) {
+-    error!("test log with placeholder {}", i);
+-}
+diff --git a/third_party/rust/chromium_crates_io/gnrt_config.toml b/third_party/rust/chromium_crates_io/gnrt_config.toml
+index 84de45c336..121b4d1921 100644
+--- a/third_party/rust/chromium_crates_io/gnrt_config.toml
++++ b/third_party/rust/chromium_crates_io/gnrt_config.toml
+@@ -207,6 +207,7 @@ ban_features = [
+ license_files= ["LICENSE.txt"]
+ 
+ [crate.log]
++group = 'test'
+ 
+ [crate.miniz_oxide.extra_kv]
+ # Web tests (aka WPT tests, also formerly known as Layout Tests) require fast
+diff --git a/third_party/rust/log/v0_4/BUILD.gn b/third_party/rust/log/v0_4/BUILD.gn
+index f2f0679a8b..73c3a8acee 100644
+--- a/third_party/rust/log/v0_4/BUILD.gn
++++ b/third_party/rust/log/v0_4/BUILD.gn
+@@ -47,4 +47,6 @@ cargo_crate("lib") {
+   rustflags = [
+     "--cap-lints=allow",  # Suppress all warnings in crates.io crates
+   ]
++
++  testonly = true
+ }


### PR DESCRIPTION
Issue: https://github.com/OSSystems/meta-browser/issues/901
Original PR: https://github.com/OSSystems/meta-browser/pull/902

Reported in comment https://github.com/OSSystems/meta-browser/issues/901#issuecomment-3128523426

```
Commit 979d7470 ("chromium: Update to 136.0.7103.113") removed patch 0015-Revert-Connect-the-Rust-log-crate-to-the-base-loggin.patch.

However, the build issue still persists so re-add and rebase this patch on top of the new chromium release.
```

