### PR TITLE
scarthgap: chromium: Fix build with Rust >= 1.86

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -53,6 +53,8 @@ SRC_URI:append:libc-musl = "\
     file://musl/0015-fix-libc-version-include.patch \
 "
 
+SRC_URI:append = "${@oe.utils.version_less_or_equal('RUSTVERSION', '1.85', '', ' file://0016-Fix-adler-reference-for-Rust-1.86-and-later.patch', d)}"
+
 ANY_OF_DISTRO_FEATURES = "opengl vulkan"
 
 # Append instead of assigning; the gtk-icon-cache class inherited above also

--- a/meta-chromium/recipes-browser/chromium/files/0016-Fix-adler-reference-for-Rust-1.86-and-later.patch
+++ b/meta-chromium/recipes-browser/chromium/files/0016-Fix-adler-reference-for-Rust-1.86-and-later.patch
@@ -1,0 +1,28 @@
+From 416c6c72c9be8092911b68d0edc2f96a1b0ad349 Mon Sep 17 00:00:00 2001
+From: Alexander Stein <alexander.stein@ew.tq-group.com>
+Date: Wed, 3 Sep 2025 11:26:19 +0200
+Subject: [PATCH 1/1] Fix adler reference for Rust 1.86 and later
+
+Since version 1.86.0 Rust ships adler2. Adjust the reference.
+
+Signed-off-by: Alexander Stein <alexander.stein@ew.tq-group.com>
+---
+ build/rust/std/BUILD.gn | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/rust/std/BUILD.gn b/build/rust/std/BUILD.gn
+index 38e5ab76457dd..ca5d97ea7ef81 100644
+--- a/build/rust/std/BUILD.gn
++++ b/build/rust/std/BUILD.gn
+@@ -74,7 +74,7 @@ if (toolchain_has_rust) {
+     # These are no longer present in the Windows toolchain.
+     stdlib_files += [
+       "addr2line",
+-      "adler",
++      "adler2",
+       "gimli",
+       "libc",
+       "memchr",
+-- 
+2.43.0
+


### PR DESCRIPTION
Rust 1.86 ships adler2, so the library name has to be adjusted accordingly.

Fixes #909