### PR TITLE
firefox: remove hard clang dependency

### DIFF
--- a/meta-firefox/classes/mozilla.bbclass
+++ b/meta-firefox/classes/mozilla.bbclass
@@ -36,6 +36,8 @@ export WASM_CXX = "${WASI_SYSROOT}/bin/clang++ -target wasm32-wasip1 "
 
 export BUILD_VERBOSE_LOG = "1"
 
+export MOZ_MAKE_FLAGS = "${PARALLEL_MAKE}"
+
 RUST_HOST ?= "${RUST_BUILD_SYS}"
 RUST_TARGET ?= "${RUST_HOST_SYS}"
 

--- a/meta-firefox/recipes-browser/firefox/firefox-latest/llama.cpp-unknown-type-name-__fp16.patch
+++ b/meta-firefox/recipes-browser/firefox/firefox-latest/llama.cpp-unknown-type-name-__fp16.patch
@@ -1,0 +1,21 @@
+Fixes error on 32-bit arm:
+
+E [...]/third_party/llama.cpp/ggml/src/ggml-cpu/simd-mappings.h:45:9: error: unknown type name '__fp16'; did you mean '__bf16'?
+
+Solution taken from
+https://stackoverflow.com/questions/31242106/fp16-type-undefined-in-gnu-arm-c
+
+Upstream-Status: Pending
+Signed-off-by: Gyorgy Sarvari <skandigraun@gmail.com>
+
+--- ./third_party/llama.cpp/moz.build.orig	2026-05-30 08:47:27.294716362 +0200
++++ ./third_party/llama.cpp/moz.build	2026-05-30 08:20:07.478595605 +0200
+@@ -45,6 +45,8 @@
+ elif CONFIG['TARGET_CPU'] == 'aarch64':
+     SOURCES += files['ARM64_SOURCES']
+ elif CONFIG['TARGET_CPU'] == 'arm':
++    CXXFLAGS += ["-mfp16-format=ieee"]
++    CFLAGS += ["-mfp16-format=ieee"]
+     SOURCES += files['ARM_SOURCES']
+ else:
+     DEFINES["GGML_CPU_GENERIC"] = 1

--- a/meta-firefox/recipes-browser/firefox/firefox.inc
+++ b/meta-firefox/recipes-browser/firefox/firefox.inc
@@ -54,7 +54,6 @@ SRC_URI += "https://ftp.mozilla.org/pub/firefox/releases/${PV}/source/firefox-${
            file://0001-Add-option-to-disable-arm-hw-crypto-engine.patch \
            file://0001-Fix-conflicting-types-for-once_flag-and-call_once-wi.patch \
            file://fix-glibc-2.43-compilation.patch \
-           file://freebl-ignore-unused-arguments-during-configure.patch \
            file://debian-hacks/Add-another-preferences-directory-for-applications-p.patch \
            file://debian-hacks/Avoid-using-vmrs-vmsr-on-armel.patch \
            file://debian-hacks/Avoid-wrong-sessionstore-data-to-keep-windows-out-of.patch \
@@ -72,6 +71,10 @@ SRC_URI += "https://ftp.mozilla.org/pub/firefox/releases/${PV}/source/firefox-${
            file://prefs/Don-t-auto-disable-extensions-in-system-directories.patch \
            file://prefs/Set-DPI-to-system-settings.patch \
            "
+
+SRC_URI:append:toolchain-gcc = " file://fix-gcc-compilation.patch"
+SRC_URI:append:toolchain-clang = " file://freebl-ignore-unused-arguments-during-configure.patch"
+SRC_URI:append:riscv64:toolchain-gcc = " file://msgpack-enforce-endian-functionality.patch"
 
 SRCREV_FORMAT = "default"
 
@@ -91,8 +94,6 @@ SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'forbid-multiple-compositors',
            'file://prefs/single-compositor.js \
             file://fixes/0001-Enable-to-suppress-multiple-compositors.patch \
            ', '', d)}"
-
-TOOLCHAIN:pn-firefox = "clang"
 
 DISABLE_STATIC = ""
 

--- a/meta-firefox/recipes-browser/firefox/firefox/fix-gcc-compilation.patch
+++ b/meta-firefox/recipes-browser/firefox/firefox/fix-gcc-compilation.patch
@@ -1,0 +1,21 @@
+By default, OE sets "-Wformat-security" in the CFLAGS variable.
+One particular module in the Firefox tree is trying to disable all
+such warnings, however it doesn't disable the -Wformat-security
+flag in particular, and due to this, compilation fails with the
+following error:
+
+cc1plus: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
+
+Add this missing warning removal to the list of ignored warnings.
+
+Upstream-Status: Inappropriate [oe-specific]
+Signed-off-by: Gyorgy Sarvari <skandigraun@gmail.com>
+
+--- ./js/src/xsum/moz.build.orig	2026-05-29 10:18:14.888226193 +0200
++++ ./js/src/xsum/moz.build	2026-05-29 10:18:29.490810894 +0200
+@@ -17,4 +17,4 @@
+ ]
+ 
+ # Suppress warnings in third-party code.
+-SOURCES['xsum.cpp'].flags += ['-Wno-implicit-fallthrough', '-Wno-format', '-Wno-unused-value']
++SOURCES['xsum.cpp'].flags += ['-Wno-implicit-fallthrough', '-Wno-format', '-Wno-unused-value', '-Wno-format-security']

--- a/meta-firefox/recipes-browser/firefox/firefox/freebl-ignore-unused-arguments-during-configure.patch
+++ b/meta-firefox/recipes-browser/firefox/firefox/freebl-ignore-unused-arguments-during-configure.patch
@@ -1,4 +1,4 @@
-Clang sends warnings about unsued command line arguments to stderr during configuring
+Clang sends warnings about unused command line arguments to stderr during configuring
 freebl (which is enabled for targets without hw crypto support). Gyp only checks
 if there is anything on stderr, but not the content - it throws an error like this:
 

--- a/meta-firefox/recipes-browser/firefox/firefox/msgpack-enforce-endian-functionality.patch
+++ b/meta-firefox/recipes-browser/firefox/firefox/msgpack-enforce-endian-functionality.patch
@@ -1,0 +1,39 @@
+From f6ddc9b85adaa58f6426544e2bd1bd16e0aecd70 Mon Sep 17 00:00:00 2001
+From: Takatoshi Kondo <redboltz@gmail.com>
+Date: Sat, 8 Sep 2018 20:06:00 +0900
+Subject: [PATCH] Added enforcing endian functionality.
+
+Fixes error with gcc@riscv:
+third_party/msgpack/include/msgpack/sysdep.h:146:5: error: #error msgpack-c supports only big endian and little endian
+
+Upstream-Status: Backport [https://github.com/msgpack/msgpack-c/commit/f6ddc9b85adaa58f6426544e2bd1bd16e0aecd70]
+Signed-off-by: Gyorgy Sarvari <skandigraun@gmail.com>
+
+---
+ include/msgpack/sysdep.h | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/include/msgpack/sysdep.h b/include/msgpack/sysdep.h
+index 569ae4cdf..b430956b4 100644
+--- a/third_party/msgpack/include/msgpack/sysdep.h
++++ b/third_party/msgpack/include/msgpack/sysdep.h
+@@ -10,8 +10,6 @@
+ #ifndef MSGPACK_SYSDEP_H
+ #define MSGPACK_SYSDEP_H
+ 
+-#include <msgpack/predef.h>
+-
+ #include <stdlib.h>
+ #include <stddef.h>
+ 
+@@ -86,6 +84,10 @@
+ 
+ #endif
+ 
++#if !defined(MSGPACK_ENDIAN_LITTLE_BYTE) && !defined(MSGPACK_ENDIAN_BIG_BYTE)
++#include <msgpack/predef/other/endian.h>
++#endif // !defined(MSGPACK_ENDIAN_LITTLE_BYTE) && !defined(MSGPACK_ENDIAN_BIG_BYTE)
++
+ #if MSGPACK_ENDIAN_LITTLE_BYTE
+ 
+ #   if defined(unix) || defined(__unix) || defined(__APPLE__) || defined(__OpenBSD__)

--- a/meta-firefox/recipes-browser/firefox/firefox_151.0.2.bb
+++ b/meta-firefox/recipes-browser/firefox/firefox_151.0.2.bb
@@ -13,6 +13,8 @@ SRC_URI:append:libc-musl = " \
     file://fix-undeclared-identifier__NR_riscv_hwprobe.patch \
     "
 
+SRC_URI:append:toolchain-gcc:arm = " file://llama.cpp-unknown-type-name-__fp16.patch"
+
 SRC_URI[sha256sum] = "63c4267799f2618dd7ac5997d0306bbcf2a5306caaca0056795bc6c61d00f8c8"
 
 PACKAGECONFIG[legacy-appdir] = ""


### PR DESCRIPTION
TBH I don't remember anymore why I made initially Firefox require clang, unfortunately it was too long time ago.
But today I was curious if gcc works - and it does, it required only a minor patch.

This PR removes the hardcoded clang dependency from the Firefox recipe.

After this clang is only required if Firefox is built with sandboxed libraries enabled (this is the default, and can be changed with a `PACKAGECONFIG`. This is due to wasi-sdk having a hard dependency on clang)

When built without sandboxed libraries, clang can be avoided completely (at least from Firefox's point of view).

So far I tested successfully Scarthgap with glibc on x86-64, with both versions of Firefox. The rest of the test is left to the CI.