### PR TITLE
meta-chromium: Support only wrynose

### DIFF
--- a/meta-chromium/conf/layer.conf
+++ b/meta-chromium/conf/layer.conf
@@ -9,6 +9,6 @@ BBFILE_PATTERN_chromium-browser-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_chromium-browser-layer = "7"
 
 LAYERVERSION_chromium-browser-layer = "1"
-LAYERSERIES_COMPAT_chromium-browser-layer = "whinlatter wrynose"
+LAYERSERIES_COMPAT_chromium-browser-layer = "wrynose"
 
 LAYERDEPENDS_chromium-browser-layer = "core openembedded-layer"


### PR DESCRIPTION
With the gn recipe addendum removed, Chromium 145/146 can't be built from master when coupled with the openembedded-core whinlatter branch.