### PR TITLE
nodejs-oe-cache-native: Remove use of UNPACKDIR

### DIFF
--- a/meta-chromium/recipes-devtools/nodejs/nodejs-oe-cache-native_22.11.bb
+++ b/meta-chromium/recipes-devtools/nodejs/nodejs-oe-cache-native_22.11.bb
@@ -8,13 +8,10 @@ SRC_URI = "\
 
 inherit native
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
-
 B = "${WORKDIR}/build"
 
 do_configure() {
-    sed -e 's!@@libdir@@!${libdir}!g' < '${UNPACKDIR}/oe-npm-cache' > '${B}/oe-npm-cache'
+    sed -e 's!@@libdir@@!${libdir}!g' < '${WORKDIR}/oe-npm-cache' > '${B}/oe-npm-cache'
 }
 
 do_install() {


### PR DESCRIPTION
The recipe was backported from a newer version but didn't account for scarthgap lacking the new UNPACKDIR behavior. Building this recipe in scarthgap results in a do_configure failure:

	/mnt/ssd/poky-scarthgap/build/tmp/work/x86_64-linux/nodejs-oe-cache-native/22.11/temp/run.do_configure.988441: line 144: /mnt/ssd/poky-scarthgap/build/tmp/work/x86_64-linux/nodejs-oe-cache-native/22.11/sources/oe-npm-cache: No such file or directory
	WARNING: /mnt/ssd/poky-scarthgap/build/tmp/work/x86_64-linux/nodejs-oe-cache-native/22.11/temp/run.do_configure.988441:144 exit 1 from 'sed -e 's!@@libdir@@!/mnt/ssd/poky-scarthgap/build/tmp/work/x86_64-linux/nodejs-oe-cache-native/22.11/recipe-sysroot-native/usr/lib!g' < '/mnt/ssd/poky-scarthgap/build/tmp/work/x86_64-linux/nodejs-oe-cache-native/22.11/sources/oe-npm-cache' > '/mnt/ssd/poky-scarthgap/build/tmp/work/x86_64-linux/nodejs-oe-cache-native/22.11/build/oe-npm-cache''

Change UNPACKDIR to WORKDIR to be compatible with scarthgap.