### PR TITLE
chromium: Fix compile errors on arm32 architecture

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -222,6 +222,13 @@ DEBUG_FLAGS:remove:x86 = "-g"
 DEBUG_FLAGS:append:x86 = "-g1"
 GN_ARGS += "symbol_level=0"
 
+# For ARM builds, completely remove debug flags that cause binary size issues
+# This prevents the "output file too large" linker error on ARM32
+CFLAGS:remove:arm = "-g"
+CXXFLAGS:remove:arm = "-g"
+TARGET_CFLAGS:remove:arm = "-g"
+TARGET_CXXFLAGS:remove:arm = "-g"
+
 # As of Chromium 62.0.3202.94 and Yocto Rocko (GCC 7, binutils 2.29), passing
 # -g to the compiler results in many linker errors on aarch64, such as:
 # obj/third_party/WebKit/Source/modules/payments/libpayments.a(PaymentEventDataConversion.o)(.debug_loc+0x4e25): error: relocation overflow in R_AARCH64_ABS32

--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -34,6 +34,7 @@ SRC_URI += "\
     file://0017-rust-Use-adler-instead-of-adler2.patch \
     file://0018-third_party-node-update_node_binaries-Update-nodejs-.patch \
     file://0019-Reduce-minimum-browser-window-width-to-480px.patch \
+    file://0020-rust-filter-out-arm-specific-flags-from-rust-compile.patch \
 "
 
 # Missing third_party sources.

--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -35,6 +35,7 @@ SRC_URI += "\
     file://0018-third_party-node-update_node_binaries-Update-nodejs-.patch \
     file://0019-Reduce-minimum-browser-window-width-to-480px.patch \
     file://0020-rust-filter-out-arm-specific-flags-from-rust-compile.patch \
+    file://0021-chromium-fix-v4l2-compiler-error-on-arm.patch \
 "
 
 # Missing third_party sources.

--- a/meta-chromium/recipes-browser/chromium/files/0020-rust-filter-out-arm-specific-flags-from-rust-compile.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0020-rust-filter-out-arm-specific-flags-from-rust-compile.patch
@@ -1,0 +1,29 @@
+From f29addf315e55f371c7c9a973002607a628ea3ea Mon Sep 17 00:00:00 2001
+From: Caner Altinbasak <cal@brightsign.biz>
+Date: Fri, 25 Jul 2025 13:00:14 +0100
+Subject: [PATCH] rust: filter out arm specific flags from rust compiler
+
+Upstream-Status: Inappropriate [specific to our build setup]
+---
+ build/rust/filter_clang_args.py | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/build/rust/filter_clang_args.py b/build/rust/filter_clang_args.py
+index 5a1843c0df..7fb4b49516 100644
+--- a/build/rust/filter_clang_args.py
++++ b/build/rust/filter_clang_args.py
+@@ -24,6 +24,11 @@ def filter_clang_args(clangargs):
+           pass
+         elif args[i].startswith('-plugin-arg'):
+           i += 2
++      # Filter out ARM-specific flags that aren't supported on other architectures
++      elif args[i].startswith('-mbranch-protection'):
++        pass  # Skip this argument
++      elif args[i].startswith('-mfpu='):
++        pass
+       else:
+         yield args[i]
+       i += 1
+-- 
+2.39.5
+

--- a/meta-chromium/recipes-browser/chromium/files/0021-chromium-fix-v4l2-compiler-error-on-arm.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0021-chromium-fix-v4l2-compiler-error-on-arm.patch
@@ -1,0 +1,31 @@
+From 568dd0026ac86878bf6f0c99ac837a964525860f Mon Sep 17 00:00:00 2001
+From: Caner Altinbasak <cal@brightsign.biz>
+Date: Sat, 26 Jul 2025 12:47:57 +0100
+Subject: [PATCH] chromium: fix v4l2 compiler error on arm
+
+fixes:
+../../media/gpu/v4l2/legacy/v4l2_video_decoder_backend_stateful.cc:450:20:
+error: non-constant-expression cannot be narrowed from type '__suseconds64_t'
+(aka 'long long') to 'long' in initializer list [-Wc++11-narrowing]
+
+Upstream-Status: Inappropriate [specific to our build setup]
+---
+ media/gpu/v4l2/legacy/v4l2_video_decoder_backend_stateful.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/media/gpu/v4l2/legacy/v4l2_video_decoder_backend_stateful.cc b/media/gpu/v4l2/legacy/v4l2_video_decoder_backend_stateful.cc
+index b77f2b08d7..9069b97c02 100644
+--- a/media/gpu/v4l2/legacy/v4l2_video_decoder_backend_stateful.cc
++++ b/media/gpu/v4l2/legacy/v4l2_video_decoder_backend_stateful.cc
+@@ -447,7 +447,7 @@ void V4L2StatefulVideoDecoderBackend::OnOutputBufferDequeued(
+     const struct timeval timeval = buffer->GetTimeStamp();
+     const struct timespec timespec = {
+         .tv_sec = timeval.tv_sec,
+-        .tv_nsec = timeval.tv_usec * 1000,
++        .tv_nsec = static_cast<long>(timeval.tv_usec * 1000),
+     };
+ 
+     const int64_t flat_timespec =
+-- 
+2.39.5
+


### PR DESCRIPTION
This pull request adds two new patches to the Chromium build for ARM platforms, addressing build and compiler errors specific to ARM architectures. The main changes include filtering out unsupported ARM-specific flags from Rust compiler arguments and fixing a narrowing conversion error in the V4L2 video decoder backend. Additionally, debug flags are removed for ARM builds to prevent linker errors due to large binary sizes.

ARM-specific build and compiler fixes:

* Added `0020-rust-filter-out-arm-specific-flags-from-rust-compile.patch` to filter out `-mbranch-protection` and `-mfpu=` flags from Rust compiler arguments, which are not supported on non-ARM architectures. (`meta-chromium/recipes-browser/chromium/chromium-gn.inc`, `meta-chromium/recipes-browser/chromium/files/0020-rust-filter-out-arm-specific-flags-from-rust-compile.patch`) [[1]](diffhunk://#diff-436bebc7f6c04ff6040b2273ced509fa01ef9453a4fe30c569445ee21e37e364R37-R38) [[2]](diffhunk://#diff-d05e519feca151335f1f23634e8be89d0dec00801dc94f2ac1602934847e1ac9R1-R29)
* Added `0021-chromium-fix-v4l2-compiler-error-on-arm.patch` to fix a narrowing conversion error in `v4l2_video_decoder_backend_stateful.cc` by explicitly casting the value to `long`. (`meta-chromium/recipes-browser/chromium/chromium-gn.inc`, `meta-chromium/recipes-browser/chromium/files/0021-chromium-fix-v4l2-compiler-error-on-arm.patch`) [[1]](diffhunk://#diff-436bebc7f6c04ff6040b2273ced509fa01ef9453a4fe30c569445ee21e37e364R37-R38) [[2]](diffhunk://#diff-b4ce43b1baec1e405deefbd0647ef8bdac867b6d2464f50983005559fc16a740R1-R31)

ARM build configuration improvements:

* Removed debug flags (`-g`) from various compiler variables for ARM builds to prevent "output file too large" linker errors on ARM32. (`meta-chromium/recipes-browser/chromium/chromium-gn.inc`)