### PR TITLE
[backport whinlatter]chromium-ozone-wayland: fix build dependencies when using libglvnd se…

### DIFF
--- a/meta-chromium/recipes-browser/chromium/chromium-ozone-wayland_148.0.7778.215.bb
+++ b/meta-chromium/recipes-browser/chromium/chromium-ozone-wayland_148.0.7778.215.bb
@@ -5,6 +5,7 @@ REQUIRED_DISTRO_FEATURES = "wayland"
 DEPENDS += "\
         at-spi2-atk \
         virtual/egl \
+        virtual/libgbm \
         wayland \
         wayland-native \
 "


### PR DESCRIPTION
…tups

Explicitly map dependency tracking for virtual/libgbm to ensure the recipe builds correctly in environments where libglvnd is configured as the preferred EGL and GLES provider.