### PR TITLE
fix: Fix compilation error with arm targets

### DIFF
--- a/meta-chromium/recipes-browser/chromium/files/0009-Adjust-the-Rust-build-to-our-needs.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0009-Adjust-the-Rust-build-to-our-needs.patch
@@ -68,7 +68,7 @@ index 74b3b9ced5..5affd0b445 100644
        # https://github.com/rust-lang/rust/issues/44722
        if (arm_use_neon) {
 -        rust_abi_target = "thumbv7neon-unknown-linux-gnueabi" + float_suffix
-+        rust_abi_target = "thumbv7neon" + vendor + "-linux-gnueabi" + float_suffix
++        rust_abi_target = "armv7" + vendor + "-linux-gnueabi" + float_suffix
        } else {
 -        rust_abi_target = "armv7-unknown-linux-gnueabi" + float_suffix
 +        rust_abi_target = "armv7" + vendor + "-linux-gnueabi" + float_suffix


### PR DESCRIPTION
Chromium provides precompiled Rust toolchains for all supported targets.
In contrast, Yocto builds and ships a single Rust toolchain per build and does not distinguish between NEON and non-NEON Rust ABI targets.

Update the target from `thumbv7neon` to `armv7` to prevent missing Rust ABI errors when compiling for NEON-enabled ARM.