### PR TITLE
scarthgap: chromium: Fixed rust version check

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -53,7 +53,7 @@ SRC_URI:append:libc-musl = "\
     file://musl/0015-fix-libc-version-include.patch \
 "
 
-SRC_URI:append = "${@oe.utils.version_less_or_equal('RUSTVERSION', '1.85', '', ' file://0016-Fix-adler-reference-for-Rust-1.86-and-later.patch', d)}"
+SRC_URI:append = "${@oe.utils.version_less_or_equal('RUSTVERSION', '1.85.1', '', ' file://0016-Fix-adler-reference-for-Rust-1.86-and-later.patch', d)}"
 
 ANY_OF_DISTRO_FEATURES = "opengl vulkan"
 


### PR DESCRIPTION
Recently added Adler/Adler2 patch is incorrectly triggered by Rust 1.85.1.

The version check doesn’t exclude Rust 1.85.1, so the patch intended for 1.86+ is applied and causes the build to fail.