### PR TITLE
chromium: Remove defunct LLVM version check logic

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -420,26 +420,6 @@ python do_create_v8_qemu_wrapper () {
 do_create_v8_qemu_wrapper[dirs] = "${B}"
 addtask create_v8_qemu_wrapper after do_patch before do_configure
 
-# Check the LLVMVERSION defined in the meta-clang layer. Given Chromium is
-# developed using new C++ features, the LLVMVERSION has to be >= 14. Otherwise,
-# it is not guaranteed that Chromium will compile.
-python do_check_llvm_version () {
-  from distutils.version import LooseVersion
-
-  min_llvm_version = "14.0.0"
-  llvm_version = d.getVar('LLVMVERSION', False)
-  if not llvm_version:
-    bb.warn("Unable to determine LLVM version. Chromium may not be compiled "
-            "successfully if the LLVM version is below %s." % min_llvm_version)
-    return
-
-  if LooseVersion(llvm_version) < LooseVersion(min_llvm_version):
-    bb.fatal("Your LLVMVERSION (%s) is lower than the minimum required "
-             "LLVMVERSION (%s). If you are using dunfell, make sure you "
-             "use dunfell-clang14 branch." % (llvm_version, min_llvm_version))
-}
-addtask check_llvm_version before do_configure
-
 python do_write_toolchain_file () {
     """Writes a BUILD.gn file for Yocto detailing its toolchains."""
     toolchain_dir = d.expand("${S}/build/toolchain/yocto")


### PR DESCRIPTION
The new core LLVM support lacks an equivalent of LLVMVERSION as exposed by meta-clang, resulting in this benign WARNING:

    WARNING: mc:house:chromium-ozone-wayland-140.0.7339.136-r0 do_check_llvm_version: Unable to determine LLVM version. Chromium may not be compiled successfully if the LLVM version is below 14.0.0.

LLVM-14 was released nearly four years ago. Upstream chromium's current policy is summarized here:

    https://chromium.googlesource.com/chromium/src/+/main/docs/toolchain_support.md

...and quoting the releavant portion:

    Even within clang/libc++, we often rely on recent bugfixes and
    feature additions, so generally only the most recent LLVM version
    is supported.

Silence the warning by dropping the bitrotted version enforement logic.