### PR TITLE
chromium: Drop redundant V4L2 feature flags

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -373,7 +373,7 @@ CHROMIUM_EXTRA_ARGS ?= " \
         ${@bb.utils.contains('PACKAGECONFIG', 'use-egl', '--use-angle=gles-egl', '', d)} \
         ${@bb.utils.contains('PACKAGECONFIG', 'kiosk-mode', '--kiosk --no-first-run --incognito', '', d)} \
         ${@bb.utils.contains('PACKAGECONFIG', 'gtk4', '--gtk-version=4', '', d)} \
-        ${@bb.utils.contains('PACKAGECONFIG', 'use-v4l2', '--ozone-platform-hint=wayland --enable-features=AcceleratedVideoDecoder,AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL', '', d)} \
+        ${@bb.utils.contains('PACKAGECONFIG', 'use-v4l2', '--ozone-platform-hint=wayland --enable-features=AcceleratedVideoDecoder', '', d)} \
 "
 
 # V8's JIT infrastructure requires binaries such as mksnapshot and


### PR DESCRIPTION
AcceleratedVideoDecodeLinuxZeroCopyGL and AcceleratedVideoDecodeLinuxGL are enabled by default.
Only AcceleratedVideoDecoder is required.

https://chromium.googlesource.com/chromium/src/+/616cc2be25e6cef124f905a40e215c0e377701de