### PR TITLE
chromium: Fix build with non-default TARGET_VENDOR [whinlatter]

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -470,7 +470,7 @@ do_copy_clang_library () {
 
     lib_file=$(find $(find . -maxdepth 1 \! \( -name latest -o -name '.' \)) \( -name "libclang_rt.builtins-*" -o -name "liborc_rt-*" \))
     echo "lib_file = $lib_file"
-    export CHROMIUM_TARGET_TRIPLET="$(echo ${RUST_TARGET_SYS} | sed 's:-oe-:-unknown-:')"
+    export CHROMIUM_TARGET_TRIPLET="$(echo ${RUST_TARGET_SYS} | sed 's:${TARGET_VENDOR}-:-unknown-:')"
 
     mkdir -p "latest/lib/${CHROMIUM_TARGET_TRIPLET}"
     echo "Executing cp $lib_file latest/lib/${CHROMIUM_TARGET_TRIPLET}/"
@@ -490,7 +490,7 @@ do_copy_clang_library () {
     cp -r * "$native_arch_path"
 
     if [ "${TARGET_ARCH}" != "${BUILD_ARCH}" ]; then
-        export CHROMIUM_BUILD_TRIPLET="$(echo ${RUST_BUILD_SYS} | sed 's:-oe-:-unknown-:')"
+        export CHROMIUM_BUILD_TRIPLET="$(echo ${RUST_BUILD_SYS} | sed 's:${HOST_VENDOR}-:-unknown-:')"
         cd "${STAGING_LIBDIR_NATIVE}/clang"
         if [ -d "latest/lib/linux" ]; then
             rm -rf "latest/lib/${CHROMIUM_BUILD_TRIPLET}"


### PR DESCRIPTION
The sed invocation assumes TARGET_VENDOR is "-oe", which causes this error for yocto configurations which set TARGET_VENDOR or HOST_VENDOR:

    ninja: error: '.../libclang_rt.builtins.a', needed by '.../liballoc_error_handler_impl.a', missing and no known rule to make it

Fix by using "${TARGET_VENDOR}-" and "${HOST_VENDOR}-", not "-oe-".

See https://github.com/OSSystems/meta-browser/issues/974